### PR TITLE
fix: use correct Title Case keys for target_density and stop_overflow

### DIFF
--- a/chipcompiler/tools/ecc_dreamplace/builder.py
+++ b/chipcompiler/tools/ecc_dreamplace/builder.py
@@ -53,10 +53,10 @@ def build_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
     params["result_dir"] = step.data.get(step.name, step.data["dir"])
     params["base_design_name"] = workspace.design.name
     params["target_density"] = workspace.parameters.data.get(
-        "target_density", params.get("target_density", 0.3)
+        "Target density", params.get("target_density", 0.3)
     )
     params["stop_overflow"] = workspace.parameters.data.get(
-        "stop_overflow", params.get("stop_overflow", 0.1)
+        "Target overflow", params.get("stop_overflow", 0.1)
     )
     params["timing_opt_flag"] = 0
     params["timing_eval_flag"] = 0


### PR DESCRIPTION
The DreamPlace builder was reading "target_density" and "stop_overflow" (snake_case) from workspace.parameters.data, but the parameter template and GUI use "Target density" and "Target overflow" (Title Case). This meant GUI-configured values never reached DreamPlace -- the builder always fell back to dreamplace.json defaults.