### PR TITLE
fixup! fix(build): set temp uv cache dir to avoid writing read-only file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,7 +52,7 @@ genrule(
             cp "$$src" "$$STAGE/$$src"
         done
         tar -xf "$$BUNDLE" -C "$$STAGE"
-        "$$UV" build --wheel --directory "$$STAGE" --out-dir "$$STAGE/_dist"
+        "$$UV" build --wheel --directory "$$STAGE" --out-dir "$$STAGE/_dist" --cache-dir "$$STAGE/.uv-cache"
         cp "$$STAGE"/_dist/*.whl "$@"
     """,
 )


### PR DESCRIPTION
Add missing temp uv cache dir for ecc wheel build.