### PR TITLE
feat(pdk): validate critical PDK paths early in get_pdk()

### DIFF
--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -2,7 +2,10 @@
 # -*- encoding: utf-8 -*-
 
 from dataclasses import dataclass, field
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class PDK:
@@ -29,7 +32,22 @@ class PDK:
     tie_low_cell : str = ""
     tie_low_port : str = ""
     dont_use : list = field(default_factory=list) # don't use cell list
-    
+
+    def validate(self) -> None:
+        """Check that critical PDK paths exist. Raises ValueError if not."""
+        errors = []
+        if self.root and not os.path.isdir(self.root):
+            errors.append(f"PDK root directory not found: {self.root}")
+        if not self.tech:
+            errors.append("PDK tech LEF is missing")
+        if not self.lefs:
+            errors.append("PDK has no LEF files")
+        if not self.libs:
+            errors.append("PDK has no liberty files")
+        if errors:
+            msg = "PDK validation failed:\n  " + "\n  ".join(errors)
+            logger.error(msg)
+            raise ValueError(msg)
 
 def get_pdk(pdk_name : str, pdk_root: str = "") -> PDK:
     """
@@ -37,9 +55,11 @@ def get_pdk(pdk_name : str, pdk_root: str = "") -> PDK:
     """
     pdk_name_normalized = (pdk_name or "").strip().lower()
     if pdk_name_normalized == "ics55":
-        return PDK_ICS55(pdk_root=pdk_root)
+        pdk = PDK_ICS55(pdk_root=pdk_root)
     else:
-        return PDK(name=pdk_name_normalized)
+        pdk = PDK(name=pdk_name_normalized)
+    pdk.validate()
+    return pdk
 
 def PDK_ICS55(pdk_root: str = "") -> PDK:
     current_dir = os.path.split(os.path.abspath(__file__))[0]

--- a/test/test_data_pdk.py
+++ b/test/test_data_pdk.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from chipcompiler.data.pdk import get_pdk
 
 
@@ -57,12 +59,9 @@ def test_get_pdk_uses_legacy_env_when_namespaced_missing(tmp_path, monkeypatch):
     assert pdk.root == str(legacy_root.resolve())
 
 
-def test_get_pdk_allows_partial_root_without_forcing_paths(tmp_path):
+def test_get_pdk_raises_on_missing_pdk_files(tmp_path):
     invalid_root = tmp_path / "broken_ics55"
     invalid_root.mkdir(parents=True, exist_ok=True)
 
-    pdk = get_pdk("ics55", pdk_root=str(invalid_root))
-    assert pdk.root == str(invalid_root.resolve())
-    assert pdk.tech == ""
-    assert pdk.lefs == []
-    assert pdk.libs == []
+    with pytest.raises(ValueError, match="PDK validation failed"):
+        get_pdk("ics55", pdk_root=str(invalid_root))


### PR DESCRIPTION
Raises ValueError with detailed error messages when PDK root, tech LEF, LEF files, or liberty files are missing, preventing silent failures that only surface later during Yosys synthesis.