### PR TITLE
feat(test): add dump smt2 helper, sync formal verification README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Generated SMT-LIB dumps from formal verification tests
+test/formal/smt2/
+
 # C extensions
 *.so
 

--- a/test/formal/README.md
+++ b/test/formal/README.md
@@ -1,13 +1,13 @@
 # Formal Verification Tests
 
-z3-based formal verification of `EngineFlow` invariants. These tests encode production code logic as SMT constraints and use z3 to exhaustively prove properties or find concrete counterexamples.
+z3-based formal verification of the ECC chipcompiler Python codebase. Tests encode production code logic as SMT constraints and use z3 to exhaustively prove properties or find concrete counterexamples.
 
 ## How it works
 
 Each test encodes two models:
 
-1. **Code model** -- what `set_state()`, `create_step_workspaces()`, etc. actually allow (derived by reading the source)
-2. **Spec model** -- what the code *should* allow (the intended invariant)
+1. **Code model** -- what the production code actually does (derived by reading the source)
+2. **Spec model** -- what the code *should* do (the intended invariant)
 
 z3 checks: "does there exist any input where these two disagree?"
 
@@ -18,29 +18,51 @@ Tests that probe known-missing guards are marked `pytest.xfail(strict=False)`. W
 
 ## Test files
 
-### `test_state_machine.py`
-
-Verifies `EngineFlow` state transitions (`StateEnum`).
+### `test_state_machine.py` -- EngineFlow state transitions
 
 | Test | Method | Status |
 |------|--------|--------|
 | `test_no_invalid_transition_allowed` | z3 existential query over all 36 state pairs | XFAIL -- `set_state()` has no guards |
 | `test_terminal_unreachable_without_ongoing` | z3 bounded model checking (K=1..10) | XFAIL -- direct `Unstart -> Success` possible |
-| `test_is_flow_success_iff_all_success` | z3 tautology check | PASS -- `is_flow_success()` logic is correct |
+| `test_is_flow_success_iff_all_success` | z3 tautology check | PASS |
 | `test_clear_states_resets_all` | Real `EngineFlow` on mock workspace | PASS |
-| `test_run_steps_stops_on_failure` | Parametrized over fail index 0-4 | PASS -- `run_steps()` stops correctly |
+| `test_run_steps_stops_on_failure` | Parametrized over fail index 0-4 | PASS |
 
-### `test_file_chaining.py`
+### `test_file_chaining.py` -- Step output chaining invariants
 
-Verifies `create_step_workspaces()` file chaining invariants. Abstracts file paths to boolean flags (`has_def`, `has_verilog`, `has_gds`).
+Abstracts file paths to boolean flags (`has_def`, `has_verilog`, `has_gds`).
 
 | Test | Method | Status |
 |------|--------|--------|
 | `test_output_keys_present_for_all_step_types` | z3 satisfiability + unsatisfiability checks | PASS |
 | `test_chain_breaks_on_failure` | z3 existential query over step sequences | XFAIL -- silent skip on failure (flow.py:240) |
-| `test_first_step_always_reads_origin` | z3 constraint contradiction | PASS -- proven |
+| `test_first_step_always_reads_origin` | z3 constraint contradiction | PASS |
 | `test_check_step_result_completeness` | z3 exhaustive check over all `StepEnum` | PASS |
 | `test_no_stale_output_propagation` | z3 taint propagation model | XFAIL -- no taint tracking in code |
+
+### `test_param_merge.py` -- Parameter override merge behavior
+
+z3 proofs that `update_parameters()` recursive dict merge is correct.
+
+| Test | Method | Status |
+|------|--------|--------|
+| `test_scalar_override_wins` | z3 universally quantified over keys | PASS |
+| `test_absent_keys_preserved` | z3 universally quantified over keys | PASS |
+| `test_list_replaced_not_appended` | z3 universally quantified over keys | PASS |
+| `test_new_key_added` | z3 universally quantified over keys | PASS |
+| `test_nested_dict_merges_not_replaces` | z3 with fixed key layout | PASS |
+| `test_merge_against_real_template_*` | Concrete tests against ICS55 template | PASS |
+
+### `test_param_propagation.py` -- Parameter to tool config pipeline
+
+Verifies parameters reach tool configs correctly through the builder pipeline.
+
+| Test | Method | Status |
+|------|--------|--------|
+| `test_key_spelling_matches_template` | String match against ICS55 template | XFAIL -- `"File list"` missing from template |
+| `test_dead_defaults` | z3 proves config defaults overwritten by builder | PASS (3 dead defaults found) |
+| `test_builder_forced_overrides` | z3 proves forced values are immutable | PASS |
+| `test_propagation_z3` | z3 proves parameter reaches config field | PASS |
 
 ## Running
 
@@ -63,52 +85,31 @@ solver.add(x > 0, x < 10)
 dump_smt2(solver, "example")  # writes test/formal/smt2/example.smt2
 ```
 
-Output directory: `test/formal/smt2/` (gitignored, generated on demand).
+Output directory: `test/formal/smt2/` (generated on demand, not committed).
 
 ## Dependencies
 
 - `z3-solver>=4.12` (dev dependency)
 
-## Known bugs found
+## Known bugs and findings
 
-These are documented by XFAIL tests with concrete z3 counterexamples:
+Documented by XFAIL tests with concrete z3 counterexamples:
+
+### EngineFlow state machine
 
 1. **No transition guards** -- `set_state()` accepts any `(old, new)` pair, including `Success -> Ongoing`
 2. **Terminal states reachable without Ongoing** -- `Unstart -> Success` in one step
+
+### File chaining
+
 3. **Silent step skip** -- `create_step_workspaces()` silently continues when `create_step()` returns None, feeding stale data to downstream steps
 4. **No taint tracking** -- steps after a failure can "succeed" on stale input from a pre-failure step
+
+### Parameter pipeline
+
 5. **"File list" key missing from template** -- yosys builder reads `"File list"` via `dict.get()` but ICS55 template does not define it
-
-## Parameter Pipeline Verification
-
-### `test_param_merge.py`
-
-z3 proofs that `update_parameters()` merge logic is correct:
-
-| Test | Method | Status |
-|------|--------|--------|
-| `test_scalar_override_wins` | z3 universally quantified over keys | PASS |
-| `test_absent_keys_preserved` | z3 universally quantified over keys | PASS |
-| `test_list_replaced_not_appended` | z3 universally quantified over keys | PASS |
-| `test_new_key_added` | z3 universally quantified over keys | PASS |
-| `test_nested_dict_merges_not_replaces` | z3 with fixed key layout | PASS |
-| `test_merge_against_real_template_*` | Concrete tests against ICS55 template | PASS |
-
-### `test_param_propagation.py`
-
-Verifies parameters reach tool configs correctly:
-
-| Test | Method | Status |
-|------|--------|--------|
-| `test_key_spelling_matches_template` | String match against ICS55 template | XFAIL (`"File list"` missing) |
-| `test_dead_defaults` | z3 proves config defaults overwritten by builder | PASS (3 dead defaults found) |
-| `test_builder_forced_overrides` | z3 proves forced values are immutable | PASS |
-| `test_propagation_z3` | z3 proves parameter reaches config field | PASS |
-
-### Dead defaults found
-
-These JSON config defaults are always overwritten by the builder with parameter values:
-
-1. `dreamplace.json: target_density=0.8` -- overwritten with parameter default 0.3
-2. `dreamplace.json: routability_opt_flag=0` -- overwritten with parameter default 1
-3. `no_default_config_fixfanout.json: max_fanout=32` -- overwritten with parameter default 20
+6. **Dead config defaults** -- these JSON defaults are always overwritten by the builder:
+   - `dreamplace.json: target_density=0.8` -- overwritten with parameter default 0.3
+   - `dreamplace.json: routability_opt_flag=0` -- overwritten with parameter default 1
+   - `no_default_config_fixfanout.json: max_fanout=32` -- overwritten with parameter default 20
+7. **Forced overrides** -- DreamPlace builder forces `timing_opt_flag`, `timing_eval_flag`, `with_sta`, `differentiable_timing_obj` to 0 regardless of parameters

--- a/test/formal/README.md
+++ b/test/formal/README.md
@@ -48,6 +48,23 @@ Verifies `create_step_workspaces()` file chaining invariants. Abstracts file pat
 uv run pytest test/formal/ -v
 ```
 
+## SMT-LIB Export
+
+Use `dump_smt2()` from `test.formal` to export any solver's constraints to
+SMT-LIB2 format for manual review or use with other solvers (cvc5, yices2):
+
+```python
+from z3 import Solver, Int
+from test.formal import dump_smt2
+
+solver = Solver()
+x = Int("x")
+solver.add(x > 0, x < 10)
+dump_smt2(solver, "example")  # writes test/formal/smt2/example.smt2
+```
+
+Output directory: `test/formal/smt2/` (gitignored, generated on demand).
+
 ## Dependencies
 
 - `z3-solver>=4.12` (dev dependency)

--- a/test/formal/__init__.py
+++ b/test/formal/__init__.py
@@ -1,0 +1,36 @@
+"""Formal verification test utilities."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from z3 import Solver
+
+# Default output directory for SMT-LIB dumps (relative to ecc/)
+_SMT2_DIR: str = os.path.join(os.path.dirname(__file__), "smt2")
+
+
+def dump_smt2(solver: Solver, name: str, output_dir: str | None = None) -> Path:
+    """Dump a solver's constraints to an SMT-LIB2 file for review.
+
+    Args:
+        solver: z3 Solver instance with constraints added.
+        name: File stem (e.g., "state_machine_transition"). Produces `<name>.smt2`.
+        output_dir: Directory for output. Defaults to `test/formal/smt2/`.
+
+    Returns:
+        Path to the written .smt2 file.
+
+    Example:
+        >>> solver = Solver()
+        >>> solver.add(x > 0)
+        >>> path = dump_smt2(solver, "example")
+        >>> # writes test/formal/smt2/example.smt2
+    """
+    out_dir: str = output_dir or _SMT2_DIR
+    os.makedirs(out_dir, exist_ok=True)
+
+    out_path = Path(out_dir) / f"{name}.smt2"
+    out_path.write_text(solver.to_smt2())
+    return out_path

--- a/test/formal/__init__.py
+++ b/test/formal/__init__.py
@@ -17,21 +17,28 @@ def dump_smt2(solver: Solver, name: str, output_dir: str | None = None) -> Path:
     Args:
         solver: z3 Solver instance with constraints added.
         name: File stem (e.g., "state_machine_transition"). Produces `<name>.smt2`.
-              Must not contain path separators.
+              Must be a non-empty string without path separators or whitespace-only.
         output_dir: Directory for output. Defaults to `test/formal/smt2/`.
 
     Returns:
         Path to the written .smt2 file.
 
     Raises:
-        ValueError: If name contains path separators or attempts directory traversal.
+        ValueError: If name is empty, whitespace-only, contains path separators,
+                    or attempts directory traversal.
 
     Example:
+        >>> from z3 import Solver, Int
         >>> solver = Solver()
+        >>> x = Int("x")
         >>> solver.add(x > 0)
         >>> path = dump_smt2(solver, "example")
         >>> # writes test/formal/smt2/example.smt2
     """
+    if not name or not name.strip():
+        msg = f"name must be a non-empty string, got: {name!r}"
+        raise ValueError(msg)
+
     if os.path.basename(name) != name or os.sep in name or "/" in name:
         msg = f"name must be a plain filename stem, got: {name!r}"
         raise ValueError(msg)
@@ -46,5 +53,5 @@ def dump_smt2(solver: Solver, name: str, output_dir: str | None = None) -> Path:
         msg = f"resolved path {out_path} escapes output directory {resolved_dir}"
         raise ValueError(msg)
 
-    out_path.write_text(solver.to_smt2())
+    out_path.write_text(solver.to_smt2(), encoding="utf-8")
     return out_path

--- a/test/formal/__init__.py
+++ b/test/formal/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from z3 import Solver
 
-# Default output directory for SMT-LIB dumps (relative to ecc/)
+# Default output directory: test/formal/smt2/ (sibling of this __init__.py)
 _SMT2_DIR: str = os.path.join(os.path.dirname(__file__), "smt2")
 
 
@@ -17,10 +17,14 @@ def dump_smt2(solver: Solver, name: str, output_dir: str | None = None) -> Path:
     Args:
         solver: z3 Solver instance with constraints added.
         name: File stem (e.g., "state_machine_transition"). Produces `<name>.smt2`.
+              Must not contain path separators.
         output_dir: Directory for output. Defaults to `test/formal/smt2/`.
 
     Returns:
         Path to the written .smt2 file.
+
+    Raises:
+        ValueError: If name contains path separators or attempts directory traversal.
 
     Example:
         >>> solver = Solver()
@@ -28,9 +32,19 @@ def dump_smt2(solver: Solver, name: str, output_dir: str | None = None) -> Path:
         >>> path = dump_smt2(solver, "example")
         >>> # writes test/formal/smt2/example.smt2
     """
+    if os.path.basename(name) != name or os.sep in name or "/" in name:
+        msg = f"name must be a plain filename stem, got: {name!r}"
+        raise ValueError(msg)
+
     out_dir: str = output_dir or _SMT2_DIR
     os.makedirs(out_dir, exist_ok=True)
 
-    out_path = Path(out_dir) / f"{name}.smt2"
+    out_path = (Path(out_dir) / f"{name}.smt2").resolve()
+    resolved_dir = Path(out_dir).resolve()
+
+    if not out_path.is_relative_to(resolved_dir):
+        msg = f"resolved path {out_path} escapes output directory {resolved_dir}"
+        raise ValueError(msg)
+
     out_path.write_text(solver.to_smt2())
     return out_path

--- a/test/formal/test_dump_smt2.py
+++ b/test/formal/test_dump_smt2.py
@@ -1,0 +1,61 @@
+"""Unit tests for test.formal.dump_smt2 helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from z3 import Int, Solver
+
+from test.formal import dump_smt2
+
+
+def _make_solver() -> Solver:
+    """Create a minimal solver with one constraint."""
+    s = Solver()
+    s.add(Int("x") > 0)
+    return s
+
+
+def test_dump_writes_to_expected_directory(tmp_path: Path) -> None:
+    """dump_smt2 writes a .smt2 file inside the given output_dir."""
+    s = _make_solver()
+    result = dump_smt2(s, "test_output", output_dir=str(tmp_path))
+
+    assert result.exists()
+    assert result.name == "test_output.smt2"
+    assert result.parent == tmp_path
+    content = result.read_text(encoding="utf-8")
+    assert "(check-sat)" in content
+
+
+def test_dump_rejects_path_separators() -> None:
+    """Names with / or os.sep are rejected."""
+    s = _make_solver()
+
+    with pytest.raises(ValueError, match="plain filename stem"):
+        dump_smt2(s, "../escape")
+
+    with pytest.raises(ValueError, match="plain filename stem"):
+        dump_smt2(s, "sub/path")
+
+
+def test_dump_rejects_empty_name() -> None:
+    """Empty or whitespace-only names are rejected."""
+    s = _make_solver()
+
+    with pytest.raises(ValueError, match="non-empty"):
+        dump_smt2(s, "")
+
+    with pytest.raises(ValueError, match="non-empty"):
+        dump_smt2(s, "   ")
+
+
+def test_dump_uses_utf8_encoding(tmp_path: Path) -> None:
+    """Output file is written with explicit UTF-8 encoding."""
+    s = _make_solver()
+    result = dump_smt2(s, "encoding_test", output_dir=str(tmp_path))
+
+    # Read back with explicit UTF-8 -- should not raise
+    content = result.read_text(encoding="utf-8")
+    assert len(content) > 0


### PR DESCRIPTION
This pull request improves the documentation and utilities for formal verification tests in the ECC chipcompiler Python codebase. The main changes clarify the scope and organization of the formal test suite, document known bugs and findings more systematically, and introduce a utility for exporting SMT-LIB2 files for interoperability with other solvers.

**Documentation improvements:**

* Updated `test/formal/README.md` to clarify that formal verification covers the entire ECC chipcompiler Python codebase, not just `EngineFlow`, and reorganized sections for better readability.
* Expanded and restructured the documentation of test files, grouping tests by theme (state machine, file chaining, parameter pipeline), and providing clearer descriptions of each test and its status.
* Added a more systematic list of known bugs and findings, dividing them into categories and providing detailed explanations.

**New utility for SMT-LIB2 export:**

* Added `dump_smt2()` in `test/formal/__init__.py` to export z3 solver constraints to SMT-LIB2 files for manual review or use with other SMT solvers, and documented its usage in the README. [[1]](diffhunk://#diff-72d6a023ca34eb816c1714ded196085681c7a690491eb45c9e6ec7552427768fR1-R36) [[2]](diffhunk://#diff-0f13fce77582419c4b9aaa79429a095b537e02f10b0188e4444d190559d15cbfL80-R115)

**Test and dependency clarifications:**

* Clarified the installation and running instructions for the formal test suite and listed required dependencies in the README.

These changes make the formal verification process more transparent, reproducible, and extensible for future contributors.