### PR TITLE
refactor: redirect log to workspace

### DIFF
--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -13,6 +13,8 @@ from chipcompiler.engine import EngineDB
 from chipcompiler.utility import track_process_memory
 from chipcompiler.utility.log import redirect_stdio_to_file
 
+logger = logging.getLogger(__name__)
+
 def _run_step_in_subprocess(workspace: Workspace, workspace_step: WorkspaceStep) -> None:
     """
     Step subprocess entry point: redirect stdio to log file if configured,

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -324,7 +324,9 @@ class EngineFlow:
         p = Process(target=_run_step_in_subprocess,
                     args=(self.workspace, workspace_step))
         p.start()
-        self.workspace.logger.info("[DISPATCH] %s pid=%s", step_tag, p.pid)
+        step_log_file = workspace_step.log.get("file", "")
+        logger.info("[DISPATCH] %s pid=%s log=%s", step_tag, p.pid,
+                    os.path.abspath(step_log_file) if step_log_file else "N/A")
 
         # track peak memory in a background thread
         peak_memory_result = [0]

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -11,19 +11,17 @@ from threading import Thread
 from chipcompiler.data import Workspace, WorkspaceStep, StateEnum, StepEnum, log_flow
 from chipcompiler.engine import EngineDB
 from chipcompiler.utility import track_process_memory
-from chipcompiler.utility.log import (
-    API_RUNTIME_LOG_ENV_KEY,
-    redirect_stdio_to_file,
-)
+from chipcompiler.utility.log import redirect_stdio_to_file
 
 def _run_step_in_subprocess(workspace: Workspace, workspace_step: WorkspaceStep) -> None:
     """
     Step subprocess entry point: redirect stdio to log file if configured,
     then execute the EDA tool step.
     """
-    # Redirect stdout/stderr to runtime log file (if set by API server)
-    log_file = os.environ.get(API_RUNTIME_LOG_ENV_KEY, "").strip()
+    # Redirect stdout/stderr to the step's own log file.
+    log_file = workspace_step.log.get("file", "")
     if log_file:
+        log_file = os.path.abspath(log_file)
         try:
             os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
             redirect_stdio_to_file(log_file)

--- a/chipcompiler/utility/__init__.py
+++ b/chipcompiler/utility/__init__.py
@@ -10,11 +10,9 @@ from .json import (
 )
 
 from .log import (
-    API_RUNTIME_LOG_ENV_KEY,
     Logger,
     build_timestamped_log_file,
     create_logger,
-    get_api_log_file_from_env,
     init_api_runtime_log,
     redirect_stdio_to_file,
     rotate_log_on_start,
@@ -51,12 +49,10 @@ __all__ = [
     'dict_to_str',
     'Logger',
     'create_logger',
-    'API_RUNTIME_LOG_ENV_KEY',
     'build_timestamped_log_file',
     'rotate_log_on_start',
     'redirect_stdio_to_file',
     'init_api_runtime_log',
-    'get_api_log_file_from_env',
     'track_process_memory',
     'plot_csv_map',
     'plot_metrics',

--- a/chipcompiler/utility/log.py
+++ b/chipcompiler/utility/log.py
@@ -10,8 +10,6 @@ from typing import Optional, TextIO
 import time
 
 
-API_RUNTIME_LOG_ENV_KEY = "CHIPCOMPILER_API_SERVER_LOG_FILE"
-
 #TODO: Move some functions to Logger Module
 def build_timestamped_log_file(log_file: str, pid: int | None = None) -> str:
     """
@@ -89,14 +87,6 @@ def init_api_runtime_log(
     rotate_log_on_start(resolved, max_bytes, backup_count)
     redirect_stdio_to_file(resolved)
     return resolved
-
-
-def get_api_log_file_from_env() -> str | None:
-    """
-    Get runtime log file path from environment.
-    """
-    value = os.environ.get(API_RUNTIME_LOG_ENV_KEY, "").strip()
-    return value or None
 
 
 class Logger:

--- a/chipcompiler/utility/log.py
+++ b/chipcompiler/utility/log.py
@@ -98,16 +98,20 @@ class Logger:
         max_bytes: int = 10 * 1024 * 1024,  # 10MB
         backup_count: int = 5,
         level: int = logging.INFO,
+        console_level: Optional[int] = None,
+        file_level: Optional[int] = None,
         fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     ):
         self.logger = logging.getLogger(name)
         self.logger.setLevel(level)
+        self.logger.propagate = False
 
         if not self.logger.handlers:
             formatter = logging.Formatter(fmt)
 
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(formatter)
+            console_handler.setLevel(logging.WARNING if console_level is None else console_level)
             self.logger.addHandler(console_handler)
             
             if log_file or log_dir:
@@ -116,6 +120,7 @@ class Logger:
                     file, maxBytes=max_bytes, backupCount=backup_count
                 )
                 file_handler.setFormatter(formatter)
+                file_handler.setLevel(level if file_level is None else file_level)
                 self.logger.addHandler(file_handler)
 
     def debug(self, msg: str, *args, **kwargs):
@@ -154,6 +159,8 @@ def create_logger(
     max_bytes: int = 10 * 1024 * 1024,  # 10MB
     backup_count: int = 5,
     level: int = logging.INFO,
+    console_level: Optional[int] = None,
+    file_level: Optional[int] = None,
     fmt: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 ) -> Logger:
     if log_file is not None and os.path.exists(log_file):
@@ -163,6 +170,8 @@ def create_logger(
             max_bytes=max_bytes,
             backup_count=backup_count,
             level=level,
+            console_level=console_level,
+            file_level=file_level,
             fmt=fmt,
         )
     elif log_dir is not None and os.path.exists(log_dir):
@@ -172,6 +181,8 @@ def create_logger(
             max_bytes=max_bytes,
             backup_count=backup_count,
             level=level,
+            console_level=console_level,
+            file_level=file_level,
             fmt=fmt,
         ) 
     else:
@@ -181,5 +192,7 @@ def create_logger(
             max_bytes=max_bytes,
             backup_count=backup_count,
             level=level,
+            console_level=console_level,
+            file_level=file_level,
             fmt=fmt,
         )


### PR DESCRIPTION
This pull request refactors the logging configuration and usage throughout the codebase, focusing on simplifying log file management and improving logger flexibility. The main changes include removing environment variable-based log file selection, enhancing the logger to support different log levels for console and file outputs, and updating subprocess step logging to use per-step log files.

**Logging configuration and usage improvements:**

* Removed reliance on the `API_RUNTIME_LOG_ENV_KEY` environment variable and related helper functions, simplifying log file selection and making logging more explicit and per-step.
* Updated `_run_step_in_subprocess` in `flow.py` to always use the log file specified in the `workspace_step` object, ensuring each step logs to its own file.
* Enhanced log dispatch messages in `run_step` to include the absolute path of the log file used for the step, improving traceability.

**Logger flexibility enhancements:**

* Added `console_level` and `file_level` parameters to the `Logger` class and the `create_logger` function, allowing different log levels for console and file outputs. Also set `propagate` to `False` to prevent duplicate log messages.