### PR TITLE
fix(runner): use step.output instead of nonexistent step.out

### DIFF
--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -73,7 +73,7 @@ def save_data(workspace: Workspace,
     ecc_module.def_save(def_path=step.output.get("def", ""))
     ecc_module.verilog_save(output_verilog=step.output.get("verilog", ""))
     ecc_module.gds_save(output_path=step.output.get("gds", ""))
-    ecc_module.json_save(path=step.out.get("json", ""))
+    ecc_module.json_save(path=step.output.get("json", ""))
     ecc_module.feature_sammry(json_path=step.feature.get("summary", ""))
     if feature_step:
         ecc_module.feature_step(step=step.name,


### PR DESCRIPTION
WorkspaceStep has an `output` attribute, not `out`. The `.get()` call on `step.out` raised AttributeError at runtime.

This was introduced by [605de6d](https://github.com/openecos-projects/ecc/commit/605de6de03ab8d78b63db73c527067d9a203e88d).