### PR TITLE
feat(chipcompiler): add cli user interface

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -28,9 +28,9 @@ ECOS Chip Compiler 是一个**开源芯片设计自动化解决方案**，集成
   <img alt="ECOS Chip Compiler 概览" src="docs/asset/overview-light.png">
 </picture>
 
-**两种使用方式：**
+**使用方式：**
 - **桌面 GUI (ECOS Studio)** - 可视化设计工具，用于交互式芯片设计
-- **Python API** - 编程式流程控制，用于自动化
+- **CLI (`cli`)** - 命令行流程执行
 
 
 ## 快速开始
@@ -75,14 +75,23 @@ Nix 构建包含所有依赖。提供二进制缓存以加速构建。
 
 ### 开发环境
 
-开发或使用 Python API，请参阅 **[开发指南](docs/development.md)**。
+开发请参阅 **[开发指南](docs/development.md)**。
+
+### CLI 流程运行
+
+可以使用 `cli` 命令直接创建 workspace 并执行完整 RTL2GDS 流程。
+
+```bash
+cli --workspace ./ws --rtl ./rtl/top.v --design top --top top --clock clk --pdk-root /path/to/ics55
+cli --workspace ./ws --rtl ./rtl/filelist.f --design top --top top --clock clk --pdk-root /path/to/ics55 --freq 200
+```
 
 ## 功能特性
 
 - **完整 RTL-to-GDS 流程** - 综合、布局、布线、时序优化
 - **可视化设计界面** - 基于 PixiJS 的版图编辑器，WebGL 渲染
 - **开源 EDA 集成** - Yosys（综合）、ECC-Tools（布局布线）、KLayout（查看器）
-- **Python API** - 可脚本化自动化，支持批处理
+- **CLI 自动化** - 可脚本化的命令行流程执行
 - **REST API** - FastAPI 后端，支持外部工具集成
 - **便携部署** - AppImage、Nix 或独立构建
 
@@ -99,7 +108,7 @@ Nix 构建包含所有依赖。提供二进制缓存以加速构建。
 - [文档索引](docs/index.md) - 完整导航
 - [架构](docs/architecture.md) - 系统设计和模式
 - [开发指南](docs/development.md) - 配置和工作流
-- [API 指南](docs/api-guide.md) - Python API 参考
+- [API 指南](docs/api-guide.md) - REST API 参考
 - [GUI 指南](docs/gui-develop-guide.md) - GUI 开发
 - [示例](docs/examples/) - 使用示例
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ ECOS Chip Compiler is an **open-source chip design automation solution** that in
   <img alt="ECOS Chip Compiler Overview" src="docs/asset/overview-light.png">
 </picture>
 
-**Two ways to use:**
+**How to use:**
 - **Desktop GUI (ECOS Studio)** - Visual design tool for interactive chip design
-- **Python API** - Programmatic flow control for automation
+- **CLI (`cli`)** - Command-line flow execution
 
 
 ## Quick Start
@@ -75,14 +75,23 @@ For detailed usage, see **[User Guide](docs/user-guide.md)**.
 
 ### Development Environment
 
-For active development or Python API usage, see **[Development Guide](docs/development.md)**.
+For active development, see **[Development Guide](docs/development.md)**.
+
+### CLI Flow Runner
+
+Use `cli` to create a workspace and run the full RTL2GDS flow directly.
+
+```bash
+cli --workspace ./ws --rtl ./rtl/top.v --design top --top top --clock clk --pdk-root /path/to/ics55
+cli --workspace ./ws --rtl ./rtl/filelist.f --design top --top top --clock clk --pdk-root /path/to/ics55 --freq 200
+```
 
 ## Features
 
 - **Complete RTL-to-GDS Flow** - Synthesis, placement, routing, timing optimization
 - **Visual Design Interface** - PixiJS-based layout editor with WebGL rendering
 - **Open-Source EDA Integration** - Yosys (synthesis), ECC-Tools (P&R), KLayout (viewer)
-- **Python API** - Scriptable automation for batch processing
+- **CLI Automation** - Scriptable flow execution from command line
 - **REST API** - FastAPI backend for external tool integration
 - **Portable Deployment** - AppImage, Nix, or standalone builds
 
@@ -100,7 +109,7 @@ For active development or Python API usage, see **[Development Guide](docs/devel
 - [Documentation Index](docs/index.md) - Complete navigation
 - [Architecture](docs/architecture.md) - System design and patterns
 - [Development Guide](docs/development.md) - Setup and workflows
-- [API Guide](docs/api-guide.md) - Python API reference
+- [API Guide](docs/api-guide.md) - REST API reference
 - [GUI Guide](docs/gui-develop-guide.md) - GUI development
 - [Examples](docs/examples/) - Usage examples
 

--- a/chipcompiler/cli/__init__.py
+++ b/chipcompiler/cli/__init__.py
@@ -1,0 +1,2 @@
+"""Command-line interface for ChipCompiler flow execution."""
+

--- a/chipcompiler/cli/main.py
+++ b/chipcompiler/cli/main.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+from collections.abc import Sequence
+
+from chipcompiler.data import create_workspace, get_parameters, log_workspace
+from chipcompiler.engine import EngineFlow
+from chipcompiler.rtl2gds import build_rtl2gds_flow
+from chipcompiler.utility.filelist import parse_filelist, validate_filelist
+
+FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
+RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cli",
+        description="Create ChipCompiler workspace and run RTL2GDS flow",
+    )
+    parser.add_argument("--workspace", required=True, help="Workspace directory path")
+    parser.add_argument("--rtl", required=True, help="RTL file or filelist path")
+    parser.add_argument("--design", required=True, help="Design name")
+    parser.add_argument("--top", required=True, help="Top module name")
+    parser.add_argument("--clock", required=True, help="Clock port name")
+    parser.add_argument("--pdk-root", required=True, help="ICS55 PDK root directory")
+    parser.add_argument(
+        "--freq",
+        type=float,
+        default=100.0,
+        help="Clock frequency in MHz (default: 100)",
+    )
+    return parser
+
+
+def resolve_rtl_input(rtl_path: str) -> tuple[str, str, str]:
+    normalized_path = os.path.abspath(os.path.expanduser(rtl_path))
+    suffix = os.path.splitext(normalized_path)[1].lower()
+
+    if suffix in FILELIST_SUFFIXES:
+        return ("filelist", "", normalized_path)
+
+    if suffix in RTL_SUFFIXES:
+        return ("rtl", normalized_path, "")
+
+    try:
+        parse_filelist(normalized_path)
+        _, missing_files = validate_filelist(normalized_path)
+        if len(missing_files) == 0:
+            return ("filelist", "", normalized_path)
+    except Exception:
+        pass
+
+    return ("rtl", normalized_path, "")
+
+
+def build_parameters(args: argparse.Namespace) -> dict:
+    parameters = get_parameters("ics55")
+    parameters.data.update(
+        {
+            "PDK": "ics55",
+            "Design": args.design,
+            "Top module": args.top,
+            "Clock": args.clock,
+            "Frequency max [MHz]": args.freq,
+        }
+    )
+    return parameters.data
+
+
+def _validate_args(args: argparse.Namespace) -> str | None:
+    if not str(args.workspace).strip():
+        return "--workspace must not be empty"
+    if not str(args.design).strip():
+        return "--design must not be empty"
+    if not str(args.top).strip():
+        return "--top must not be empty"
+    if not str(args.clock).strip():
+        return "--clock must not be empty"
+
+    rtl_path = os.path.abspath(os.path.expanduser(args.rtl))
+    if not os.path.exists(rtl_path):
+        return f"--rtl path does not exist: {rtl_path}"
+    if not os.path.isfile(rtl_path):
+        return f"--rtl must point to a file: {rtl_path}"
+
+    pdk_root = os.path.abspath(os.path.expanduser(args.pdk_root))
+    if not os.path.exists(pdk_root):
+        return f"--pdk-root path does not exist: {pdk_root}"
+    if not os.path.isdir(pdk_root):
+        return f"--pdk-root must point to a directory: {pdk_root}"
+
+    if args.freq <= 0:
+        return "--freq must be greater than 0"
+
+    return None
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    validation_error = _validate_args(args)
+    if validation_error:
+        print(f"Error: {validation_error}", file=sys.stderr)
+        return 1
+
+    try:
+        _, origin_verilog, input_filelist = resolve_rtl_input(args.rtl)
+        parameters = build_parameters(args)
+
+        workspace = create_workspace(
+            directory=args.workspace,
+            origin_def="",
+            origin_verilog=origin_verilog,
+            pdk="ics55",
+            parameters=parameters,
+            input_filelist=input_filelist,
+            pdk_root=args.pdk_root,
+        )
+        if workspace is None:
+            print("Error: failed to create workspace", file=sys.stderr)
+            return 1
+
+        engine_flow = EngineFlow(workspace=workspace)
+        if not engine_flow.has_init():
+            for step, tool, state in build_rtl2gds_flow():
+                engine_flow.add_step(step=step, tool=tool, state=state)
+
+        engine_flow.create_step_workspaces()
+        log_workspace(workspace=workspace)
+
+        if not engine_flow.run_steps():
+            print("Error: flow execution failed", file=sys.stderr)
+            return 1
+
+        return 0
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,116 +1,64 @@
 # API Guide
 
-This document explains how to use ECOS Chip Compiler's Python API.
+This document explains ChipCompiler's REST API.
 
-## Python API
+## Server Startup
 
-### Basic Usage
+Start the backend server:
 
-```python
-from chipcompiler.engine import EngineFlow
-from chipcompiler.data import create_workspace, get_parameters, get_pdk
-
-# Create a workspace (using built-in PDK template)
-pdk = get_pdk("ics55", pdk_root="/path/to/icsprout55-pdk")
-parameters = get_parameters("ics55")
-workspace = create_workspace(
-    directory="workspace/my_design",
-    pdk=pdk,
-    parameters=parameters,
-    origin_def="",
-    origin_verilog="path/to/design.v",
-)
-
-# Initialize the flow engine
-flow = EngineFlow(workspace)
-flow.build_default_steps()  # Build default flow steps
-flow.create_step_workspaces()  # Create step workspaces
-
-# Run the full flow
-flow.run_steps()
-
-# Check flow status
-for step in flow.workspace_steps:
-    print(f"{step.name}: {step.state}")
+```bash
+chipcompiler --host 127.0.0.1 --port 8765
 ```
 
-### Custom Flow
+Swagger UI:
+- `http://127.0.0.1:8765/docs`
 
-```python
-from chipcompiler.data import StepEnum
+Health checks:
+- `GET /health`
+- `GET /api/workspace/health`
+- `GET /sse/health`
 
-flow = EngineFlow(workspace)
+## Request/Response Schema
 
-# Manually add steps
-flow.add_step(StepEnum.SYNTHESIS, "yosys")
-flow.add_step(StepEnum.PLACEMENT, "ecc")
-flow.add_step(StepEnum.CTS, "ecc")
-flow.add_step(StepEnum.ROUTING, "ecc")
+Most workspace APIs use this envelope:
 
-flow.create_step_workspaces()
-flow.run_steps()
+```json
+{
+  "cmd": "create_workspace",
+  "data": {}
+}
 ```
 
-### Incremental Execution
+Response envelope:
 
-```python
-# First run
-flow.run_steps()
-
-# After fixing errors, rerun only failed steps
-flow = EngineFlow.load("workspace/my_design")
-flow.run_steps()  # Automatically skip successful steps
+```json
+{
+  "cmd": "create_workspace",
+  "response": "success",
+  "data": {},
+  "message": []
+}
 ```
 
-### Single-Step Execution
+## Workspace Endpoints
 
-```python
-# Run a specific step
-flow.run_step(flow.workspace_steps[0])
+Base path: `/api/workspace`
 
-# Check status
-state = flow.check_state("SYNTHESIS")
-print(state)  # StateEnum.Success / Incomplete
-```
+- `POST /create_workspace`
+- `POST /set_pdk_root`
+- `POST /load_workspace`
+- `POST /delete_workspace`
+- `POST /rtl2gds`
+- `POST /run_step`
+- `POST /get_info`
+- `POST /get_home_page`
 
-### State Management
+## SSE Endpoints
 
-```python
-# Clear all states (start over)
-flow.clear_states()
+Base path: `/sse`
 
-# Set a specific step state
-flow.set_state("SYNTHESIS", StateEnum.Unstart)
-
-# Save flow configuration
-flow.save()
-```
-
-### Use a Predefined Flow
-
-```python
-from chipcompiler.rtl2gds import build_rtl2gds_flow
-
-# Get the full RTL-to-GDS flow
-steps = build_rtl2gds_flow()
-
-flow = EngineFlow(workspace)
-for step_enum, tool, state in steps:
-    flow.add_step(step_enum, tool)
-
-flow.create_step_workspaces()
-flow.run_steps()
-```
-
-### Database Engine
-
-```python
-# Initialize the database engine (uses ECC-Tools engine internally)
-db_engine = flow.init_db_engine()
-
-# Use the ECC-Tools Python bindings for post-flow analysis
-# db_engine provides access to circuit data for analysis and optimization
-```
+- `GET /stream/{workspace_id}` for real-time flow notifications
+- `GET /health`
 
 ## Related Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,5 +202,5 @@ Usage: `parameters = get_parameters("ics55", "gcd")`
 ## Related Documentation
 
 - [Development Guide](development.md) - Setup, workflows, adding tools
-- [API Guide](api-guide.md) - Python API usage
+- [API Guide](api-guide.md) - REST API usage
 - [GUI Development Guide](gui-develop-guide.md) - GUI development

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,9 +28,9 @@ source .venv/bin/activate                         # Activate venv
 
 Skip OSS CAD Suite if yosys installed: `ENABLE_OSS_CAD_SUITE=false ./build.sh`
 
-## Python API Usage
+## CLI Usage
 
-For programmatic automation and scripting, install ChipCompiler:
+For command-line automation and scripting, install ChipCompiler:
 
 ```bash
 # For end users: Install via Nix
@@ -46,28 +46,12 @@ source .venv/bin/activate
 ```
 
 **Example usage:**
-```python
-from chipcompiler.data import create_workspace, get_pdk, get_design_parameters
-from chipcompiler.engine import EngineFlow
-
-# Create workspace with PDK and parameters
-pdk = get_pdk("ics55")
-parameters = get_design_parameters("ics55", "gcd")
-workspace = create_workspace(
-    directory="./gcd_workspace",
-    origin_verilog="./design.v",
-    pdk=pdk,
-    parameters=parameters
-)
-
-# Run RTL-to-GDS flow
-flow = EngineFlow(workspace=workspace)
-flow.build_default_steps()
-flow.create_step_workspaces()
-flow.run_steps()
+```bash
+cli --workspace ./ws --rtl ./rtl/top.v --design top --top top --clock clk --pdk-root /path/to/ics55
+cli --workspace ./ws --rtl ./rtl/filelist.f --design top --top top --clock clk --pdk-root /path/to/ics55 --freq 200
 ```
 
-Full API reference: **[API Guide](api-guide.md)** | Examples: **[examples/gcd](examples/gcd/README.md)**
+REST API reference: **[API Guide](api-guide.md)** | Examples: **[examples/gcd](examples/gcd/README.md)**
 
 ### Yosys Runtime Resolution
 
@@ -260,5 +244,5 @@ Output in `dist/`.
 ## Related Documentation
 
 - [Architecture](architecture.md) - System design and patterns
-- [API Guide](api-guide.md) - Python API usage
+- [API Guide](api-guide.md) - REST API usage
 - [GUI Development Guide](gui-develop-guide.md) - GUI development

--- a/docs/examples/gcd/README.cn.md
+++ b/docs/examples/gcd/README.cn.md
@@ -1,4 +1,4 @@
-# 使用 Python API 的 GCD 示例
+# GCD 流程示例
 
 ## 安装
 

--- a/docs/examples/gcd/README.md
+++ b/docs/examples/gcd/README.md
@@ -1,4 +1,4 @@
-# GCD Examples with Python API
+# GCD Flow Examples
 
 ## Installation
 

--- a/docs/gui-develop-guide.md
+++ b/docs/gui-develop-guide.md
@@ -147,4 +147,4 @@ Output: `src-tauri/target/release/bundle/appimage/`
 
 - [Architecture](architecture.md) - System design and patterns
 - [Development Guide](development.md) - Complete development setup
-- [API Guide](api-guide.md) - Python API reference
+- [API Guide](api-guide.md) - REST API reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,9 @@ Welcome to the ChipCompiler documentation center.
   - Adding new EDA tools
   - Debugging and testing
 
-- **[API Guide](api-guide.md)** - Python API and REST API documentation
-  - Python API examples
+- **[API Guide](api-guide.md)** - REST API documentation
   - REST API endpoints
-  - Client examples
+  - API usage examples
   - Custom endpoint development
 
 - **[GUI Guide](gui-develop-guide.md)** - Desktop GUI development documentation
@@ -45,7 +44,7 @@ ChipCompiler supports various EDA file formats. Technical specifications for par
 - **Get started with ChipCompiler** → See main [README](../README.md)
 - **Understand the architecture** → [Architecture](architecture.md)
 - **Set up development environment** → [Development Guide](development.md)
-- **Use Python API** → [API Guide - Python API](api-guide.md#python-api)
+- **Use REST API** → [API Guide](api-guide.md)
 - **Develop GUI** → [GUI Guide](gui-develop-guide.md)
 - **Add new tools** → [Development Guide - Adding EDA Tools](development.md#adding-new-eda-tools)
 - **Debug workflows** → [Development Guide - Debugging](development.md#debugging-workflow-steps)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -456,7 +456,7 @@ View design metrics and analysis charts generated during the flow:
 ## Next Steps
 
 - **Explore Examples** - Check `docs/examples/` for sample projects
-- **Read API Guide** - Learn to automate flows with Python API
+- **Read API Guide** - Learn backend integration with REST API
 - **Join Community** - Participate in discussions and contribute
 
 For more information, see:

--- a/flake.nix
+++ b/flake.nix
@@ -57,9 +57,10 @@
           };
           packages = {
             inherit (pkgs)
+              ecos-studio
               ecc-tools
               chipcompiler
-              ecos-studio
+              cli
               ;
           };
         };

--- a/nix/cli/default.nix
+++ b/nix/cli/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  python3Packages,
+  ecc-tools,
+  yosysWithSlang,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonPackage {
+  pname = "chipcompiler-cli";
+  version = "0.1.0";
+  pyproject = true;
+
+  src =
+    with lib.fileset;
+    toSource {
+      root = ./../..;
+      fileset = unions [
+        ./../../README.md
+        ./../../uv.lock
+        ./../../pyproject.toml
+        ./../../chipcompiler
+      ];
+    };
+
+  postPatch = ''
+    mkdir -p thirdparty/ecc-tools/bin
+    install -m 755 ${ecc-tools}/bin/*.cpython-*.so thirdparty/ecc-tools/bin/
+    install -m 755 ${ecc-tools}/bin/*.cpython-*.so chipcompiler/tools/ecc/bin/
+  '';
+
+  postInstall = ''
+    site_packages="$out/${python3Packages.python.sitePackages}"
+
+    for rel in \
+      chipcompiler/tools/ecc/configs \
+      chipcompiler/tools/yosys/configs \
+      chipcompiler/tools/yosys/scripts
+    do
+      if [ -d "$rel" ]; then
+        install -d "$site_packages/$rel"
+        cp -r "$rel"/. "$site_packages/$rel/"
+      fi
+    done
+
+    # This package should expose only the dedicated `cli` entrypoint.
+    rm -f "$out/bin/chipcompiler"
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/cli" \
+      --set CHIPCOMPILER_OSS_CAD_DIR "${yosysWithSlang}" \
+      --prefix PATH : "${yosysWithSlang}/bin"
+  '';
+
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    fastapi
+    klayout
+    matplotlib
+    numpy
+    pandas
+    pydantic
+    pyjson5
+    pyyaml
+    scipy
+    tqdm
+    uvicorn
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Skip tests for now (they require full environment setup)
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "chipcompiler"
+    "chipcompiler.server"
+    "chipcompiler.engine"
+    "chipcompiler.tools"
+    "chipcompiler.cli"
+  ];
+
+  meta = {
+    description = "CLI interface for ECOS chip design automation solution";
+    homepage = "https://github.com/openecos-projects/ecc";
+    license = lib.licenses.mulan-psl2;
+    platforms = lib.platforms.linux;
+    maintainers = [ ];
+    mainProgram = "cli";
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,5 +1,6 @@
 final: prev: {
   ecc-tools = prev.callPackage ./ecc-tools { };
   chipcompiler = prev.callPackage ./chipcompiler { };
+  cli = prev.callPackage ./cli { };
   ecos-studio = final.callPackage ./ecos-studio { };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "uvicorn>=0.27",
 ]
 scripts.chipcompiler = "chipcompiler.server.run_server:main"
+scripts.cli = "chipcompiler.cli.main:main"
 
 [dependency-groups]
 dev = [

--- a/test/cli/test_cli_main.py
+++ b/test/cli/test_cli_main.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+from types import SimpleNamespace
+
+import pytest
+
+from chipcompiler.cli import main as cli_main
+
+
+class DummyFlow:
+    has_init_value = False
+    run_steps_value = True
+    instances = []
+
+    def __init__(self, workspace):
+        self.workspace = workspace
+        self.added_steps = []
+        self.create_called = False
+        self.run_called = False
+        DummyFlow.instances.append(self)
+
+    def has_init(self):
+        return self.has_init_value
+
+    def add_step(self, step, tool, state):
+        self.added_steps.append((step, tool, state))
+
+    def create_step_workspaces(self):
+        self.create_called = True
+
+    def run_steps(self):
+        self.run_called = True
+        return self.run_steps_value
+
+
+def _common_args(workspace, rtl, pdk_root):
+    return [
+        "--workspace",
+        str(workspace),
+        "--rtl",
+        str(rtl),
+        "--design",
+        "top_design",
+        "--top",
+        "top",
+        "--clock",
+        "clk",
+        "--pdk-root",
+        str(pdk_root),
+    ]
+
+
+def _install_cli_mocks(monkeypatch):
+    capture = {
+        "create_kwargs": None,
+        "log_workspace_calls": 0,
+    }
+    workspace_obj = SimpleNamespace(name="workspace")
+
+    DummyFlow.instances = []
+    DummyFlow.has_init_value = False
+    DummyFlow.run_steps_value = True
+
+    def fake_create_workspace(**kwargs):
+        capture["create_kwargs"] = kwargs
+        return workspace_obj
+
+    def fake_log_workspace(workspace):
+        assert workspace is workspace_obj
+        capture["log_workspace_calls"] += 1
+
+    monkeypatch.setattr(cli_main, "create_workspace", fake_create_workspace)
+    monkeypatch.setattr(cli_main, "EngineFlow", DummyFlow)
+    monkeypatch.setattr(cli_main, "build_rtl2gds_flow", lambda: [("Synthesis", "yosys", "Unstart")])
+    monkeypatch.setattr(cli_main, "log_workspace", fake_log_workspace)
+
+    return capture
+
+
+def test_cli_rtl_mode_calls_create_workspace_correctly(tmp_path, monkeypatch):
+    rtl = tmp_path / "top.v"
+    rtl.write_text("module top(input clk); endmodule\n")
+    pdk_root = tmp_path / "ics55"
+    pdk_root.mkdir()
+    workspace_dir = tmp_path / "ws"
+
+    capture = _install_cli_mocks(monkeypatch)
+    rc = cli_main.run(_common_args(workspace_dir, rtl, pdk_root))
+
+    assert rc == 0
+    assert capture["create_kwargs"]["origin_verilog"] == str(rtl.resolve())
+    assert capture["create_kwargs"]["input_filelist"] == ""
+    assert capture["create_kwargs"]["pdk"] == "ics55"
+    assert capture["create_kwargs"]["parameters"]["Design"] == "top_design"
+    assert capture["create_kwargs"]["parameters"]["Top module"] == "top"
+    assert capture["create_kwargs"]["parameters"]["Clock"] == "clk"
+    assert capture["create_kwargs"]["parameters"]["Frequency max [MHz]"] == 100.0
+    assert DummyFlow.instances[0].create_called is True
+    assert DummyFlow.instances[0].run_called is True
+    assert capture["log_workspace_calls"] == 1
+
+
+def test_cli_filelist_mode_calls_create_workspace_correctly(tmp_path, monkeypatch):
+    rtl_source = tmp_path / "a.v"
+    rtl_source.write_text("module a(); endmodule\n")
+    filelist = tmp_path / "design.f"
+    filelist.write_text("a.v\n")
+    pdk_root = tmp_path / "ics55"
+    pdk_root.mkdir()
+    workspace_dir = tmp_path / "ws"
+
+    capture = _install_cli_mocks(monkeypatch)
+    rc = cli_main.run(_common_args(workspace_dir, filelist, pdk_root))
+
+    assert rc == 0
+    assert capture["create_kwargs"]["origin_verilog"] == ""
+    assert capture["create_kwargs"]["input_filelist"] == str(filelist.resolve())
+
+
+def test_cli_unknown_suffix_fallback_to_filelist(tmp_path, monkeypatch):
+    rtl_source = tmp_path / "b.v"
+    rtl_source.write_text("module b(); endmodule\n")
+    filelist_like = tmp_path / "design.listing"
+    filelist_like.write_text("b.v\n")
+    pdk_root = tmp_path / "ics55"
+    pdk_root.mkdir()
+    workspace_dir = tmp_path / "ws"
+
+    capture = _install_cli_mocks(monkeypatch)
+    rc = cli_main.run(_common_args(workspace_dir, filelist_like, pdk_root))
+
+    assert rc == 0
+    assert capture["create_kwargs"]["origin_verilog"] == ""
+    assert capture["create_kwargs"]["input_filelist"] == str(filelist_like.resolve())
+
+
+def test_cli_requires_mandatory_arguments():
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main.run([])
+    assert exc_info.value.code == 2
+
+
+def test_cli_returns_nonzero_when_run_steps_failed(tmp_path, monkeypatch):
+    rtl = tmp_path / "top.v"
+    rtl.write_text("module top(input clk); endmodule\n")
+    pdk_root = tmp_path / "ics55"
+    pdk_root.mkdir()
+    workspace_dir = tmp_path / "ws"
+
+    _install_cli_mocks(monkeypatch)
+    DummyFlow.run_steps_value = False
+
+    rc = cli_main.run(_common_args(workspace_dir, rtl, pdk_root))
+    assert rc == 1
+


### PR DESCRIPTION
@0xharry 

This pull request introduces a new command-line interface (CLI) for ChipCompiler, enabling users to automate the RTL-to-GDS flow directly from the terminal.

- Added a new CLI entrypoint (`cli`) for flow execution, implemented in `chipcompiler/cli/main.py`, with argument parsing, workspace creation, flow execution, and error handling.
- Provided a CLI-specific package definition in `nix/cli/default.nix` and integrated it into the Nix flake and overlay, exposing the `cli` binary and ensuring proper dependencies and environment setup.
- Registered the CLI entrypoint in `pyproject.toml` and added a module docstring in `chipcompiler/cli/__init__.py`.
- Updated both English and Chinese docs

