### PR TITLE
 feat: add auto-patchelf and autopatch-ecc-py.sh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get install -y \
     libhwloc-dev \
     libcairo2-dev \
     libcurl4-openssl-dev \
-    libtbb-dev
+    libtbb-dev \
+    patchelf
 
 # Install Node.js (LTS) and pnpm
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,10 +12,10 @@ setup_project_vars
 cd -
 
 uv sync --frozen --all-groups --python 3.11
+source .venv/bin/activate
+
 setup_oss_cad_suite
 setup_ics55_pdk
-
-source .venv/bin/activate
 build_ecc_py
 bash ./scripts/autopatch-ecc-py.sh
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
 # Setup script for devcontainer post-create command
-# This script is extracted from .devcontainer/devcontainer.json postCreateCommand
-
 set -e
 
-# Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-
 cd "$PROJECT_ROOT"
-
-rm -rf .venv
 
 cd scripts
 source common.sh
@@ -18,8 +12,11 @@ setup_project_vars
 cd -
 
 uv sync --frozen --all-groups --python 3.11
-
-build_ecc_py
-
 setup_oss_cad_suite
+setup_ics55_pdk
 
+source .venv/bin/activate
+build_ecc_py
+bash ./scripts/autopatch-ecc-py.sh
+
+echo "✓ Development environment ready!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,46 @@ make
 ```
 Builds ECC-Tools C++ bindings. Python executable path defaults to `.venv/bin/python3`.
 
+### Patching ECC Runtime Dependencies
+
+After building ECC-Tools Python bindings, use `autopatch-ecc-py.sh` to bundle runtime dependencies:
+
+```bash
+# Auto-detect from default location
+./scripts/autopatch-ecc-py.sh
+
+# Specify custom ecc_py.so location
+./scripts/autopatch-ecc-py.sh --ecc-py /path/to/ecc_py.so
+
+# Separated ecc_py.so and build directory
+./scripts/autopatch-ecc-py.sh \
+    --ecc-py chipcompiler/tools/ecc/bin/ecc_py.so \
+    --runtime-lib-path /path/to/build
+
+# Multiple runtime library paths
+./scripts/autopatch-ecc-py.sh \
+    --runtime-lib-path /path/to/build \
+    --runtime-lib-path /path/to/extra/libs
+```
+
+**What it does:**
+1. Collects all `.so` dependencies from ECC-Tools build directory
+2. Copies them to `chipcompiler/tools/ecc/bin/lib/`
+3. Uses `auto-patchelf` to fix library dependencies and RPATH
+4. Sets RUNPATH to `$ORIGIN:$ORIGIN/lib` for portable deployment
+5. Verifies all dependencies are resolved via `ldd`
+
+**Requirements:**
+- `patchelf` - ELF binary patcher (`apt install patchelf`)
+- `pyelftools` - Python library (auto-installed in isolated venv)
+
+**When to use:**
+- After building ECC-Tools (`build_ecc_py`)
+- Before packaging for distribution
+- When deploying to systems without ECC-Tools build directory
+
+This script is automatically called by `build.sh`, `Dockerfile`, and `.devcontainer/setup.sh`.
+
 ### Running the API Server
 
 The REST API provides programmatic access to ChipCompiler functionality:
@@ -392,6 +432,7 @@ parameters = get_parameters("ics55", "gcd")  # Returns pre-configured Parameters
 - **GUI-API Communication:** GUI frontend communicates with Python backend via REST API (port 8765). CORS is configured for Tauri dev server (1420) and Vite dev server (5173).
 - **Package Management:** Uses `uv` for fast dependency resolution and environment management. Dependencies defined in pyproject.toml.
 - **Filelist Support:** The project supports Verilog filelist format (`.f` files) for specifying multiple RTL sources. See [docs/examples/gcd/ics55flow_with_filelist.py](docs/examples/gcd/ics55flow_with_filelist.py) for usage.
+- **ECC Runtime Dependencies:** ECC-Tools Python bindings require bundled `.so` libraries. The `autopatch-ecc-py.sh` script automatically collects, patches, and bundles these dependencies with correct RPATH settings (`$ORIGIN:$ORIGIN/lib`) for portable deployment. This ensures `ecc_py*.so` can load all dependencies without requiring the original build directory.
 
 ## Testing Strategy
 
@@ -434,6 +475,18 @@ Extend tests by adding new designs in benchmark/parameters.py and benchmark/ics5
 2. Call flow.save() to persist changes to workspace.flow.json
 3. Run flow.run_steps() - will skip already-successful steps
 4. Use clear_states() to reset and re-run
+
+**Rebuilding ECC-Tools with dependency bundling:**
+1. Build ECC-Tools Python bindings: `build_ecc_py` (from common.sh)
+2. Bundle runtime dependencies: `./scripts/autopatch-ecc-py.sh`
+3. Verify dependencies: `ldd chipcompiler/tools/ecc/bin/ecc_py*.so`
+4. All dependencies should resolve to `$ORIGIN/lib/` or system libraries
+
+**Deploying to a new system:**
+1. Copy `chipcompiler/tools/ecc/bin/` directory (includes ecc_py*.so and lib/)
+2. Ensure `patchelf` is installed on target system
+3. No need to copy ECC-Tools build directory - all dependencies are bundled
+4. Python can import ecc_py module directly from this location
 
 **Working with the GUI:**
 1. Start backend API: `chipcompiler --reload` (port 8765)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,24 @@ tool_name/
 ├── configs/      # Config templates
 ├── scripts/      # Tool scripts
 └── bin/          # Tool binaries (ecc only)
+    └── lib/      # Bundled runtime dependencies (ecc only)
 ```
+
+**ECC-Tools Runtime Dependencies:**
+
+The ECC-Tools Python bindings (`ecc_py*.so`) require numerous shared libraries (`.so` files) at runtime. To enable portable deployment without requiring the full ECC-Tools build directory, these dependencies are bundled:
+
+- **Location**: `chipcompiler/tools/ecc/bin/lib/`
+- **Bundling script**: `scripts/autopatch-ecc-py.sh`
+- **RPATH configuration**: `$ORIGIN:$ORIGIN/lib` (relative paths for portability)
+
+The bundling process:
+1. Collects all `.so` dependencies from ECC-Tools build directory
+2. Copies them to the `lib/` subdirectory
+3. Uses `auto-patchelf` to rewrite RPATH entries in all binaries
+4. Verifies dependency resolution via `ldd`
+
+This allows `ecc_py*.so` to be deployed independently of the build environment, as all dependencies are co-located and referenced via relative paths.
 
 ### Yosys Runtime Flow (Current)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -105,6 +105,55 @@ cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_AIEDA=ON ..
 ninja ieda_py
 ```
 
+### Bundle ECC Runtime Dependencies
+
+After building ECC-Tools Python bindings, bundle runtime dependencies for portable deployment:
+
+```bash
+# Auto-detect from default location
+./scripts/autopatch-ecc-py.sh
+
+# Specify custom ecc_py.so location
+./scripts/autopatch-ecc-py.sh --ecc-py /path/to/ecc_py.so
+
+# Separated ecc_py.so and build directory
+./scripts/autopatch-ecc-py.sh \
+    --ecc-py chipcompiler/tools/ecc/bin/ecc_py.so \
+    --runtime-lib-path /path/to/build
+
+# Multiple runtime library paths
+./scripts/autopatch-ecc-py.sh \
+    --runtime-lib-path /path/to/build \
+    --runtime-lib-path /path/to/extra/libs
+```
+
+**What it does:**
+1. Collects all `.so` dependencies from ECC-Tools build directory
+2. Copies them to `chipcompiler/tools/ecc/bin/lib/`
+3. Uses `auto-patchelf` to fix library dependencies and RPATH
+4. Sets RUNPATH to `$ORIGIN:$ORIGIN/lib` for portable deployment
+5. Verifies all dependencies are resolved via `ldd`
+
+**Requirements:**
+- `patchelf` - ELF binary patcher (`apt install patchelf`)
+- `pyelftools` - Python library (auto-installed in isolated venv by the script)
+
+**When to use:**
+- After building ECC-Tools (`build_ecc_py` or `ninja ieda_py`)
+- Before packaging for distribution
+- When deploying to systems without ECC-Tools build directory
+
+**Verification:**
+```bash
+# Check that all dependencies resolve correctly
+ldd chipcompiler/tools/ecc/bin/ecc_py*.so
+
+# All dependencies should point to $ORIGIN/lib/ or system libraries
+# No references to the original build directory should remain
+```
+
+This script is automatically called by `build.sh`, `Dockerfile`, and `.devcontainer/setup.sh`.
+
 ## Code Quality
 
 ### Formatting

--- a/scripts/auto-patchelf/COPYING
+++ b/scripts/auto-patchelf/COPYING
@@ -1,0 +1,20 @@
+Copyright (c) 2003-2026 Eelco Dolstra and the Nixpkgs/NixOS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/scripts/auto-patchelf/LICENSE
+++ b/scripts/auto-patchelf/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2003-2026 Eelco Dolstra and the Nixpkgs/NixOS contributors
+Copyright (c) 2026 Emin (Qiming Chu)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/scripts/auto-patchelf/auto-patchelf
+++ b/scripts/auto-patchelf/auto-patchelf
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Wrapper script for autopatchelf.py with isolated venv
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+PYTHON_SCRIPT="${SCRIPT_DIR}/autopatchelf.py"
+
+# Create venv if it doesn't exist
+if [[ ! -d "${VENV_DIR}" ]]; then
+    echo "[auto-patchelf] Creating virtual environment..." >&2
+    python3 -m venv "${VENV_DIR}"
+    echo "[auto-patchelf] Installing pyelftools..." >&2
+    "${VENV_DIR}/bin/pip" install --quiet pyelftools
+fi
+
+# Run the script with venv's Python
+exec "${VENV_DIR}/bin/python3" "${PYTHON_SCRIPT}" "$@"

--- a/scripts/auto-patchelf/autopatchelf.py
+++ b/scripts/auto-patchelf/autopatchelf.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+
+# This file is from https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+import argparse
+import os
+import pprint
+import subprocess
+import sys
+import json
+from fnmatch import fnmatch
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path, PurePath
+from typing import DefaultDict, Generator, Iterator, Optional
+
+from elftools.common.exceptions import ELFError  # type: ignore
+from elftools.elf.dynamic import DynamicSection  # type: ignore
+from elftools.elf.sections import NoteSection  # type: ignore
+from elftools.elf.elffile import ELFFile  # type: ignore
+from elftools.elf.enums import ENUM_E_TYPE, ENUM_EI_OSABI  # type: ignore
+
+
+DEFAULT_BINTOOLS = "@defaultBintools@"
+
+
+@contextmanager
+def open_elf(path: Path) -> Iterator[ELFFile]:
+    with path.open('rb') as stream:
+        yield ELFFile(stream)
+
+
+def is_static_executable(elf: ELFFile) -> bool:
+    # Statically linked executables have an ELF type of EXEC but no INTERP.
+    return (elf.header["e_type"] == 'ET_EXEC'
+            and not elf.get_section_by_name(".interp"))
+
+
+def is_dynamic_executable(elf: ELFFile) -> bool:
+    # We do not require an ELF type of EXEC. This also catches
+    # position-independent executables, as they typically have an INTERP
+    # section but their ELF type is DYN.
+    return bool(elf.get_section_by_name(".interp"))
+
+def is_separate_debug_object(elf: ELFFile) -> bool:
+    # objects created by separateDebugInfo = true have all the section headers
+    # of the unstripped objects but those that normal `strip` would have kept
+    # are NOBITS
+    text_section = elf.get_section_by_name(".text")
+    return elf.has_dwarf_info() and bool(text_section) and text_section.header['sh_type'] == "SHT_NOBITS"
+
+
+def get_dependencies(elf: ELFFile) -> list[list[Path]]:
+    dependencies = []
+    # This convoluted code is here on purpose. For some reason, using
+    # elf.get_section_by_name(".dynamic") does not always return an
+    # instance of DynamicSection, but that is required to call iter_tags
+    for section in elf.iter_sections():
+        if isinstance(section, DynamicSection):
+            for tag in section.iter_tags('DT_NEEDED'):
+                dependencies.append([Path(tag.needed)])
+            break # There is only one dynamic section
+
+    return dependencies
+
+
+def get_dlopen_dependencies(elf: ELFFile) -> list[list[Path]]:
+    """
+    Extracts dependencies from the `.note.dlopen` section.
+    This is a FreeDesktop standard to annotate binaries with libraries that it may `dlopen`.
+    See https://systemd.io/ELF_DLOPEN_METADATA/
+    """
+    dependencies = []
+    for section in elf.iter_sections():
+        if not isinstance(section, NoteSection) or section.name != ".note.dlopen":
+            continue
+        for note in section.iter_notes():
+            if note["n_type"] != 0x407C0C0A or note["n_name"] != "FDO":
+                continue
+            note_desc = note["n_desc"]
+            text = note_desc.decode("utf-8").rstrip("\0")
+            j = json.loads(text)
+            for d in j:
+                dependencies.append([Path(soname) for soname in d["soname"]])
+    return dependencies
+
+
+def get_rpath(elf: ELFFile) -> list[str]:
+    # This convoluted code is here on purpose. For some reason, using
+    # elf.get_section_by_name(".dynamic") does not always return an
+    # instance of DynamicSection, but that is required to call iter_tags
+    for section in elf.iter_sections():
+        if isinstance(section, DynamicSection):
+            for tag in section.iter_tags('DT_RUNPATH'):
+                return tag.runpath.split(':')
+
+            for tag in section.iter_tags('DT_RPATH'):
+                return tag.rpath.split(':')
+
+            break # There is only one dynamic section
+
+    return []
+
+
+def get_arch(elf: ELFFile) -> str:
+    return elf.get_machine_arch()
+
+
+def get_osabi(elf: ELFFile) -> str:
+    return elf.header["e_ident"]["EI_OSABI"]
+
+
+def osabi_are_compatible(wanted: str, got: str) -> bool:
+    """
+    Tests whether two OS ABIs are compatible, taking into account the
+    generally accepted compatibility of SVR4 ABI with other ABIs.
+    """
+    if not wanted or not got:
+        # One of the types couldn't be detected, so as a fallback we'll
+        # assume they're compatible.
+        return True
+
+    # Generally speaking, the base ABI (0x00), which is represented by
+    # readelf(1) as "UNIX - System V", indicates broad compatibility
+    # with other ABIs.
+    #
+    # TODO: This isn't always true. For example, some OSes embed ABI
+    # compatibility into SHT_NOTE sections like .note.tag and
+    # .note.ABI-tag.  It would be prudent to add these to the detection
+    # logic to produce better ABI information.
+    if wanted == 'ELFOSABI_SYSV':
+        return True
+
+    # Similarly here, we should be able to link against a superset of
+    # features, so even if the target has another ABI, this should be
+    # fine.
+    if got == 'ELFOSABI_SYSV':
+        return True
+
+    # Otherwise, we simply return whether the ABIs are identical.
+    return wanted == got
+
+
+def glob(path: Path, pattern: str, recursive: bool) -> Iterator[Path]:
+    if path.is_dir():
+        return path.rglob(pattern) if recursive else path.glob(pattern)
+    else:
+        # path.glob won't return anything if the path is not a directory.
+        # We extend that behavior by matching the file name against the pattern.
+        # This allows to pass single files instead of dirs to auto_patchelf,
+        # for greater control on the files to consider.
+        return [path] if path.match(pattern) else []
+
+
+cached_paths: set[Path] = set()
+soname_cache: DefaultDict[tuple[str, str], list[tuple[Path, str]]] = defaultdict(list)
+
+
+def populate_cache(initial: list[Path], recursive: bool =False) -> None:
+    lib_dirs = list(initial)
+
+    while lib_dirs:
+        lib_dir = lib_dirs.pop(0)
+
+        if lib_dir in cached_paths:
+            continue
+
+        cached_paths.add(lib_dir)
+
+        for path in glob(lib_dir, "*.so*", recursive):
+            if not path.is_file():
+                continue
+
+            # As an optimisation, resolve the symlinks here, as the target is unique
+            # XXX: (layus, 2022-07-25) is this really an optimisation in all cases ?
+            # It could make the rpath bigger or break the fragile precedence of $out.
+            resolved = path.resolve()
+            # Do not use resolved paths when names do not match
+            if resolved.name != path.name:
+                resolved = path
+
+            try:
+                with open_elf(path) as elf:
+                    if is_separate_debug_object(elf):
+                        print(f"skipping {path} because it looks like a separate debug object")
+                        continue
+
+                    osabi = get_osabi(elf)
+                    arch = get_arch(elf)
+                    rpath = [Path(p) for p in get_rpath(elf)
+                                     if p and '$ORIGIN' not in p]
+                    lib_dirs += rpath
+                    soname_cache[(path.name, arch)].append((resolved.parent, osabi))
+
+            except ELFError:
+                # Not an ELF file in the right format
+                pass
+
+
+def find_dependency(soname: str, soarch: str, soabi: str) -> Optional[Path]:
+    for lib, libabi in soname_cache[(soname, soarch)]:
+        if osabi_are_compatible(soabi, libabi):
+            return lib
+    return None
+
+
+@dataclass
+class Dependency:
+    file: Path              # The file that contains the dependency
+    name: Path              # The name of the dependency
+    found: bool = False     # Whether it was found somewhere
+
+
+def auto_patchelf_file(path: Path, runtime_deps: list[Path], append_rpaths: list[Path] = [], keep_libc: bool = False, extra_args: list[str] = []) -> list[Dependency]:
+    try:
+        with open_elf(path) as elf:
+
+            if is_static_executable(elf):
+                # No point patching these
+                print(f"skipping {path} because it is statically linked")
+                return []
+
+            if elf.num_segments() == 0:
+                # no segment (e.g. object file)
+                print(f"skipping {path} because it contains no segment")
+                return []
+
+            file_arch = get_arch(elf)
+            if interpreter_arch != file_arch:
+                # Our target architecture is different than this file's
+                # architecture, so skip it.
+                print(f"skipping {path} because its architecture ({file_arch})"
+                      f" differs from target ({interpreter_arch})")
+                return []
+
+            file_osabi = get_osabi(elf)
+            if not osabi_are_compatible(interpreter_osabi, file_osabi):
+                print(f"skipping {path} because its OS ABI ({file_osabi}) is"
+                      f" not compatible with target ({interpreter_osabi})")
+                return []
+
+            file_is_dynamic_executable = is_dynamic_executable(elf)
+
+            file_dependencies = get_dependencies(elf) + get_dlopen_dependencies(elf)
+
+    except ELFError:
+        return []
+
+    # these platforms are packaged in nixpkgs with ld.so in a separate derivation
+    # than libc.so and friends. keep_libc is mandatory.
+    keep_libc |= file_osabi in ('ELFOSABI_FREEBSD', 'ELFOSABI_OPENBSD')
+
+    rpath = []
+    if file_is_dynamic_executable:
+        print("setting interpreter of", path)
+        subprocess.run(
+                ["patchelf", "--set-interpreter", interpreter_path.as_posix(), path.as_posix()] + extra_args,
+                check=True)
+        rpath += runtime_deps
+
+    print("searching for dependencies of", path)
+    dependencies = []
+    # Be sure to get the output of all missing dependencies instead of
+    # failing at the first one, because it's more useful when working
+    # on a new package where you don't yet know the dependencies.
+    for dep in file_dependencies:
+        was_found = False
+        for candidate in dep:
+
+            # This loop determines which candidate for a given
+            # dependency can be found, and how. There may be multiple
+            # candidates for a dep because of '.note.dlopen'
+            # dependencies.
+            #
+            # 1. If a candidate is an absolute path, it is already a
+            #    valid dependency if that path exists, and nothing needs
+            #    to be done. It should be an error if that path does not exist.
+            # 2. If a candidate is found within libc, it should be dropped
+            #    and resolved automatically by the dynamic linker, unless
+            #    keep_libc is enabled.
+            # 3. If a candidate is found in our library dependencies, that
+            #    dependency should be added to rpath.
+            # 4. If all of the above fail, libc dependencies should still be
+            #    considered found. This is in contrast to step 2, because
+            #    enabling keep_libc should allow libc to be found in step 3
+            #    if possible to preserve its presence in rpath.
+            #
+            # These conditions are checked in this order, because #2
+            # and #3 may both be true. In that case, we still want to
+            # add the dependency to rpath, as the original binary
+            # presumably had it and this should be preserved.
+
+            is_libc = (libc_lib / candidate).is_file()
+
+            if candidate.is_absolute() and candidate.is_file():
+                was_found = True
+                break
+            elif is_libc and not keep_libc:
+                was_found = True
+                break
+            elif found_dependency := find_dependency(candidate.name, file_arch, file_osabi):
+                rpath.append(found_dependency)
+                dependencies.append(Dependency(path, candidate, found=True))
+                print(f"    {candidate} -> found: {found_dependency}")
+                was_found = True
+                break
+            elif is_libc and keep_libc:
+                was_found = True
+                break
+
+        if not was_found:
+            dep_name = dep[0] if len(dep) == 1 else f"any({', '.join(map(str, dep))})"
+            dependencies.append(Dependency(path, dep_name, found=False))
+            print(f"    {dep_name} -> not found!")
+
+    rpath.extend(append_rpaths)
+
+    # Dedup the rpath
+    rpath_str = ":".join(dict.fromkeys(map(Path.as_posix, rpath)))
+
+    if rpath:
+        print("setting RPATH to:", rpath_str)
+        subprocess.run(
+                ["patchelf", "--set-rpath", rpath_str, path.as_posix()] + extra_args,
+                check=True)
+
+    return dependencies
+
+
+def auto_patchelf(
+        paths_to_patch: list[Path],
+        lib_dirs: list[Path],
+        runtime_deps: list[Path],
+        recursive: bool = True,
+        ignore_missing: list[str] = [],
+        append_rpaths: list[Path] = [],
+        keep_libc: bool = False,
+        add_existing: bool = True,
+        extra_args: list[str] = []) -> None:
+
+    if not paths_to_patch:
+        sys.exit("No paths to patch, stopping.")
+
+    # Add all shared objects of the current output path to the cache,
+    # before lib_dirs, so that they are chosen first in find_dependency.
+    if add_existing:
+        populate_cache(paths_to_patch, recursive)
+
+    populate_cache(lib_dirs)
+
+    dependencies = []
+    for path in chain.from_iterable(glob(p, '*', recursive) for p in paths_to_patch):
+        if not path.is_symlink() and path.is_file():
+            dependencies += auto_patchelf_file(path, runtime_deps, append_rpaths, keep_libc, extra_args)
+
+    missing = [dep for dep in dependencies if not dep.found]
+
+    # Print a summary of the missing dependencies at the end
+    print(f"auto-patchelf: {len(missing)} dependencies could not be satisfied")
+    failure = False
+    for dep in missing:
+        for pattern in ignore_missing:
+            if fnmatch(dep.name.name, pattern):
+                print(f"warn: auto-patchelf ignoring missing {dep.name} wanted by {dep.file}")
+                break
+        else:
+            print(f"error: auto-patchelf could not satisfy dependency {dep.name} wanted by {dep.file}")
+            failure = True
+
+    if failure:
+        sys.exit('auto-patchelf failed to find all the required dependencies.\n'
+                 'Add the missing dependencies to --libs or use '
+                 '`--ignore-missing="foo.so.1 bar.so etc.so"`.')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="auto-patchelf",
+        description='auto-patchelf tries as hard as possible to patch the'
+                    ' provided binary files by looking for compatible'
+                    ' libraries in the provided paths.')
+    parser.add_argument(
+        "--ignore-missing",
+        nargs="*",
+        type=str,
+        default=[],
+        help="Do not fail when some dependencies are not found."
+    )
+    parser.add_argument(
+        "--no-recurse",
+        dest="recursive",
+        action="store_false",
+        help="Disable the recursive traversal of paths to patch."
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        required=True,
+        help="Paths whose content needs to be patched."
+             " Single files and directories are accepted."
+             " Directories are traversed recursively by default."
+    )
+    parser.add_argument(
+        "--libs",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Paths where libraries are searched for."
+             " Single files and directories are accepted."
+             " Directories are not searched recursively."
+    )
+    parser.add_argument(
+        "--runtime-dependencies",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Paths to prepend to the runtime path of executable binaries."
+             " Subject to deduplication, which may imply some reordering."
+    )
+    parser.add_argument(
+        "--append-rpaths",
+        nargs="*",
+        type=Path,
+        default=[],
+        help="Paths to append to all runtime paths unconditionally",
+    )
+    parser.add_argument(
+        "--keep-libc",
+        dest="keep_libc",
+        action="store_true",
+        help="Attempt to search for and relink libc dependencies.",
+    )
+    parser.add_argument(
+        "--ignore-existing",
+        dest="add_existing",
+        action="store_false",
+        help="Do not add the existing rpaths of the patched files to the list of directories to search for dependencies.",
+    )
+    parser.add_argument(
+        "--extra-args",
+        # Undocumented Python argparse feature: consume all remaining arguments
+        # as values for this one. This means this argument should always be passed
+        # last.
+        nargs="...",
+        type=str,
+        default=[],
+        help="Extra arguments to pass to patchelf. This argument should always come last.",
+    )
+
+    print("automatically fixing dependencies for ELF files")
+    args = parser.parse_args()
+    pprint.pprint(vars(args))
+
+    auto_patchelf(
+        args.paths,
+        args.libs,
+        args.runtime_dependencies,
+        args.recursive,
+        args.ignore_missing,
+        append_rpaths=args.append_rpaths,
+        keep_libc=args.keep_libc,
+        add_existing=args.add_existing,
+        extra_args=args.extra_args)
+
+
+interpreter_path: Path  = None # type: ignore
+interpreter_osabi: str  = None # type: ignore
+interpreter_arch: str   = None # type: ignore
+libc_lib: Path          = None # type: ignore
+
+def detect_system_paths():
+    """Detect interpreter and libc paths for non-Nix systems"""
+    # Try common interpreter paths
+    common_interpreters = [
+        Path("/lib64/ld-linux-x86-64.so.2"),
+        Path("/lib/ld-linux-x86-64.so.2"),
+        Path("/lib64/ld-linux-aarch64.so.1"),
+        Path("/lib/ld-linux-aarch64.so.1"),
+    ]
+
+    interp = None
+    for candidate in common_interpreters:
+        if candidate.exists():
+            interp = candidate
+            break
+
+    if not interp:
+        sys.exit("Could not find system dynamic linker")
+
+    # Try common libc paths
+    common_libc_dirs = [
+        Path("/lib/x86_64-linux-gnu"),
+        Path("/lib64"),
+        Path("/usr/lib/x86_64-linux-gnu"),
+        Path("/usr/lib64"),
+        Path("/lib"),
+        Path("/usr/lib"),
+    ]
+
+    libc_dir = None
+    for candidate in common_libc_dirs:
+        if candidate.exists() and (candidate / "libc.so.6").exists():
+            libc_dir = candidate
+            break
+
+    if not libc_dir:
+        sys.exit("Could not find system libc")
+
+    return interp, libc_dir
+
+if __name__ == "__main__":
+    # Try Nix paths first
+    nix_bintools = os.environ.get('NIX_BINTOOLS', DEFAULT_BINTOOLS)
+    if nix_bintools and nix_bintools != DEFAULT_BINTOOLS:
+        nix_support = Path(nix_bintools) / 'nix-support'
+        try:
+            interpreter_path = Path((nix_support / 'dynamic-linker').read_text().strip())
+            libc_lib = Path((nix_support / 'orig-libc').read_text().strip()) / 'lib'
+        except (FileNotFoundError, OSError):
+            print("Nix paths not found, falling back to system paths")
+            interpreter_path, libc_lib = detect_system_paths()
+    else:
+        # Non-Nix system
+        interpreter_path, libc_lib = detect_system_paths()
+
+    with open_elf(interpreter_path) as interpreter:
+        interpreter_osabi = get_osabi(interpreter)
+        interpreter_arch = get_arch(interpreter)
+
+    if interpreter_arch and interpreter_osabi and interpreter_path and libc_lib:
+        main()
+    else:
+        sys.exit("Failed to parse dynamic linker (ld) properties.")

--- a/scripts/autopatch-ecc-py.sh
+++ b/scripts/autopatch-ecc-py.sh
@@ -127,7 +127,7 @@ done
 mapfile -t ecc_py_dst < <(find "$ECC_PY_DST" -maxdepth 1 -type f -name "ecc_py*.so" | sort)
 
 echo "[bundle] running auto-patchelf"
-auto-patchelf --no-recurse --ignore-missing --paths "${ecc_py_dst[@]}" "$ECC_LIB_DST" --libs "${search_paths[@]}" --runtime-dependencies --append-rpaths --extra-args
+auto-patchelf --no-recurse --ignore-missing --paths "${ecc_py_dst[@]}" "$ECC_LIB_DST" --libs "${search_paths[@]}"
 
 echo "[bundle] setting RUNPATH"
 for f in "${ecc_py_dst[@]}"; do patchelf --set-rpath '$ORIGIN:$ORIGIN/lib' "$f"; done

--- a/scripts/autopatch-ecc-py.sh
+++ b/scripts/autopatch-ecc-py.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Add local auto-patchelf to PATH if not already available
+if ! command -v auto-patchelf >/dev/null 2>&1; then
+    export PATH="${SCRIPT_DIR}/auto-patchelf:${PATH}"
+fi
+
+ECC_PY_DST="${PROJECT_ROOT}/chipcompiler/tools/ecc/bin"
+ECC_LIB_DST="${ECC_PY_DST}/lib"
+
+ecc_py_inputs=()
+runtime_lib_inputs=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --ecc-py <path>           Path to ecc_py*.so file or directory containing it
+  --runtime-lib-path <path> Additional directory to search for .so dependencies (repeatable)
+                            Use this when ecc_py.so and build/ are in different locations
+  -h, --help                Show this help message
+
+Examples:
+  # Auto-detect from default location
+  $0
+
+  # Specify ecc_py.so location
+  $0 --ecc-py /path/to/bin/ecc_py.so
+
+  # Separated ecc_py.so and build directory
+  $0 --ecc-py /install/bin/ecc_py.so --runtime-lib-path /source/build
+
+  # Multiple runtime library paths
+  $0 --runtime-lib-path /path/to/build --runtime-lib-path /path/to/extra/libs
+EOF
+            exit 0
+            ;;
+        --ecc-py) ecc_py_inputs+=("$2"); shift 2 ;;
+        --runtime-lib-path) runtime_lib_inputs+=("$2"); shift 2 ;;
+        *) echo "ERROR: unsupported argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+die() { echo "ERROR: $1" >&2; exit 1; }
+find_so() { find "$1" -maxdepth "${2:-999}" -type f \( -name "*.so" -o -name "*.so.*" \) 2>/dev/null | sort; }
+
+for cmd in auto-patchelf patchelf readelf ldd sha256sum; do
+    command -v "$cmd" >/dev/null || die "required command not found: $cmd"
+done
+
+# Collect ecc_py source files
+ecc_py_src=()
+[[ ${#ecc_py_inputs[@]} -eq 0 ]] && ecc_py_inputs=("${PROJECT_ROOT}/chipcompiler/thirdparty/ecc-tools/bin")
+for input in "${ecc_py_inputs[@]}"; do
+    if [[ -d "$input" ]]; then
+        mapfile -t -O ${#ecc_py_src[@]} ecc_py_src < <(find "$input" -maxdepth 1 -type f -name "ecc_py*.so" | sort)
+    elif [[ -f "$input" ]]; then
+        [[ "$(basename "$input")" == ecc_py*.so ]] || die "--ecc-py file must match ecc_py*.so: $input"
+        ecc_py_src+=("$(realpath "$input")")
+    else
+        die "--ecc-py path does not exist: $input"
+    fi
+done
+[[ ${#ecc_py_src[@]} -gt 0 ]] || die "no ecc_py shared object found"
+
+# Collect runtime library candidates
+runtime_candidates=()
+for f in "${ecc_py_src[@]}"; do
+    dir="$(dirname "$f")"
+    [[ "$(basename "$dir")" == "bin" ]] || continue
+    root="$(dirname "$dir")"
+    for d in "$root/build" "$root/src/third_party/onnxruntime"; do
+        [[ -d "$d" ]] && mapfile -t -O ${#runtime_candidates[@]} runtime_candidates < <(find_so "$d")
+    done
+done
+for input in "${runtime_lib_inputs[@]}"; do
+    if [[ -d "$input" ]]; then
+        mapfile -t -O ${#runtime_candidates[@]} runtime_candidates < <(find_so "$input")
+    elif [[ -f "$input" ]]; then
+        runtime_candidates+=("$(realpath "$input")")
+    else
+        die "--runtime-lib-path does not exist: $input"
+    fi
+done
+[[ ${#runtime_candidates[@]} -gt 0 ]] || die "no runtime .so libraries found"
+
+mkdir -p "$ECC_PY_DST" "$ECC_LIB_DST"
+
+echo "[bundle] copying ecc_py modules"
+cp -f "${ecc_py_src[@]}" "$ECC_PY_DST/"
+
+echo "[bundle] collecting runtime libraries"
+declare -A seen=()
+copied=0
+for src in "${runtime_candidates[@]}"; do
+    base="$(basename "$src")"
+    [[ "$base" != ecc_py*.so ]] || continue
+    hash="$(sha256sum "$src" | cut -d' ' -f1)"
+    if [[ -v seen["$base"] ]]; then
+        [[ "${seen["$base"]}" == "$hash" ]] || die "library conflict: $base"
+        continue
+    fi
+    cp -f "$src" "$ECC_LIB_DST/"
+    seen["$base"]="$hash"
+    copied=$((copied + 1))
+done
+
+# Build search paths for auto-patchelf
+search_paths=("$ECC_LIB_DST")
+for f in "${ecc_py_src[@]}"; do
+    dir="$(dirname "$f")"
+    [[ "$(basename "$dir")" == "bin" ]] || continue
+    lib="$(dirname "$dir")/lib"
+    [[ -d "$lib" ]] && search_paths+=("$lib")
+done
+for d in /lib /lib64 /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64 /lib/x86_64-linux-gnu /usr/lib/x86_64-linux-gnu; do
+    [[ -d "$d" ]] && search_paths+=("$d")
+done
+
+mapfile -t ecc_py_dst < <(find "$ECC_PY_DST" -maxdepth 1 -type f -name "ecc_py*.so" | sort)
+
+echo "[bundle] running auto-patchelf"
+auto-patchelf --no-recurse --ignore-missing --paths "${ecc_py_dst[@]}" "$ECC_LIB_DST" --libs "${search_paths[@]}" --runtime-dependencies --append-rpaths --extra-args
+
+echo "[bundle] setting RUNPATH"
+for f in "${ecc_py_dst[@]}"; do patchelf --set-rpath '$ORIGIN:$ORIGIN/lib' "$f"; done
+for f in $(find_so "$ECC_LIB_DST" 1); do
+    readelf -h "$f" &>/dev/null && patchelf --set-rpath '$ORIGIN' "$f" || echo "WARN: skip non-ELF: $f" >&2
+done
+
+echo "[bundle] verifying dependencies"
+for f in "${ecc_py_dst[@]}"; do
+    ldd "$f" | grep -q "not found" && { echo "ERROR: unresolved deps in $f" >&2; ldd "$f" >&2; exit 1; }
+done
+
+echo "[bundle] done: ${#ecc_py_dst[@]} ecc_py files, $copied runtime libs in $ECC_LIB_DST"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,6 +58,10 @@ fi
 build_ecc_py
 echo
 
+echo "=== Step 4.5: Patching ECC runtime dependencies ==="
+bash "$SCRIPT_DIR/autopatch-ecc-py.sh"
+echo
+
 echo "=== Step 5: Building API Server ==="
 cd "$PROJECT_ROOT"
 rm -rf build dist __pycache__


### PR DESCRIPTION
We want to collect all of `ecc_py`’s dynamic dependencies, put them all under `tools/ecc/bin/lib`, and run `patchelf` accordingly. That way, `ecc_py` shouldn’t run into missing shared libraries at runtime.

We copied `auto-patchelf` from [nixpkgs](https://github.com/NixOS/nixpkgs), so we added a COPYING file in the folder for clarity.

https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py