### PR TITLE
feat: refine release workflow

### DIFF
--- a/.github/pack.sh
+++ b/.github/pack.sh
@@ -29,17 +29,6 @@ require_venv() {
     source "${VENV_DIR}/bin/activate"
 }
 
-require_yosys() {
-    if [[ -d "${OSS_CAD_DIR}/bin" ]]; then
-        export PATH="${OSS_CAD_DIR}/bin:$PATH"
-    fi
-    if ! command -v yosys &> /dev/null; then
-        echo "ERROR: yosys not found in PATH."
-        exit 1
-    fi
-}
-
-
 build_api_server() {
     cd "$PROJECT_ROOT"
     rm -rf build dist __pycache__
@@ -74,7 +63,7 @@ main() {
     log "Activating venv"
     require_venv
     log "Checking yosys"
-    require_yosys
+    ensure_yosys || exit 1
     log "Staging OSS CAD Suite"
     stage_oss_cad_suite "$TAURI_RESOURCES_DIR" "$OSS_CAD_BUNDLE_DIR" "$TARGET" || exit 1
 

--- a/.github/pack.sh
+++ b/.github/pack.sh
@@ -39,52 +39,6 @@ require_yosys() {
     fi
 }
 
-stage_oss_cad_suite() {
-    mkdir -p "$TAURI_RESOURCES_DIR"
-    if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
-        mkdir -p "$OSS_CAD_BUNDLE_DIR"
-        return 0
-    fi
-
-    if [[ ! -d "${OSS_CAD_DIR}" || ! -f "${OSS_CAD_DIR}/bin/yosys" ]]; then
-        echo "ERROR: OSS CAD Suite not found at ${OSS_CAD_DIR}."
-        exit 1
-    fi
-
-    rm -rf "$OSS_CAD_BUNDLE_DIR"
-    mkdir -p "$OSS_CAD_BUNDLE_DIR"
-
-    local yosys_bin_src="$OSS_CAD_DIR/bin/yosys"
-    if [[ "$TARGET" == *"windows"* ]]; then
-        yosys_bin_src="$OSS_CAD_DIR/bin/yosys.exe"
-    fi
-
-    if [ ! -f "$yosys_bin_src" ]; then
-        echo "ERROR: yosys binary not found at $yosys_bin_src"
-        exit 1
-    fi
-
-    local slang_src
-    slang_src=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
-    if [ -z "$slang_src" ]; then
-        echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
-        exit 1
-    fi
-
-    cp -a "$OSS_CAD_DIR/." "$OSS_CAD_BUNDLE_DIR/"
-    if [ -d "$OSS_CAD_BUNDLE_DIR/bin" ]; then
-        find "$OSS_CAD_BUNDLE_DIR/bin" -maxdepth 1 -type f ! -name 'yosys' ! -name 'yosys*' ! -name 'abc' -print0 | xargs -0 -r rm -f
-    fi
-    if [ -d "$OSS_CAD_BUNDLE_DIR/share" ]; then
-        find "$OSS_CAD_BUNDLE_DIR/share" -mindepth 1 -maxdepth 1 -print0 | \
-            xargs -0 -r -I {} bash -c 'if [ "$(basename "{}")" != "yosys" ]; then rm -rf "{}"; fi'
-    fi
-    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
-        find "$OSS_CAD_BUNDLE_DIR/share/yosys" -mindepth 1 -maxdepth 1 -print0 | \
-            xargs -0 -r -I {} bash -c 'name=$(basename "{}"); case "$name" in yosys*|plugins|techlibs|scripts) ;; *) rm -rf "{}" ;; esac'
-    fi
-    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$yosys_bin_src")"
-}
 
 build_api_server() {
     cd "$PROJECT_ROOT"
@@ -122,7 +76,7 @@ main() {
     log "Checking yosys"
     require_yosys
     log "Staging OSS CAD Suite"
-    stage_oss_cad_suite
+    stage_oss_cad_suite "$TAURI_RESOURCES_DIR" "$OSS_CAD_BUNDLE_DIR" "$TARGET" || exit 1
 
     if [[ ! -d "${ECC_TOOLS_ROOT}" ]]; then
         echo "ERROR: ecc-tools submodule not found."

--- a/.github/pack.sh
+++ b/.github/pack.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# CI-oriented release build script for ChipCompiler ECC
+# Assumes dependencies and submodules are already installed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$PROJECT_ROOT/scripts/common.sh"
+
+GUI_DIR="$PROJECT_ROOT/chipcompiler/gui"
+TAURI_DIR="$GUI_DIR/src-tauri"
+BINARIES_DIR="$TAURI_DIR/binaries"
+TAURI_RESOURCES_DIR="$TAURI_DIR/resources"
+OSS_CAD_BUNDLE_DIR="$TAURI_RESOURCES_DIR/oss-cad-suite"
+
+log() {
+    echo "[$(date +%H:%M:%S)] $*"
+}
+
+require_venv() {
+    if [ ! -f "${VENV_DIR}/bin/activate" ]; then
+        echo "ERROR: venv not found at ${VENV_DIR}."
+        echo "Run: uv sync --frozen --all-groups --python ${PYTHON_VERSION}"
+        exit 1
+    fi
+    # shellcheck disable=SC1090
+    source "${VENV_DIR}/bin/activate"
+}
+
+require_yosys() {
+    if [[ -d "${OSS_CAD_DIR}/bin" ]]; then
+        export PATH="${OSS_CAD_DIR}/bin:$PATH"
+    fi
+    if ! command -v yosys &> /dev/null; then
+        echo "ERROR: yosys not found in PATH."
+        exit 1
+    fi
+}
+
+stage_oss_cad_suite() {
+    mkdir -p "$TAURI_RESOURCES_DIR"
+    if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
+        mkdir -p "$OSS_CAD_BUNDLE_DIR"
+        return 0
+    fi
+
+    if [[ ! -d "${OSS_CAD_DIR}" || ! -f "${OSS_CAD_DIR}/bin/yosys" ]]; then
+        echo "ERROR: OSS CAD Suite not found at ${OSS_CAD_DIR}."
+        exit 1
+    fi
+
+    rm -rf "$OSS_CAD_BUNDLE_DIR"
+    mkdir -p "$OSS_CAD_BUNDLE_DIR"
+
+    local yosys_bin_src="$OSS_CAD_DIR/bin/yosys"
+    if [[ "$TARGET" == *"windows"* ]]; then
+        yosys_bin_src="$OSS_CAD_DIR/bin/yosys.exe"
+    fi
+
+    if [ ! -f "$yosys_bin_src" ]; then
+        echo "ERROR: yosys binary not found at $yosys_bin_src"
+        exit 1
+    fi
+
+    local slang_src
+    slang_src=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
+    if [ -z "$slang_src" ]; then
+        echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
+        exit 1
+    fi
+
+    cp -a "$OSS_CAD_DIR/." "$OSS_CAD_BUNDLE_DIR/"
+    if [ -d "$OSS_CAD_BUNDLE_DIR/bin" ]; then
+        find "$OSS_CAD_BUNDLE_DIR/bin" -maxdepth 1 -type f ! -name 'yosys' ! -name 'yosys*' ! -name 'abc' -print0 | xargs -0 -r rm -f
+    fi
+    if [ -d "$OSS_CAD_BUNDLE_DIR/share" ]; then
+        find "$OSS_CAD_BUNDLE_DIR/share" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'if [ "$(basename "{}")" != "yosys" ]; then rm -rf "{}"; fi'
+    fi
+    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
+        find "$OSS_CAD_BUNDLE_DIR/share/yosys" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'name=$(basename "{}"); case "$name" in yosys*|plugins|techlibs|scripts) ;; *) rm -rf "{}" ;; esac'
+    fi
+    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$yosys_bin_src")"
+}
+
+build_api_server() {
+    cd "$PROJECT_ROOT"
+    rm -rf build dist __pycache__
+    PYINSTALLER_ONEFILE=1 pyinstaller chipcompiler.spec --clean --noconfirm
+
+    local source_binary="dist/chipcompiler"
+    if [[ "$TARGET" == *"windows"* ]]; then
+        source_binary="${source_binary}.exe"
+    fi
+    if [ ! -f "$source_binary" ]; then
+        echo "ERROR: PyInstaller build failed"
+        exit 1
+    fi
+
+    mkdir -p "$BINARIES_DIR"
+    local binary_name="api-server-$TARGET"
+    if [[ "$TARGET" == *"windows"* ]]; then
+        binary_name="$binary_name.exe"
+    fi
+    cp "$source_binary" "$BINARIES_DIR/$binary_name"
+    chmod +x "$BINARIES_DIR/$binary_name"
+
+    echo "$binary_name"
+}
+
+main() {
+    setup_project_vars
+    ENABLE_OSS_CAD_SUITE="${ENABLE_OSS_CAD_SUITE:-true}"
+    TARGET=$(get_target_platform)
+
+    log "CI build target: $TARGET"
+    log "Activating venv"
+    require_venv
+    log "Checking yosys"
+    require_yosys
+    log "Staging OSS CAD Suite"
+    stage_oss_cad_suite
+
+    if [[ ! -d "${ECC_TOOLS_ROOT}" ]]; then
+        echo "ERROR: ecc-tools submodule not found."
+        exit 1
+    fi
+    log "Building ecc_py"
+    build_ecc_py
+
+    log "Building API server"
+    local binary_name
+    binary_name=$(build_api_server)
+
+    log "Building Tauri app"
+    build_tauri_bundle "$GUI_DIR" "$TAURI_DIR" "$OSS_CAD_BUNDLE_DIR" "$BINARIES_DIR" "$binary_name" || exit 1
+}
+
+main "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,17 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: latest
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
-
+          cache-dependency-path: chipcompiler/gui/pnpm-lock.yaml
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
           sudo apt-get install -y g++-10 \
             tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev \
             flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison \
-            libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git
+            libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git \
+            libftdi1-2 libhidapi-hidraw0 librsvg2-dev
 
       - name: Download OSS CAD Suite
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,13 +103,29 @@ jobs:
           CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' \
             bash ./.github/pack.sh
 
-      - name: Upload build artifacts
+      - name: Upload ecc-client artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts
+          name: ecc-client
           if-no-files-found: ignore
           path: |
             chipcompiler/gui/src-tauri/target/release/ecc-client
+
+      - name: Upload AppImage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage
+          if-no-files-found: ignore
+          path: |
             chipcompiler/gui/src-tauri/target/release/bundle/**/*.AppImage
+
+      - name: Upload deb artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb
+          if-no-files-found: ignore
+          path: |
             chipcompiler/gui/src-tauri/target/release/bundle/**/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - 'main'
   pull_request:
 
+env:
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
 jobs:
   build-package:
     name: Build Package
@@ -14,7 +17,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: recursive
+          token: ${{ env.GH_TOKEN }}
+
+      - name: Convert SSH to HTTPS in gitmodules
+        run: sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,33 +80,18 @@ jobs:
         working-directory: chipcompiler/gui
         run: pnpm install
 
-      - name: Install LinuxDeploy # For AppImage packaging
-        id: install-linuxdeploy
-        uses: miurahr/install-linuxdeploy-action@v1.8.0
-        with:
-          plugins: appimage
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config \
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libfuse2 \
-            patchelf squashfs-tools desktop-file-utils
-          sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
+            patchelf squashfs-tools desktop-file-utils libwebkit2gtk-4.1-dev
 
           sudo apt-get install -y g++-10 \
             tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev \
             flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison \
             libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git \
             libftdi1-2 libhidapi-hidraw0 librsvg2-dev
-
-      - name: Download OSS CAD Suite
-        env:
-          ENABLE_OSS_CAD_SUITE: "true"
-        run: |
-          source ./scripts/common.sh
-          setup_project_vars
-          setup_oss_cad_suite
 
       - name: Build release (packaging test)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build-package:
@@ -18,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ env.GH_TOKEN }}
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Convert SSH to HTTPS in gitmodules
         run: sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
@@ -59,7 +63,7 @@ jobs:
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
-      # - name: Build release (packaging test)
-      #   env:
-      #     ENABLE_OSS_CAD_SUITE: "true"
-      #   run: ./scripts/build_release.sh
+      - name: Build release (packaging test)
+        env:
+          ENABLE_OSS_CAD_SUITE: "true"
+        run: CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - 'main'
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
-      - name: Build release (packaging test)
-        env:
-          ENABLE_OSS_CAD_SUITE: "true"
-        run: ./scripts/build_release.sh
+      # - name: Build release (packaging test)
+      #   env:
+      #     ENABLE_OSS_CAD_SUITE: "true"
+      #   run: ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config \
-            libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+            libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libfuse2
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
           sudo apt-get install -y g++-10 cmake ninja-build \
@@ -94,4 +94,5 @@ jobs:
         env:
           ENABLE_OSS_CAD_SUITE: "true"
           CARGO_PROFILE_RELEASE_STRIP: "false"
+          APPIMAGE_EXTRACT_AND_RUN: "1"
         run: CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           version: latest
+          enable-cache: "true"
 
       - name: Install LinuxDeploy # For AppImage packaging
         id: install-linuxdeploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ jobs:
     name: Build Package
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+
+          # feel free to set to "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  build-package:
+    name: Build Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config yosys \
+            libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+          sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
+
+      - name: Build release (packaging test)
+        env:
+          ENABLE_OSS_CAD_SUITE: "false"
+        run: ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,6 @@ jobs:
           name: build-artifacts
           if-no-files-found: ignore
           path: |
-            chipcompiler/gui/src-tauri/target/release/*.AppImage
-            chipcompiler/gui/src-tauri/target/release/*.deb
-            chipcompiler/gui/src-tauri/target/release/*.rpm
-            chipcompiler/gui/src-tauri/target/release/*.dmg
-            chipcompiler/gui/src-tauri/target/release/*.msi
-            chipcompiler/gui/src-tauri/target/release/*.exe
+            chipcompiler/gui/src-tauri/target/release/ecc-client
+            chipcompiler/gui/src-tauri/target/release/bundle/**/*.AppImage
+            chipcompiler/gui/src-tauri/target/release/bundle/**/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libfuse2
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
-          sudo apt-get install -y g++-10 cmake ninja-build \
+          sudo apt-get install -y g++-10 \
             tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev \
             flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison rustc \
             cargo libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
+          sudo apt-get install -y g++-10 cmake ninja-build \
+            tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev \
+            flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison rustc \
+            cargo libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git
+
       - name: Build release (packaging test)
         env:
           ENABLE_OSS_CAD_SUITE: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,20 @@ jobs:
           CARGO_PROFILE_RELEASE_STRIP: "false"
           APPIMAGE_EXTRACT_AND_RUN: "1"
         run: CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' ./scripts/build_release.sh
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          if-no-files-found: ignore
+          path: |
+            dist/**
+            build/**
+            chipcompiler/gui/src-tauri/target/release/bundle/**
+            chipcompiler/gui/src-tauri/target/release/*.AppImage
+            chipcompiler/gui/src-tauri/target/release/*.deb
+            chipcompiler/gui/src-tauri/target/release/*.rpm
+            chipcompiler/gui/src-tauri/target/release/*.dmg
+            chipcompiler/gui/src-tauri/target/release/*.msi
+            chipcompiler/gui/src-tauri/target/release/*.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         with:
           version: latest
 
+      - name: Install LinuxDeploy # For AppImage packaging
+        id: install-linuxdeploy
+        uses: miurahr/install-linuxdeploy-action@v1.8.0
+        with:
+          plugins: appimage
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -71,4 +77,5 @@ jobs:
       - name: Build release (packaging test)
         env:
           ENABLE_OSS_CAD_SUITE: "true"
+          CARGO_PROFILE_RELEASE_STRIP: "false"
         run: CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config yosys \
+          sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config \
             libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
       - name: Build release (packaging test)
         env:
-          ENABLE_OSS_CAD_SUITE: "false"
+          ENABLE_OSS_CAD_SUITE: "true"
         run: ./scripts/build_release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  UV_PYTHON_PREFERENCE: only-managed
 
 jobs:
   build-package:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Convert SSH to HTTPS in gitmodules
         run: sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
 
+      - name: Configure git credentials
+        run: |
+          git config --global url."https://${{ env.GH_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Checkout submodules
         run: git submodule update --init --recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
-          tool-cache: false
+          tool-cache: true
 
           # feel free to set to "false" if necessary for your workflow
           android: true
@@ -73,6 +73,13 @@ jobs:
           version: latest
           enable-cache: "true"
 
+      - name: Install Python dependencies (uv)
+        run: uv sync --frozen --all-groups --python 3.10
+
+      - name: Install frontend dependencies
+        working-directory: chipcompiler/gui
+        run: pnpm install
+
       - name: Install LinuxDeploy # For AppImage packaging
         id: install-linuxdeploy
         uses: miurahr/install-linuxdeploy-action@v1.8.0
@@ -83,20 +90,31 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build build-essential unzip pkg-config \
-            libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libfuse2
+            libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev libfuse2 \
+            patchelf squashfs-tools desktop-file-utils
           sudo apt-get install -y libwebkit2gtk-4.1-dev || sudo apt-get install -y libwebkit2gtk-4.0-dev
 
           sudo apt-get install -y g++-10 \
             tcl-dev libgflags-dev libgoogle-glog-dev libboost-all-dev libgtest-dev \
-            flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison rustc \
-            cargo libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git
+            flex libeigen3-dev libunwind-dev libmetis-dev libgmp-dev bison \
+            libhwloc-dev libcairo2-dev libcurl4-openssl-dev libtbb-dev git
+
+      - name: Download OSS CAD Suite
+        env:
+          ENABLE_OSS_CAD_SUITE: "true"
+        run: |
+          source ./scripts/common.sh
+          setup_project_vars
+          setup_oss_cad_suite
 
       - name: Build release (packaging test)
         env:
           ENABLE_OSS_CAD_SUITE: "true"
           CARGO_PROFILE_RELEASE_STRIP: "false"
           APPIMAGE_EXTRACT_AND_RUN: "1"
-        run: CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' ./scripts/build_release.sh
+        run: |
+          CMAKE_EXTRA_OPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache' \
+            bash ./.github/pack.sh
 
       - name: Upload build artifacts
         if: always()
@@ -105,9 +123,6 @@ jobs:
           name: build-artifacts
           if-no-files-found: ignore
           path: |
-            dist/**
-            build/**
-            chipcompiler/gui/src-tauri/target/release/bundle/**
             chipcompiler/gui/src-tauri/target/release/*.AppImage
             chipcompiler/gui/src-tauri/target/release/*.deb
             chipcompiler/gui/src-tauri/target/release/*.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,7 @@ chipcompiler.egg-info/
 
 # OSS CAD Suite
 chipcompiler/thirdparty/oss-cad-suite/
+chipcompiler/gui/src-tauri/resources/oss-cad-suite/
+
+# Tauri dev files
+.pnpm-store/

--- a/build.sh
+++ b/build.sh
@@ -2,126 +2,31 @@
 
 set -e
 
-# Setup Project Variables
-PROJECT_ROOT=$(cd "$(dirname "$0")";pwd)
-CHIPCOMPILER_ROOT="${PROJECT_ROOT}/chipcompiler"
-ECC_TOOLS_ROOT="${CHIPCOMPILER_ROOT}/thirdparty/ecc-tools"
-ICS55_PDK_ROOT="${CHIPCOMPILER_ROOT}/thirdparty/icsprout55-pdk"
-VENV_DIR="${PROJECT_ROOT}/.venv"
-PYTHON_VERSION="3.10"
-ENABLE_OSS_CAD_SUITE=${ENABLE_OSS_CAD_SUITE:-true}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
 
-# Check for uv installation
-if ! command -v uv &> /dev/null; then
-    echo "Error: uv is not installed or not in PATH"
-    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
-    exit 1
-fi
+# Source common functions
+source "${SCRIPT_DIR}/scripts/common.sh"
 
-# Create virtual environment if it doesn't exist
-echo "Setting up Python ${PYTHON_VERSION} environment with uv..."
-uv sync --frozen --all-groups --python ${PYTHON_VERSION}
+# Initialize project variables
+setup_project_vars
 
-# Activate virtual environment (for subsequent commands in the script)
-echo "Activating virtual environment..."
-source "${VENV_DIR}/bin/activate"
+# Setup Python environment
+setup_uv_env || exit 1
 
-# Download and set up OSS CAD Suite if enabled
-if [ "$ENABLE_OSS_CAD_SUITE" == "true" ]; then
-    OSS_CAD_DIR="${CHIPCOMPILER_ROOT}/thirdparty/oss-cad-suite"
-    echo "==============================="
-    if [ -d "${OSS_CAD_DIR}" ] && [ -f "${OSS_CAD_DIR}/bin/yosys" ]; then
-        echo "OSS CAD Suite already exists at ${OSS_CAD_DIR}, skipping download..."
-    else
-        LATEST_TAG=$(curl -s "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
-        OSS_CAD_URL="https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${LATEST_TAG}/oss-cad-suite-linux-x64-${LATEST_TAG//-/}.tgz"
-        mkdir -p "${OSS_CAD_DIR}"
-        TMP_DIR=$(mktemp -d)
-        echo "Downloading OSS CAD SUITE BUILD from ${OSS_CAD_URL} to ${TMP_DIR}..."
-        curl -fL "${OSS_CAD_URL}" -o "${TMP_DIR}/oss-cad-suite.tgz"
-        tar -xzf "${TMP_DIR}/oss-cad-suite.tgz" -C "${OSS_CAD_DIR}" --strip-components=1
-        rm -rf "${TMP_DIR}/oss-cad-suite.tgz"
-    fi
-    echo "OSS CAD Suite is set up at ${OSS_CAD_DIR}, please remember to add it to your PATH:"
-    echo -e "\033[1;33mexport PATH=\"${OSS_CAD_DIR}/bin:\$PATH\"\033[0m"
-    echo "==============================="
-    echo " "
-    echo "export PATH=\"${OSS_CAD_DIR}/bin:\$PATH\"" >> "${VENV_DIR}/bin/activate"
-fi
+# Setup OSS CAD Suite (if enabled)
+setup_oss_cad_suite
+append_oss_cad_to_venv
 
-echo "Setting up third-party submodules..."
-git submodule update --init --recursive
-cd ${ICS55_PDK_ROOT} && make unzip && cd -
+# Initialize submodules and PDK
+setup_submodules
+setup_ics55_pdk
 
-# Build ecc_py
-echo "Building ecc_py..."
+# Build and install ecc_py
+build_ecc_py || exit 1
+install_ecc_py
 
-BUILD_DIR="${ECC_TOOLS_ROOT}/build"
-if [ ! -d "${BUILD_DIR}" ]; then
-    echo "Creating build directory at ${BUILD_DIR}..."
-    mkdir -p "${BUILD_DIR}"
-else
-    echo "Cleaning existing build files at ${BUILD_DIR}..."
-    rm -rf "${BUILD_DIR}/CMakeCache.txt" "${BUILD_DIR}/CMakeFiles" "${BUILD_DIR}/build.ninja" "${BUILD_DIR}/Makefile"
-fi
-
-cd "${BUILD_DIR}" || exit 1
-
-echo "Configuring project with CMake..."
-if command -v cmake &> /dev/null; then
-    echo "CMake found: $(cmake --version | head -n 1)"
-else
-    echo "Error: CMake is not installed or not in PATH"
-    bash "${ECC_TOOLS_ROOT}/build.sh" -i apt
-fi
-
-# Prefer Ninja if available
-if command -v ninja &> /dev/null; then
-    echo "Using Ninja generator..."
-    cmake -G Ninja -DBUILD_AIEDA=ON ..
-else
-    echo "Using default generator..."
-    cmake -DBUILD_AIEDA=ON ..
-fi
-if [ $? -ne 0 ]; then
-    echo "Error: CMake configuration failed"
-    exit 1
-fi
-
-echo "Building project..."
-if command -v ninja &> /dev/null; then
-    echo "Using ninja build system..."
-    ninja ecc_py
-else
-    echo "Using make build system..."
-    make -j$(nproc) ecc_py
-fi
-if [ $? -ne 0 ]; then
-    echo "Error: Build failed"
-    exit 1
-fi
-
-echo "ecc_py build completed successfully!"
-
-# Copy ecc_py.so to tools/ecc/bin directory
-echo "Copying ecc_py.so to tools/ecc/bin directory..."
-ECC_PY_BIN_DIR="${CHIPCOMPILER_ROOT}/tools/ecc/bin"
-ECC_TOOLS_BIN_DIR="${ECC_TOOLS_ROOT}/bin"
-
-# Ensure the target directory exists
-mkdir -p "${ECC_PY_BIN_DIR}"
-
-# Find the ecc_py.so file (considering version and platform suffixes)
-ECC_PY_FILE=$(find "${ECC_TOOLS_BIN_DIR}" -name "ecc_py*.so" | head -1)
-
-if [ -f "${ECC_PY_FILE}" ]; then
-    echo "Found ecc_py file: ${ECC_PY_FILE}"
-    cp "${ECC_PY_FILE}" "${ECC_PY_BIN_DIR}/"
-    echo "Successfully copied ecc_py.so to ${ECC_PY_BIN_DIR}/"
-else
-    echo "Warning: ecc_py.so file not found in ${ECC_TOOLS_BIN_DIR}"
-fi
-
+echo ""
 echo "Environment setup completed successfully!"
 echo "To activate the virtual environment in future sessions, run:"
 echo "source ${VENV_DIR}/bin/activate"
@@ -129,10 +34,6 @@ echo "source ${VENV_DIR}/bin/activate"
 if [ "$1" == "--release" ]; then
     echo "Starting executable build process..."
     export PYINSTALLER_ONEFILE=1
-    # Clean previous builds
-    echo "Cleaning previous builds..."
     rm -rf build/ dist/
-
-    # Run pyinstaller via uv
     uv run pyinstaller chipcompiler.spec
 fi

--- a/chipcompiler.spec
+++ b/chipcompiler.spec
@@ -97,7 +97,6 @@ hiddenimports = [
     'chipcompiler.tools.yosys.runner',
     'chipcompiler.tools.yosys.utility',
     'benchmark',
-    'benchmark.pdk',
     'benchmark.get_parameters',
     'benchmark.benchmark',
     # Multiprocessing support

--- a/chipcompiler/gui/src-tauri/src/main.rs
+++ b/chipcompiler/gui/src-tauri/src/main.rs
@@ -234,9 +234,17 @@ fn start_api_server(app_handle: &tauri::AppHandle) -> Option<Child> {
         };
         
         println!("Starting FastAPI server (prod mode) from: {:?}", server_binary);
-        
-        // Note: Don't use --reload in production mode
-        match Command::new(&server_binary)
+
+        let mut cmd = Command::new(&server_binary);
+        if let Ok(resource_dir) = app_handle.path().resource_dir() {
+            let oss_dir = resource_dir.join("oss-cad-suite");
+            if oss_dir.exists() {
+                println!("Setting CHIPCOMPILER_OSS_CAD_DIR to {:?}", oss_dir);
+                cmd.env("CHIPCOMPILER_OSS_CAD_DIR", &oss_dir);
+            }
+        }
+
+        match cmd
             .arg("--host")
             .arg("127.0.0.1")
             .arg("--port")

--- a/chipcompiler/gui/src-tauri/tauri.conf.json
+++ b/chipcompiler/gui/src-tauri/tauri.conf.json
@@ -39,7 +39,8 @@
       "icons/icon.png"
     ],
     "resources": [
-      "resources/oss-cad-suite/**"
+      "resources/oss-cad-suite/**/*",
+      "resources/oss-cad-suite/README"
     ],
     "externalBin": [
       "binaries/api-server"

--- a/chipcompiler/gui/src-tauri/tauri.conf.json
+++ b/chipcompiler/gui/src-tauri/tauri.conf.json
@@ -34,7 +34,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "appimage"],
     "icon": [
       "icons/icon.png"
     ],

--- a/chipcompiler/gui/src-tauri/tauri.conf.json
+++ b/chipcompiler/gui/src-tauri/tauri.conf.json
@@ -38,6 +38,9 @@
     "icon": [
       "icons/icon.png"
     ],
+    "resources": [
+      "resources/oss-cad-suite/**"
+    ],
     "externalBin": [
       "binaries/api-server"
     ]

--- a/chipcompiler/tools/yosys/utility.py
+++ b/chipcompiler/tools/yosys/utility.py
@@ -1,6 +1,22 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+import os
 import shutil
+from pathlib import Path
+
+
+def _setup_oss_cad_env(oss_path: Path) -> None:
+    """Configure environment variables for OSS CAD Suite."""
+    bin_dir = str(oss_path / "bin")
+    current_path = os.environ.get("PATH", "")
+    if bin_dir not in current_path.split(os.pathsep):
+        os.environ["PATH"] = f"{bin_dir}{os.pathsep}{current_path}".rstrip(os.pathsep)
+
+    share_dir = oss_path / "share" / "yosys"
+    if (share_dir / "plugins").exists():
+        os.environ.setdefault("YOSYS_PLUGINPATH", str(share_dir / "plugins"))
+    if (share_dir / "techlibs").exists():
+        os.environ.setdefault("YOSYS_DATDIR", str(share_dir))
 
 
 def get_yosys_command() -> list[str]:
@@ -9,10 +25,14 @@ def get_yosys_command() -> list[str]:
 
     Checks if 'yosys' is available in PATH (from nix develop, OSS CAD Suite, or system install).
     """
-    if shutil.which("yosys"):
-        return ["yosys"]
+    if oss_cad_dir := os.environ.get("CHIPCOMPILER_OSS_CAD_DIR"):
+        oss_path = Path(oss_cad_dir)
+        yosys_bin = oss_path / "bin" / ("yosys.exe" if os.name == "nt" else "yosys")
+        if yosys_bin.exists():
+            _setup_oss_cad_env(oss_path)
+            return [str(yosys_bin)]
 
-    return []
+    return ["yosys"] if shutil.which("yosys") else []
 
 
 def is_eda_exist() -> bool:

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -50,61 +50,11 @@ echo ""
 
 # Step 3: Stage Yosys runtime for bundling
 echo "=== Step 3: Staging Yosys runtime ==="
-mkdir -p "$TAURI_RESOURCES_DIR"
-if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
-    echo "Skipping yosys bundling (ENABLE_OSS_CAD_SUITE=$ENABLE_OSS_CAD_SUITE)"
-    # Ensure resources path exists so Tauri glob doesn't fail
-    mkdir -p "$OSS_CAD_BUNDLE_DIR"
-    echo ""
-else
-    # Ensure OSS CAD Suite is downloaded (even if system yosys exists)
+if [[ "$ENABLE_OSS_CAD_SUITE" == "true" ]]; then
     setup_oss_cad_suite
-
-    rm -rf "$OSS_CAD_BUNDLE_DIR"
-    mkdir -p "$OSS_CAD_BUNDLE_DIR"
-
-    YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys"
-    if [[ "$TARGET" == *"windows"* ]]; then
-        YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys.exe"
-    fi
-
-    if [ ! -f "$YOSYS_BIN_SRC" ]; then
-        echo "ERROR: yosys binary not found at $YOSYS_BIN_SRC"
-        exit 1
-    fi
-
-    SLANG_SRC=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
-    if [ -z "$SLANG_SRC" ]; then
-        echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
-        exit 1
-    fi
-
-    echo "Syncing OSS CAD Suite into Tauri resources..."
-    cp -a "$OSS_CAD_DIR/." "$OSS_CAD_BUNDLE_DIR/"
-    echo "Pruning OSS CAD Suite resources (keep yosys + abc)..."
-    # Keep only yosys, yosys* and abc executables in bin/
-    if [ -d "$OSS_CAD_BUNDLE_DIR/bin" ]; then
-        find "$OSS_CAD_BUNDLE_DIR/bin" -maxdepth 1 -type f ! -name 'yosys' ! -name 'yosys*' ! -name 'abc' -print0 | xargs -0 -r rm -f
-    fi
-    # Keep only yosys-related content in share/
-    if [ -d "$OSS_CAD_BUNDLE_DIR/share" ]; then
-        # Remove all top-level share entries except yosys
-        find "$OSS_CAD_BUNDLE_DIR/share" -mindepth 1 -maxdepth 1 -print0 | \
-            xargs -0 -r -I {} bash -c 'if [ "$(basename "{}")" != "yosys" ]; then rm -rf "{}"; fi'
-    fi
-    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
-        # Inside share/yosys, keep only yosys-related files/directories
-        find "$OSS_CAD_BUNDLE_DIR/share/yosys" -mindepth 1 -maxdepth 1 -print0 | \
-            xargs -0 -r -I {} bash -c 'name=$(basename "{}"); case "$name" in yosys*|plugins|techlibs|scripts) ;; *) rm -rf "{}" ;; esac'
-    fi
-    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-    echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
-        echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
-    fi
-
-    echo ""
 fi
+stage_oss_cad_suite "$TAURI_RESOURCES_DIR" "$OSS_CAD_BUNDLE_DIR" "$TARGET" || exit 1
+echo ""
 
 # Step 4: Ensure ecc_py is built
 echo "=== Step 4: Ensuring ecc_py is built ==="

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -22,6 +22,11 @@ OSS_CAD_BUNDLE_DIR="$TAURI_RESOURCES_DIR/oss-cad-suite"
 # Initialize project variables
 setup_project_vars
 
+# Default to enabling OSS CAD Suite bundling unless explicitly disabled
+if [ -z "$ENABLE_OSS_CAD_SUITE" ]; then
+    ENABLE_OSS_CAD_SUITE="true"
+fi
+
 echo "=========================================="
 echo "ChipCompiler ECC Release Build"
 echo "=========================================="
@@ -45,15 +50,18 @@ echo ""
 
 # Step 3: Stage Yosys runtime for bundling
 echo "=== Step 3: Staging Yosys runtime ==="
+mkdir -p "$TAURI_RESOURCES_DIR"
 if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
     echo "Skipping yosys bundling (ENABLE_OSS_CAD_SUITE=$ENABLE_OSS_CAD_SUITE)"
+    # Ensure resources path exists so Tauri glob doesn't fail
+    mkdir -p "$OSS_CAD_BUNDLE_DIR"
     echo ""
 else
     # Ensure OSS CAD Suite is downloaded (even if system yosys exists)
     setup_oss_cad_suite
 
     rm -rf "$OSS_CAD_BUNDLE_DIR"
-    mkdir -p "$OSS_CAD_BUNDLE_DIR/bin" "$OSS_CAD_BUNDLE_DIR/share"
+    mkdir -p "$OSS_CAD_BUNDLE_DIR"
 
     YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys"
     if [[ "$TARGET" == *"windows"* ]]; then
@@ -71,15 +79,16 @@ else
         exit 1
     fi
 
-    cp "$YOSYS_BIN_SRC" "$OSS_CAD_BUNDLE_DIR/bin/"
-    if [ -f "$OSS_CAD_DIR/bin/abc" ]; then
-        cp "$OSS_CAD_DIR/bin/abc" "$OSS_CAD_BUNDLE_DIR/bin/"
+    echo "Syncing OSS CAD Suite into Tauri resources..."
+    cp -a "$OSS_CAD_DIR/." "$OSS_CAD_BUNDLE_DIR/"
+    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
+    if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
         chmod +x "$OSS_CAD_BUNDLE_DIR/bin/abc"
     fi
-    cp -a "$OSS_CAD_DIR/share/yosys" "$OSS_CAD_BUNDLE_DIR/share/"
-    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
     echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-    echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
+    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
+        echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
+    fi
     if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
         echo "Bundled abc: $OSS_CAD_BUNDLE_DIR/bin/abc"
     fi
@@ -145,6 +154,10 @@ echo ""
 
 # Step 8: Build Tauri application
 echo "=== Step 8: Building Tauri application ==="
+if [ ! -d "$OSS_CAD_BUNDLE_DIR" ]; then
+    echo "ERROR: Tauri resources missing: $OSS_CAD_BUNDLE_DIR"
+    exit 1
+fi
 pnpm run tauri build
 
 # Step 9: Copy API Server binary to release directory (for direct execution)

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -8,11 +8,15 @@ set -e  # Exit on error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SERVICES_DIR="$PROJECT_ROOT/chipcompiler/services"
 GUI_DIR="$PROJECT_ROOT/chipcompiler/gui"
 TAURI_DIR="$GUI_DIR/src-tauri"
 BINARIES_DIR="$TAURI_DIR/binaries"
 VENV_DIR="$PROJECT_ROOT/.venv"
+PYTHON_VERSION="3.10"
+ENABLE_OSS_CAD_SUITE=${ENABLE_OSS_CAD_SUITE:-true}
+ECC_TOOLS_ROOT="$PROJECT_ROOT/chipcompiler/thirdparty/ecc-tools"
+ECC_PY_GLOB="$ECC_TOOLS_ROOT/bin/ecc_py*.so"
+OSS_CAD_DIR="$PROJECT_ROOT/chipcompiler/thirdparty/oss-cad-suite"
 
 echo "=========================================="
 echo "ChipCompiler ECC Release Build"
@@ -25,50 +29,119 @@ TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
 echo "Target platform: $TARGET"
 echo ""
 
-# Step 1: Ensure virtual environment is activated
+# Step 1: Setup Python environment with uv (aligned with build.sh)
 echo "=== Step 1: Setting up Python environment ==="
-if [ -d "$VENV_DIR" ]; then
-    echo "Activating virtual environment..."
-    source "$VENV_DIR/bin/activate"
-else
-    echo "Creating virtual environment..."
-    python3 -m venv "$VENV_DIR"
-    source "$VENV_DIR/bin/activate"
+if ! command -v uv &> /dev/null; then
+    echo "ERROR: uv is not installed or not in PATH"
+    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
 fi
-
-# Install dependencies
-echo "Installing Python dependencies..."
-if command -v uv &> /dev/null; then
-    uv pip install -e "$PROJECT_ROOT" --quiet
-    uv pip install pyinstaller --quiet
-else
-    python -m ensurepip --upgrade --default-pip
-    python -m pip install -e "$PROJECT_ROOT" --quiet
-    python -m pip install pyinstaller --quiet
-fi
+echo "Syncing Python ${PYTHON_VERSION} environment with uv..."
+uv sync --frozen --all-groups --python ${PYTHON_VERSION}
+echo "Activating virtual environment..."
+source "$VENV_DIR/bin/activate"
 echo "Python environment ready."
 echo ""
 
-# Step 2: Build API Server with PyInstaller
-echo "=== Step 2: Building API Server ==="
-cd "$SERVICES_DIR"
+# Step 2: Ensure yosys is available (required by runtime)
+echo "=== Step 2: Ensuring yosys is available ==="
+if command -v yosys &> /dev/null; then
+    echo "yosys found: $(command -v yosys)"
+else
+    if [ "$ENABLE_OSS_CAD_SUITE" == "true" ]; then
+        echo "yosys not found, installing OSS CAD Suite..."
+        if [ -d "${OSS_CAD_DIR}" ] && [ -f "${OSS_CAD_DIR}/bin/yosys" ]; then
+            echo "OSS CAD Suite already exists at ${OSS_CAD_DIR}, skipping download..."
+        else
+            LATEST_TAG=$(curl -s "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+            OSS_CAD_URL="https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${LATEST_TAG}/oss-cad-suite-linux-x64-${LATEST_TAG//-/}.tgz"
+            mkdir -p "${OSS_CAD_DIR}"
+            TMP_DIR=$(mktemp -d)
+            echo "Downloading OSS CAD Suite from ${OSS_CAD_URL}..."
+            curl -fL "${OSS_CAD_URL}" -o "${TMP_DIR}/oss-cad-suite.tgz"
+            tar -xzf "${TMP_DIR}/oss-cad-suite.tgz" -C "${OSS_CAD_DIR}" --strip-components=1
+            rm -rf "${TMP_DIR}/oss-cad-suite.tgz"
+        fi
+        export PATH="${OSS_CAD_DIR}/bin:$PATH"
+        if command -v yosys &> /dev/null; then
+            echo "yosys installed: $(command -v yosys)"
+        else
+            echo "ERROR: yosys still not found after OSS CAD Suite setup."
+            exit 1
+        fi
+    else
+        echo "ERROR: yosys not found and ENABLE_OSS_CAD_SUITE=false"
+        exit 1
+    fi
+fi
+echo ""
+
+# Step 3: Ensure ecc_py is built (required by chipcompiler.spec)
+echo "=== Step 3: Ensuring ecc_py is built ==="
+if ls $ECC_PY_GLOB >/dev/null 2>&1; then
+    echo "ecc_py already exists in $ECC_TOOLS_ROOT/bin."
+else
+    echo "ecc_py not found, building..."
+    if [ ! -d "$ECC_TOOLS_ROOT" ]; then
+        echo "ERROR: ecc-tools submodule not found. Run: git submodule update --init --recursive"
+        exit 1
+    fi
+    git submodule update --init --recursive
+
+    BUILD_DIR="$ECC_TOOLS_ROOT/build"
+    mkdir -p "$BUILD_DIR"
+    rm -rf "$BUILD_DIR/CMakeCache.txt" "$BUILD_DIR/CMakeFiles" "$BUILD_DIR/build.ninja" "$BUILD_DIR/Makefile"
+
+    cd "$BUILD_DIR"
+    if ! command -v cmake &> /dev/null; then
+        echo "ERROR: cmake not found. Please install cmake."
+        exit 1
+    fi
+
+    if command -v ninja &> /dev/null; then
+        echo "Configuring with Ninja..."
+        cmake -G Ninja -DBUILD_AIEDA=ON ..
+        echo "Building ecc_py with Ninja..."
+        ninja ecc_py
+    else
+        echo "Configuring with default generator..."
+        cmake -DBUILD_AIEDA=ON ..
+        echo "Building ecc_py with make..."
+        make -j$(nproc) ecc_py
+    fi
+
+    if ! ls $ECC_PY_GLOB >/dev/null 2>&1; then
+        echo "ERROR: ecc_py build failed (ecc_py*.so not found)."
+        exit 1
+    fi
+fi
+echo ""
+
+# Step 4: Build API Server with PyInstaller
+echo "=== Step 4: Building API Server ==="
+cd "$PROJECT_ROOT"
 
 # Clean previous builds
 rm -rf build dist __pycache__
 
 # Build with PyInstaller
 echo "Running PyInstaller..."
-pyinstaller api-server.spec --clean --noconfirm
+PYINSTALLER_ONEFILE=1 pyinstaller chipcompiler.spec --clean --noconfirm
 
-if [ ! -f "dist/api-server" ]; then
+SOURCE_BINARY="dist/chipcompiler"
+if [[ "$TARGET" == *"windows"* ]]; then
+    SOURCE_BINARY="${SOURCE_BINARY}.exe"
+fi
+
+if [ ! -f "$SOURCE_BINARY" ]; then
     echo "ERROR: PyInstaller build failed"
     exit 1
 fi
 echo "API Server built successfully."
 echo ""
 
-# Step 3: Copy binary to Tauri binaries directory
-echo "=== Step 3: Installing API Server binary ==="
+# Step 5: Copy binary to Tauri binaries directory
+echo "=== Step 5: Installing API Server binary ==="
 mkdir -p "$BINARIES_DIR"
 
 # Determine binary name based on platform
@@ -77,13 +150,13 @@ if [[ "$TARGET" == *"windows"* ]]; then
     BINARY_NAME="$BINARY_NAME.exe"
 fi
 
-cp "dist/api-server" "$BINARIES_DIR/$BINARY_NAME"
+cp "$SOURCE_BINARY" "$BINARIES_DIR/$BINARY_NAME"
 chmod +x "$BINARIES_DIR/$BINARY_NAME"
 echo "Installed: $BINARIES_DIR/$BINARY_NAME"
 echo ""
 
-# Step 4: Install frontend dependencies
-echo "=== Step 4: Installing frontend dependencies ==="
+# Step 6: Install frontend dependencies
+echo "=== Step 6: Installing frontend dependencies ==="
 cd "$GUI_DIR"
 if command -v pnpm &> /dev/null; then
     pnpm install
@@ -95,12 +168,12 @@ fi
 echo "Frontend dependencies installed."
 echo ""
 
-# Step 5: Build Tauri application
-echo "=== Step 5: Building Tauri application ==="
+# Step 7: Build Tauri application
+echo "=== Step 7: Building Tauri application ==="
 pnpm run tauri build
 
-# Step 6: Copy API Server binary to release directory (for direct execution)
-echo "=== Step 6: Copying API Server to release directory ==="
+# Step 8: Copy API Server binary to release directory (for direct execution)
+echo "=== Step 8: Copying API Server to release directory ==="
 RELEASE_DIR="$TAURI_DIR/target/release"
 if [ -d "$RELEASE_DIR" ]; then
     cp "$BINARIES_DIR/$BINARY_NAME" "$RELEASE_DIR/$BINARY_NAME"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Complete release build script for ChipCompiler ECC
 # This script builds both the Python API server and the Tauri application
@@ -163,25 +163,7 @@ fi
 echo "Frontend dependencies installed."
 echo ""
 
-# Step 8: Build Tauri application
-echo "=== Step 8: Building Tauri application ==="
-if [ ! -d "$OSS_CAD_BUNDLE_DIR" ]; then
-    echo "ERROR: Tauri resources missing: $OSS_CAD_BUNDLE_DIR"
-    exit 1
-fi
-pnpm run tauri build
-
-# Step 9: Copy API Server binary to release directory (for direct execution)
-echo "=== Step 9: Copying API Server to release directory ==="
-RELEASE_DIR="$TAURI_DIR/target/release"
-if [ -d "$RELEASE_DIR" ]; then
-    cp "$BINARIES_DIR/$BINARY_NAME" "$RELEASE_DIR/$BINARY_NAME"
-    chmod +x "$RELEASE_DIR/$BINARY_NAME"
-    echo "Copied: $RELEASE_DIR/$BINARY_NAME"
-else
-    echo "Warning: Release directory not found, skipping copy"
-fi
-echo ""
+build_tauri_bundle "$GUI_DIR" "$TAURI_DIR" "$OSS_CAD_BUNDLE_DIR" "$BINARIES_DIR" "$BINARY_NAME" || exit 1
 
 echo ""
 echo "=========================================="
@@ -192,11 +174,3 @@ echo "Output locations:"
 echo "  - Executable: $TAURI_DIR/target/release/ecc-client"
 echo "  - Bundles:    $TAURI_DIR/target/release/bundle/"
 echo ""
-
-# List generated bundles
-if [ -d "$TAURI_DIR/target/release/bundle" ]; then
-    echo "Generated packages:"
-    find "$TAURI_DIR/target/release/bundle" -type f \( -name "*.dmg" -o -name "*.app" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" -o -name "*.msi" -o -name "*.exe" \) 2>/dev/null | while read f; do
-        echo "  - $f"
-    done
-fi

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -8,17 +8,19 @@ set -e  # Exit on error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Source common functions
+source "${SCRIPT_DIR}/common.sh"
+
+# GUI paths
 GUI_DIR="$PROJECT_ROOT/chipcompiler/gui"
 TAURI_DIR="$GUI_DIR/src-tauri"
 BINARIES_DIR="$TAURI_DIR/binaries"
-VENV_DIR="$PROJECT_ROOT/.venv"
-PYTHON_VERSION="3.10"
-ENABLE_OSS_CAD_SUITE=${ENABLE_OSS_CAD_SUITE:-true}
-ECC_TOOLS_ROOT="$PROJECT_ROOT/chipcompiler/thirdparty/ecc-tools"
-ECC_PY_GLOB="$ECC_TOOLS_ROOT/bin/ecc_py*.so"
-OSS_CAD_DIR="$PROJECT_ROOT/chipcompiler/thirdparty/oss-cad-suite"
 TAURI_RESOURCES_DIR="$TAURI_DIR/resources"
 OSS_CAD_BUNDLE_DIR="$TAURI_RESOURCES_DIR/oss-cad-suite"
+
+# Initialize project variables
+setup_project_vars
 
 echo "=========================================="
 echo "ChipCompiler ECC Release Build"
@@ -27,55 +29,18 @@ echo "Project root: $PROJECT_ROOT"
 echo ""
 
 # Get target platform
-TARGET=$(rustc -vV | grep host | cut -d' ' -f2)
+TARGET=$(get_target_platform)
 echo "Target platform: $TARGET"
 echo ""
 
-# Step 1: Setup Python environment with uv (aligned with build.sh)
+# Step 1: Setup Python environment
 echo "=== Step 1: Setting up Python environment ==="
-if ! command -v uv &> /dev/null; then
-    echo "ERROR: uv is not installed or not in PATH"
-    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
-    exit 1
-fi
-echo "Syncing Python ${PYTHON_VERSION} environment with uv..."
-uv sync --frozen --all-groups --python ${PYTHON_VERSION}
-echo "Activating virtual environment..."
-source "$VENV_DIR/bin/activate"
-echo "Python environment ready."
+setup_uv_env || exit 1
 echo ""
 
-# Step 2: Ensure yosys is available (required by runtime)
+# Step 2: Ensure yosys is available
 echo "=== Step 2: Ensuring yosys is available ==="
-if command -v yosys &> /dev/null; then
-    echo "yosys found: $(command -v yosys)"
-else
-    if [ "$ENABLE_OSS_CAD_SUITE" == "true" ]; then
-        echo "yosys not found, installing OSS CAD Suite..."
-        if [ -d "${OSS_CAD_DIR}" ] && [ -f "${OSS_CAD_DIR}/bin/yosys" ]; then
-            echo "OSS CAD Suite already exists at ${OSS_CAD_DIR}, skipping download..."
-        else
-            LATEST_TAG=$(curl -s "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
-            OSS_CAD_URL="https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${LATEST_TAG}/oss-cad-suite-linux-x64-${LATEST_TAG//-/}.tgz"
-            mkdir -p "${OSS_CAD_DIR}"
-            TMP_DIR=$(mktemp -d)
-            echo "Downloading OSS CAD Suite from ${OSS_CAD_URL}..."
-            curl -fL "${OSS_CAD_URL}" -o "${TMP_DIR}/oss-cad-suite.tgz"
-            tar -xzf "${TMP_DIR}/oss-cad-suite.tgz" -C "${OSS_CAD_DIR}" --strip-components=1
-            rm -rf "${TMP_DIR}/oss-cad-suite.tgz"
-        fi
-        export PATH="${OSS_CAD_DIR}/bin:$PATH"
-        if command -v yosys &> /dev/null; then
-            echo "yosys installed: $(command -v yosys)"
-        else
-            echo "ERROR: yosys still not found after OSS CAD Suite setup."
-            exit 1
-        fi
-    else
-        echo "ERROR: yosys not found and ENABLE_OSS_CAD_SUITE=false"
-        exit 1
-    fi
-fi
+ensure_yosys || exit 1
 echo ""
 
 # Step 3: Stage Yosys runtime for bundling
@@ -113,45 +78,10 @@ if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
 fi
 echo ""
 
-# Step 4: Ensure ecc_py is built (required by chipcompiler.spec)
+# Step 4: Ensure ecc_py is built
 echo "=== Step 4: Ensuring ecc_py is built ==="
-if ls $ECC_PY_GLOB >/dev/null 2>&1; then
-    echo "ecc_py already exists in $ECC_TOOLS_ROOT/bin."
-else
-    echo "ecc_py not found, building..."
-    if [ ! -d "$ECC_TOOLS_ROOT" ]; then
-        echo "ERROR: ecc-tools submodule not found. Run: git submodule update --init --recursive"
-        exit 1
-    fi
-    git submodule update --init --recursive
-
-    BUILD_DIR="$ECC_TOOLS_ROOT/build"
-    mkdir -p "$BUILD_DIR"
-    rm -rf "$BUILD_DIR/CMakeCache.txt" "$BUILD_DIR/CMakeFiles" "$BUILD_DIR/build.ninja" "$BUILD_DIR/Makefile"
-
-    cd "$BUILD_DIR"
-    if ! command -v cmake &> /dev/null; then
-        echo "ERROR: cmake not found. Please install cmake."
-        exit 1
-    fi
-
-    if command -v ninja &> /dev/null; then
-        echo "Configuring with Ninja..."
-        cmake -G Ninja -DBUILD_AIEDA=ON ..
-        echo "Building ecc_py with Ninja..."
-        ninja ecc_py
-    else
-        echo "Configuring with default generator..."
-        cmake -DBUILD_AIEDA=ON ..
-        echo "Building ecc_py with make..."
-        make -j$(nproc) ecc_py
-    fi
-
-    if ! ls $ECC_PY_GLOB >/dev/null 2>&1; then
-        echo "ERROR: ecc_py build failed (ecc_py*.so not found)."
-        exit 1
-    fi
-fi
+setup_submodules
+build_ecc_py || exit 1
 echo ""
 
 # Step 5: Build API Server with PyInstaller

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -17,6 +17,8 @@ ENABLE_OSS_CAD_SUITE=${ENABLE_OSS_CAD_SUITE:-true}
 ECC_TOOLS_ROOT="$PROJECT_ROOT/chipcompiler/thirdparty/ecc-tools"
 ECC_PY_GLOB="$ECC_TOOLS_ROOT/bin/ecc_py*.so"
 OSS_CAD_DIR="$PROJECT_ROOT/chipcompiler/thirdparty/oss-cad-suite"
+TAURI_RESOURCES_DIR="$TAURI_DIR/resources"
+OSS_CAD_BUNDLE_DIR="$TAURI_RESOURCES_DIR/oss-cad-suite"
 
 echo "=========================================="
 echo "ChipCompiler ECC Release Build"
@@ -76,8 +78,43 @@ else
 fi
 echo ""
 
-# Step 3: Ensure ecc_py is built (required by chipcompiler.spec)
-echo "=== Step 3: Ensuring ecc_py is built ==="
+# Step 3: Stage Yosys runtime for bundling
+echo "=== Step 3: Staging Yosys runtime ==="
+rm -rf "$OSS_CAD_BUNDLE_DIR"
+mkdir -p "$OSS_CAD_BUNDLE_DIR/bin" "$OSS_CAD_BUNDLE_DIR/share"
+
+YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys"
+if [[ "$TARGET" == *"windows"* ]]; then
+    YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys.exe"
+fi
+
+if [ ! -f "$YOSYS_BIN_SRC" ]; then
+    echo "ERROR: yosys binary not found at $YOSYS_BIN_SRC"
+    exit 1
+fi
+
+SLANG_SRC=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
+if [ -z "$SLANG_SRC" ]; then
+    echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
+    exit 1
+fi
+
+cp "$YOSYS_BIN_SRC" "$OSS_CAD_BUNDLE_DIR/bin/"
+if [ -f "$OSS_CAD_DIR/bin/abc" ]; then
+    cp "$OSS_CAD_DIR/bin/abc" "$OSS_CAD_BUNDLE_DIR/bin/"
+    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/abc"
+fi
+cp -a "$OSS_CAD_DIR/share/yosys" "$OSS_CAD_BUNDLE_DIR/share/"
+chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
+echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
+echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
+if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
+    echo "Bundled abc: $OSS_CAD_BUNDLE_DIR/bin/abc"
+fi
+echo ""
+
+# Step 4: Ensure ecc_py is built (required by chipcompiler.spec)
+echo "=== Step 4: Ensuring ecc_py is built ==="
 if ls $ECC_PY_GLOB >/dev/null 2>&1; then
     echo "ecc_py already exists in $ECC_TOOLS_ROOT/bin."
 else
@@ -117,8 +154,8 @@ else
 fi
 echo ""
 
-# Step 4: Build API Server with PyInstaller
-echo "=== Step 4: Building API Server ==="
+# Step 5: Build API Server with PyInstaller
+echo "=== Step 5: Building API Server ==="
 cd "$PROJECT_ROOT"
 
 # Clean previous builds
@@ -140,8 +177,8 @@ fi
 echo "API Server built successfully."
 echo ""
 
-# Step 5: Copy binary to Tauri binaries directory
-echo "=== Step 5: Installing API Server binary ==="
+# Step 6: Copy binary to Tauri binaries directory
+echo "=== Step 6: Installing API Server binary ==="
 mkdir -p "$BINARIES_DIR"
 
 # Determine binary name based on platform
@@ -155,8 +192,8 @@ chmod +x "$BINARIES_DIR/$BINARY_NAME"
 echo "Installed: $BINARIES_DIR/$BINARY_NAME"
 echo ""
 
-# Step 6: Install frontend dependencies
-echo "=== Step 6: Installing frontend dependencies ==="
+# Step 7: Install frontend dependencies
+echo "=== Step 7: Installing frontend dependencies ==="
 cd "$GUI_DIR"
 if command -v pnpm &> /dev/null; then
     pnpm install
@@ -168,12 +205,12 @@ fi
 echo "Frontend dependencies installed."
 echo ""
 
-# Step 7: Build Tauri application
-echo "=== Step 7: Building Tauri application ==="
+# Step 8: Build Tauri application
+echo "=== Step 8: Building Tauri application ==="
 pnpm run tauri build
 
-# Step 8: Copy API Server binary to release directory (for direct execution)
-echo "=== Step 8: Copying API Server to release directory ==="
+# Step 9: Copy API Server binary to release directory (for direct execution)
+echo "=== Step 9: Copying API Server to release directory ==="
 RELEASE_DIR="$TAURI_DIR/target/release"
 if [ -d "$RELEASE_DIR" ]; then
     cp "$BINARIES_DIR/$BINARY_NAME" "$RELEASE_DIR/$BINARY_NAME"

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -81,17 +81,28 @@ else
 
     echo "Syncing OSS CAD Suite into Tauri resources..."
     cp -a "$OSS_CAD_DIR/." "$OSS_CAD_BUNDLE_DIR/"
-    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-    if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
-        chmod +x "$OSS_CAD_BUNDLE_DIR/bin/abc"
+    echo "Pruning OSS CAD Suite resources (keep yosys + abc)..."
+    # Keep only yosys, yosys* and abc executables in bin/
+    if [ -d "$OSS_CAD_BUNDLE_DIR/bin" ]; then
+        find "$OSS_CAD_BUNDLE_DIR/bin" -maxdepth 1 -type f ! -name 'yosys' ! -name 'yosys*' ! -name 'abc' -print0 | xargs -0 -r rm -f
     fi
+    # Keep only yosys-related content in share/
+    if [ -d "$OSS_CAD_BUNDLE_DIR/share" ]; then
+        # Remove all top-level share entries except yosys
+        find "$OSS_CAD_BUNDLE_DIR/share" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'if [ "$(basename "{}")" != "yosys" ]; then rm -rf "{}"; fi'
+    fi
+    if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
+        # Inside share/yosys, keep only yosys-related files/directories
+        find "$OSS_CAD_BUNDLE_DIR/share/yosys" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'name=$(basename "{}"); case "$name" in yosys*|plugins|techlibs|scripts) ;; *) rm -rf "{}" ;; esac'
+    fi
+    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
     echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
     if [ -d "$OSS_CAD_BUNDLE_DIR/share/yosys" ]; then
         echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
     fi
-    if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
-        echo "Bundled abc: $OSS_CAD_BUNDLE_DIR/bin/abc"
-    fi
+
     echo ""
 fi
 

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -45,38 +45,46 @@ echo ""
 
 # Step 3: Stage Yosys runtime for bundling
 echo "=== Step 3: Staging Yosys runtime ==="
-rm -rf "$OSS_CAD_BUNDLE_DIR"
-mkdir -p "$OSS_CAD_BUNDLE_DIR/bin" "$OSS_CAD_BUNDLE_DIR/share"
+if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
+    echo "Skipping yosys bundling (ENABLE_OSS_CAD_SUITE=$ENABLE_OSS_CAD_SUITE)"
+    echo ""
+else
+    # Ensure OSS CAD Suite is downloaded (even if system yosys exists)
+    setup_oss_cad_suite
 
-YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys"
-if [[ "$TARGET" == *"windows"* ]]; then
-    YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys.exe"
-fi
+    rm -rf "$OSS_CAD_BUNDLE_DIR"
+    mkdir -p "$OSS_CAD_BUNDLE_DIR/bin" "$OSS_CAD_BUNDLE_DIR/share"
 
-if [ ! -f "$YOSYS_BIN_SRC" ]; then
-    echo "ERROR: yosys binary not found at $YOSYS_BIN_SRC"
-    exit 1
-fi
+    YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys"
+    if [[ "$TARGET" == *"windows"* ]]; then
+        YOSYS_BIN_SRC="$OSS_CAD_DIR/bin/yosys.exe"
+    fi
 
-SLANG_SRC=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
-if [ -z "$SLANG_SRC" ]; then
-    echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
-    exit 1
-fi
+    if [ ! -f "$YOSYS_BIN_SRC" ]; then
+        echo "ERROR: yosys binary not found at $YOSYS_BIN_SRC"
+        exit 1
+    fi
 
-cp "$YOSYS_BIN_SRC" "$OSS_CAD_BUNDLE_DIR/bin/"
-if [ -f "$OSS_CAD_DIR/bin/abc" ]; then
-    cp "$OSS_CAD_DIR/bin/abc" "$OSS_CAD_BUNDLE_DIR/bin/"
-    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/abc"
+    SLANG_SRC=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
+    if [ -z "$SLANG_SRC" ]; then
+        echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
+        exit 1
+    fi
+
+    cp "$YOSYS_BIN_SRC" "$OSS_CAD_BUNDLE_DIR/bin/"
+    if [ -f "$OSS_CAD_DIR/bin/abc" ]; then
+        cp "$OSS_CAD_DIR/bin/abc" "$OSS_CAD_BUNDLE_DIR/bin/"
+        chmod +x "$OSS_CAD_BUNDLE_DIR/bin/abc"
+    fi
+    cp -a "$OSS_CAD_DIR/share/yosys" "$OSS_CAD_BUNDLE_DIR/share/"
+    chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
+    echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
+    echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
+    if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
+        echo "Bundled abc: $OSS_CAD_BUNDLE_DIR/bin/abc"
+    fi
+    echo ""
 fi
-cp -a "$OSS_CAD_DIR/share/yosys" "$OSS_CAD_BUNDLE_DIR/share/"
-chmod +x "$OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-echo "Bundled yosys: $OSS_CAD_BUNDLE_DIR/bin/$(basename "$YOSYS_BIN_SRC")"
-echo "Bundled share/yosys: $OSS_CAD_BUNDLE_DIR/share/yosys"
-if [ -f "$OSS_CAD_BUNDLE_DIR/bin/abc" ]; then
-    echo "Bundled abc: $OSS_CAD_BUNDLE_DIR/bin/abc"
-fi
-echo ""
 
 # Step 4: Ensure ecc_py is built
 echo "=== Step 4: Ensuring ecc_py is built ==="

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -59,6 +59,67 @@ setup_oss_cad_suite() {
     echo "==============================="
 }
 
+# Stage OSS CAD Suite into Tauri resources
+stage_oss_cad_suite() {
+    local tauri_resources_dir="$1"
+    local oss_cad_bundle_dir="$2"
+    local target="$3"
+
+    mkdir -p "$tauri_resources_dir"
+    if [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]]; then
+        mkdir -p "$oss_cad_bundle_dir"
+        return 0
+    fi
+
+    if [[ ! -d "${OSS_CAD_DIR}" || ! -f "${OSS_CAD_DIR}/bin/yosys" ]]; then
+        echo "ERROR: OSS CAD Suite not found at ${OSS_CAD_DIR}."
+        return 1
+    fi
+
+    rm -rf "$oss_cad_bundle_dir"
+    mkdir -p "$oss_cad_bundle_dir"
+
+    local yosys_bin_src="$OSS_CAD_DIR/bin/yosys"
+    if [[ "$target" == *"windows"* ]]; then
+        yosys_bin_src="$OSS_CAD_DIR/bin/yosys.exe"
+    fi
+
+    if [ ! -f "$yosys_bin_src" ]; then
+        echo "ERROR: yosys binary not found at $yosys_bin_src"
+        return 1
+    fi
+
+    local slang_src
+    slang_src=$(ls "$OSS_CAD_DIR/share/yosys/plugins"/slang.* 2>/dev/null | head -1)
+    if [ -z "$slang_src" ]; then
+        echo "ERROR: slang plugin not found under $OSS_CAD_DIR/share/yosys/plugins"
+        return 1
+    fi
+
+    cp -a "$OSS_CAD_DIR/." "$oss_cad_bundle_dir/"
+    if [ -d "$oss_cad_bundle_dir/bin" ]; then
+        find "$oss_cad_bundle_dir/bin" -maxdepth 1 -type f ! -name 'yosys' ! -name 'yosys*' ! -name 'abc' -print0 | xargs -0 -r rm -f
+    fi
+    if [ -d "$oss_cad_bundle_dir/libexec" ]; then
+        rm -rf "$oss_cad_bundle_dir/libexec"
+    fi
+    if [ -d "$oss_cad_bundle_dir/lib" ]; then
+        rm -rf "$oss_cad_bundle_dir/lib"
+    fi
+    if [ -d "$oss_cad_bundle_dir/share" ]; then
+        find "$oss_cad_bundle_dir/share" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'if [ "$(basename "{}")" != "yosys" ]; then rm -rf "{}"; fi'
+    fi
+    if [ -d "$oss_cad_bundle_dir/share/yosys" ]; then
+        find "$oss_cad_bundle_dir/share/yosys" -mindepth 1 -maxdepth 1 -print0 | \
+            xargs -0 -r -I {} bash -c 'name=$(basename "{}"); case "$name" in yosys*|plugins|techlibs|scripts) ;; *) rm -rf "{}" ;; esac'
+        if [ -d "$oss_cad_bundle_dir/share/yosys/plugins" ]; then
+            find "$oss_cad_bundle_dir/share/yosys/plugins" -type f ! -name 'slang.so' -print0 | xargs -0 -r rm -f
+        fi
+    fi
+    chmod +x "$oss_cad_bundle_dir/bin/$(basename "$yosys_bin_src")"
+}
+
 # Append OSS CAD path to venv activate script
 append_oss_cad_to_venv() {
     if [[ "$ENABLE_OSS_CAD_SUITE" == "true" ]]; then
@@ -208,21 +269,16 @@ build_tauri_bundle() {
         return 1
     fi
 
-    export APPIMAGE_EXTRACT_AND_RUN=1
-    if [ -z "${LINUXDEPLOY:-}" ] && command -v linuxdeploy &> /dev/null; then
-        export LINUXDEPLOY="$(command -v linuxdeploy)"
-    fi
-    if [ -z "${LINUXDEPLOY_PLUGIN_APPIMAGE:-}" ] && command -v linuxdeploy-plugin-appimage &> /dev/null; then
-        export LINUXDEPLOY_PLUGIN_APPIMAGE="$(command -v linuxdeploy-plugin-appimage)"
-    fi
-    if [ -z "${LINUXDEPLOY:-}" ]; then
-        echo "Warning: linuxdeploy not found in PATH. Set LINUXDEPLOY to its absolute path if AppImage bundling fails."
-    fi
-    if [ -z "${LINUXDEPLOY_PLUGIN_APPIMAGE:-}" ]; then
-        echo "Warning: linuxdeploy-plugin-appimage not found in PATH. Set LINUXDEPLOY_PLUGIN_APPIMAGE to its absolute path if AppImage bundling fails."
+    if [ -d "$HOME/.local/bin" ]; then
+        export PATH="$HOME/.local/bin:$PATH"
     fi
 
-    (cd "$gui_dir" && pnpm run tauri build)
+    export RUST_BACKTRACE=1
+
+    if ! (cd "$gui_dir" && pnpm run tauri build -- --verbose); then
+        echo "ERROR: Tauri build failed"
+        return 1
+    fi
 
     echo "=== Step 9: Copying API Server to release directory ==="
     local release_dir="$tauri_dir/target/release"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -14,6 +14,7 @@ setup_project_vars() {
     export PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
     export ENABLE_OSS_CAD_SUITE="${ENABLE_OSS_CAD_SUITE:-true}"
     export ECC_PY_GLOB="${ECC_TOOLS_ROOT}/bin/ecc_py*.so"
+    export CMAKE_EXTRA_OPTIONS="${CMAKE_EXTRA_OPTIONS:-}"
 }
 
 # Check and setup uv environment
@@ -126,13 +127,21 @@ build_ecc_py() {
     fi
 
     echo "Configuring project with CMake..."
+    local cmake_opts=("-DBUILD_AIEDA=ON")
+    local cmake_gen=""
     if command -v ninja &> /dev/null; then
         echo "Using Ninja generator..."
-        cmake -G Ninja -DBUILD_AIEDA=ON ..
+        cmake_gen="-G Ninja"
     else
         echo "Using default generator..."
-        cmake -DBUILD_AIEDA=ON ..
     fi
+
+    local cmake_cmd="cmake ${cmake_gen} ${cmake_opts[*]}"
+    if [[ -n "${CMAKE_EXTRA_OPTIONS}" ]]; then
+        cmake_cmd+=" ${CMAKE_EXTRA_OPTIONS}"
+    fi
+    cmake_cmd+=" .."
+    eval "${cmake_cmd}"
 
     if [[ $? -ne 0 ]]; then
         echo "Error: CMake configuration failed"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# Common functions and variables for ChipCompiler build scripts
+#
+
+# Setup Project Variables
+setup_project_vars() {
+    export PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[1]}")/.." && pwd)}"
+    export CHIPCOMPILER_ROOT="${PROJECT_ROOT}/chipcompiler"
+    export ECC_TOOLS_ROOT="${CHIPCOMPILER_ROOT}/thirdparty/ecc-tools"
+    export ICS55_PDK_ROOT="${CHIPCOMPILER_ROOT}/thirdparty/icsprout55-pdk"
+    export OSS_CAD_DIR="${CHIPCOMPILER_ROOT}/thirdparty/oss-cad-suite"
+    export VENV_DIR="${PROJECT_ROOT}/.venv"
+    export PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
+    export ENABLE_OSS_CAD_SUITE="${ENABLE_OSS_CAD_SUITE:-true}"
+    export ECC_PY_GLOB="${ECC_TOOLS_ROOT}/bin/ecc_py*.so"
+}
+
+# Check and setup uv environment
+setup_uv_env() {
+    if ! command -v uv &> /dev/null; then
+        echo "Error: uv is not installed or not in PATH"
+        echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+        return 1
+    fi
+
+    echo "Setting up Python ${PYTHON_VERSION} environment with uv..."
+    uv sync --frozen --all-groups --python "${PYTHON_VERSION}"
+
+    echo "Activating virtual environment..."
+    source "${VENV_DIR}/bin/activate"
+}
+
+# Download and setup OSS CAD Suite
+setup_oss_cad_suite() {
+    [[ "$ENABLE_OSS_CAD_SUITE" != "true" ]] && return 0
+
+    echo "==============================="
+    if [[ -d "${OSS_CAD_DIR}" && -f "${OSS_CAD_DIR}/bin/yosys" ]]; then
+        echo "OSS CAD Suite already exists at ${OSS_CAD_DIR}, skipping download..."
+    else
+        local latest_tag
+        latest_tag=$(curl -s "https://api.github.com/repos/YosysHQ/oss-cad-suite-build/releases/latest" | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        local oss_cad_url="https://github.com/YosysHQ/oss-cad-suite-build/releases/download/${latest_tag}/oss-cad-suite-linux-x64-${latest_tag//-/}.tgz"
+
+        mkdir -p "${OSS_CAD_DIR}"
+        local tmp_dir
+        tmp_dir=$(mktemp -d)
+        echo "Downloading OSS CAD Suite from ${oss_cad_url}..."
+        curl -fL "${oss_cad_url}" -o "${tmp_dir}/oss-cad-suite.tgz"
+        tar -xzf "${tmp_dir}/oss-cad-suite.tgz" -C "${OSS_CAD_DIR}" --strip-components=1
+        rm -rf "${tmp_dir}"
+    fi
+
+    export PATH="${OSS_CAD_DIR}/bin:$PATH"
+    echo "OSS CAD Suite is set up at ${OSS_CAD_DIR}"
+    echo -e "\033[1;33mexport PATH=\"${OSS_CAD_DIR}/bin:\$PATH\"\033[0m"
+    echo "==============================="
+}
+
+# Append OSS CAD path to venv activate script
+append_oss_cad_to_venv() {
+    if [[ "$ENABLE_OSS_CAD_SUITE" == "true" ]]; then
+        echo "export PATH=\"${OSS_CAD_DIR}/bin:\$PATH\"" >> "${VENV_DIR}/bin/activate"
+    fi
+}
+
+# Initialize git submodules
+setup_submodules() {
+    echo "Setting up third-party submodules..."
+    git submodule update --init --recursive
+}
+
+# Setup ICS55 PDK
+setup_ics55_pdk() {
+    if [[ -d "${ICS55_PDK_ROOT}" ]]; then
+        echo "Setting up ICS55 PDK..."
+        (cd "${ICS55_PDK_ROOT}" && make unzip)
+    fi
+}
+
+# Ensure yosys is available
+ensure_yosys() {
+    if command -v yosys &> /dev/null; then
+        echo "yosys found: $(command -v yosys)"
+        return 0
+    fi
+
+    if [[ "$ENABLE_OSS_CAD_SUITE" == "true" ]]; then
+        setup_oss_cad_suite
+        if command -v yosys &> /dev/null; then
+            echo "yosys installed: $(command -v yosys)"
+            return 0
+        fi
+    fi
+
+    echo "ERROR: yosys not found"
+    return 1
+}
+
+# Build ecc_py
+build_ecc_py() {
+    local force="${1:-false}"
+
+    if [[ "$force" != "true" ]] && ls ${ECC_PY_GLOB} >/dev/null 2>&1; then
+        echo "ecc_py already exists in ${ECC_TOOLS_ROOT}/bin."
+        return 0
+    fi
+
+    echo "Building ecc_py..."
+
+    if [[ ! -d "${ECC_TOOLS_ROOT}" ]]; then
+        echo "ERROR: ecc-tools submodule not found. Run: git submodule update --init --recursive"
+        return 1
+    fi
+
+    local build_dir="${ECC_TOOLS_ROOT}/build"
+    mkdir -p "${build_dir}"
+    rm -rf "${build_dir}/CMakeCache.txt" "${build_dir}/CMakeFiles" "${build_dir}/build.ninja" "${build_dir}/Makefile"
+
+    cd "${build_dir}" || return 1
+
+    if ! command -v cmake &> /dev/null; then
+        echo "Error: CMake is not installed or not in PATH"
+        bash "${ECC_TOOLS_ROOT}/build.sh" -i apt
+    fi
+
+    echo "Configuring project with CMake..."
+    if command -v ninja &> /dev/null; then
+        echo "Using Ninja generator..."
+        cmake -G Ninja -DBUILD_AIEDA=ON ..
+    else
+        echo "Using default generator..."
+        cmake -DBUILD_AIEDA=ON ..
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        echo "Error: CMake configuration failed"
+        return 1
+    fi
+
+    echo "Building project..."
+    if command -v ninja &> /dev/null; then
+        ninja ecc_py
+    else
+        make -j"$(nproc)" ecc_py
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Build failed"
+        return 1
+    fi
+
+    if ! ls ${ECC_PY_GLOB} >/dev/null 2>&1; then
+        echo "ERROR: ecc_py build failed (ecc_py*.so not found)."
+        return 1
+    fi
+
+    echo "ecc_py build completed successfully!"
+    cd "${PROJECT_ROOT}" || return 1
+}
+
+# Copy ecc_py.so to tools/ecc/bin directory
+install_ecc_py() {
+    echo "Copying ecc_py.so to tools/ecc/bin directory..."
+    local ecc_py_bin_dir="${CHIPCOMPILER_ROOT}/tools/ecc/bin"
+    local ecc_tools_bin_dir="${ECC_TOOLS_ROOT}/bin"
+
+    mkdir -p "${ecc_py_bin_dir}"
+
+    local ecc_py_file
+    ecc_py_file=$(find "${ecc_tools_bin_dir}" -name "ecc_py*.so" | head -1)
+
+    if [[ -f "${ecc_py_file}" ]]; then
+        echo "Found ecc_py file: ${ecc_py_file}"
+        cp "${ecc_py_file}" "${ecc_py_bin_dir}/"
+        echo "Successfully copied ecc_py.so to ${ecc_py_bin_dir}/"
+    else
+        echo "Warning: ecc_py.so file not found in ${ecc_tools_bin_dir}"
+    fi
+}
+
+# Get target platform for Tauri
+get_target_platform() {
+    rustc -vV | grep host | cut -d' ' -f2
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -193,3 +193,52 @@ install_ecc_py() {
 get_target_platform() {
     rustc -vV | grep host | cut -d' ' -f2
 }
+
+# Build Tauri bundles and copy the API server binary into release dir
+build_tauri_bundle() {
+    local gui_dir="$1"
+    local tauri_dir="$2"
+    local oss_cad_bundle_dir="$3"
+    local binaries_dir="$4"
+    local binary_name="$5"
+
+    echo "=== Step 8: Building Tauri application ==="
+    if [ ! -d "$oss_cad_bundle_dir" ]; then
+        echo "ERROR: Tauri resources missing: $oss_cad_bundle_dir"
+        return 1
+    fi
+
+    export APPIMAGE_EXTRACT_AND_RUN=1
+    if [ -z "${LINUXDEPLOY:-}" ] && command -v linuxdeploy &> /dev/null; then
+        export LINUXDEPLOY="$(command -v linuxdeploy)"
+    fi
+    if [ -z "${LINUXDEPLOY_PLUGIN_APPIMAGE:-}" ] && command -v linuxdeploy-plugin-appimage &> /dev/null; then
+        export LINUXDEPLOY_PLUGIN_APPIMAGE="$(command -v linuxdeploy-plugin-appimage)"
+    fi
+    if [ -z "${LINUXDEPLOY:-}" ]; then
+        echo "Warning: linuxdeploy not found in PATH. Set LINUXDEPLOY to its absolute path if AppImage bundling fails."
+    fi
+    if [ -z "${LINUXDEPLOY_PLUGIN_APPIMAGE:-}" ]; then
+        echo "Warning: linuxdeploy-plugin-appimage not found in PATH. Set LINUXDEPLOY_PLUGIN_APPIMAGE to its absolute path if AppImage bundling fails."
+    fi
+
+    (cd "$gui_dir" && pnpm run tauri build)
+
+    echo "=== Step 9: Copying API Server to release directory ==="
+    local release_dir="$tauri_dir/target/release"
+    if [ -d "$release_dir" ]; then
+        cp "$binaries_dir/$binary_name" "$release_dir/$binary_name"
+        chmod +x "$release_dir/$binary_name"
+        echo "Copied: $release_dir/$binary_name"
+    else
+        echo "Warning: Release directory not found, skipping copy"
+    fi
+    echo ""
+
+    if [ -d "$tauri_dir/target/release/bundle" ]; then
+        echo "Generated packages:"
+        find "$tauri_dir/target/release/bundle" -type f \( -name "*.dmg" -o -name "*.app" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" -o -name "*.msi" -o -name "*.exe" \) 2>/dev/null | while read f; do
+            echo "  - $f"
+        done
+    fi
+}


### PR DESCRIPTION
* Extract common build and environment setup logic into a new `scripts/common.sh`, providing reusable functions for Python environment setup, OSS CAD Suite management, submodule initialization, and more. This reduces duplication and simplifies maintenance across build scripts
* Refactor `build.sh` and `scripts/build_release.sh` to use these new common functions, resulting in cleaner and more maintainable scripts
* Enhance the build process to bundle the OSS CAD Suite (Yosys and plugins) directly into the Tauri application's resources, ensuring the GUI can run Yosys out-of-the-box on user systems
* Update the Tauri configuration (`tauri.conf.json`) to include the OSS CAD Suite in the packaged application resources.
* Improved Python tooling by ensuring the bundled Yosys is preferred if present, and by setting up environment variables for plugins and data directories in `chipcompiler/tools/yosys/utility.py`
* Add a new GitHub Actions workflow (`.github/workflows/ci.yml`) to automate the build and packaging process, ensuring consistency and catching integration issues early
