### PR TITLE
deprecate: mark chipcompiler.server as deprecated in favor of ecos_server

### DIFF
--- a/chipcompiler/server/__init__.py
+++ b/chipcompiler/server/__init__.py
@@ -1,3 +1,31 @@
+"""
+.. deprecated::
+    This package has been moved to ``ecos_server.ecc``.
+    Use ``from ecos_server.ecc import ...`` instead.
+    This package will be removed in a future release.
+
+    Module mapping:
+
+    ========================================  ==========================================
+    Old module                                New module
+    ========================================  ==========================================
+    chipcompiler.server                       ecos_server.ecc
+    chipcompiler.server.main                  ecos_server.main
+    chipcompiler.server.routers.ecc           ecos_server.ecc.routers.workspace
+    chipcompiler.server.routers.sse           ecos_server.ecc.routers.sse
+    chipcompiler.server.schemas.*             ecos_server.ecc.schemas.*
+    chipcompiler.server.services.*            ecos_server.ecc.services.*
+    chipcompiler.server.sse.*                 ecos_server.ecc.sse.* / ecos_server.sse.*
+    ========================================  ==========================================
+"""
+import warnings
+warnings.warn(
+    "chipcompiler.server is deprecated and will be removed in a future release. "
+    "Use ecos_server.ecc instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 from .main import app
 from .routers import workspace_router
 from .schemas import (


### PR DESCRIPTION
This pull request introduces a deprecation notice for the `chipcompiler.server` package, informing users that the package has been moved to `ecos_server.ecc` and will be removed in a future release. The update provides clear guidance on module mapping and triggers a warning when the old package is imported.

Deprecation and migration guidance:

* Added a deprecation docstring to `chipcompiler.server/__init__.py` with detailed instructions and a module mapping table to guide users in transitioning to `ecos_server.ecc`.
* Implemented a `DeprecationWarning` in `chipcompiler.server/__init__.py` to alert users at import time about the upcoming removal and migration path.