### PR TITLE
chore: bump version to 0.1.0-alpha.1

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,7 +13,7 @@ genrule(
         "//chipcompiler:chipcompiler_python_sources",
         "//chipcompiler:chipcompiler_runtime_data",
     ],
-    outs = ["raw_wheel/ecc-0.1.0a0-py3-none-any.whl"],
+    outs = ["raw_wheel/ecc-0.1.0a1-py3-none-any.whl"],
     tools = ["@multitool//tools/uv"],
     cmd = """
         set -euo pipefail

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "ecc",
-    version = "0.1.0-alpha",
+    version = "0.1.0-alpha.1",
 )
 
 bazel_dep(name = "rules_python", version = "1.7.0")

--- a/bazel/scripts/build-wheel.sh
+++ b/bazel/scripts/build-wheel.sh
@@ -65,7 +65,7 @@ venv_python="$smoke_dir/venv/bin/python"
 # ecc-dreamplace and ecc-tools are not on PyPI; install them from GitHub URLs first,
 # then install the local ecc wheel so uv resolves the remaining PyPI deps.
 "$UV" pip install --python "$venv_python" \
-    "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha/ecc_tools-0.1.0a0-py3-none-manylinux_2_34_x86_64.whl" \
+    "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" \
     "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" \
     "$final_whl"
 

--- a/chipcompiler/__init__.py
+++ b/chipcompiler/__init__.py
@@ -1,2 +1,2 @@
 # chipcompiler package
-__version__ = "0.1.0-alpha"
+__version__ = "0.1.0-alpha.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.8.5" ]
 
 [project]
 name = "ecc"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.1"
 readme = "README.md"
 authors = [
   { name = "Emin", email = "me@emin.chat" },
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "ecc-dreamplace==0.1.0a1",
-  "ecc-tools==0.1.0a0",
+  "ecc-tools==0.1.0a1",
   "fastapi>=0.109",
   "klayout>=0.30.2",
   "matplotlib>=3.4",
@@ -77,7 +77,7 @@ explicit = true
 
 [tool.uv.sources]
 ecc-dreamplace = { url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" }
-ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha/ecc_tools-0.1.0a0-py3-none-manylinux_2_34_x86_64.whl" }
+ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" }
 torch = { index = "pytorch-cpu" }
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -431,7 +431,7 @@ wheels = [
 
 [[package]]
 name = "ecc"
-version = "0.1.0"
+version = "0.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "ecc-dreamplace" },
@@ -471,7 +471,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ecc-dreamplace", url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" },
-    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha/ecc_tools-0.1.0a0-py3-none-manylinux_2_34_x86_64.whl" },
+    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" },
     { name = "fastapi", specifier = ">=0.109" },
     { name = "klayout", specifier = ">=0.30.2" },
     { name = "matplotlib", specifier = ">=3.4" },
@@ -533,11 +533,6 @@ wheels = [
     { url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:212139c43f825498968eda10309959b99cd93aec0744d182a17bb5d34b53145e" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "auditwheel" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "cairocffi", specifier = ">=0.9.0" },
@@ -559,15 +554,12 @@ requires-dist = [
     { name = "xgboost", specifier = ">=1.5.1" },
 ]
 
-[package.metadata.requires-dev]
-dev = [{ name = "auditwheel" }]
-
 [[package]]
 name = "ecc-tools"
-version = "0.1.0a0"
-source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha/ecc_tools-0.1.0a0-py3-none-manylinux_2_34_x86_64.whl" }
+version = "0.1.0a1"
+source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl" }
 wheels = [
-    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha/ecc_tools-0.1.0a0-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:ac1370f9ee412332cf9161db74eae959f4e40e1b296f24e428dabe7e1abbadbb" },
+    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:762cef33f7d2bffb9e90e51c7c1c62f9a6bee3cb9ac97c888951351487663288" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `ecc-tools` 0.1.0-alpha.1 version is incompatible with the `ecc` 0.1.0-alpha version, particularly regarding the issue addressed in this PR: [https://github.com/openecos-projects/ecc/pull/58](https://github.com/openecos-projects/ecc/pull/58). The relevant API was modified in this commit: [https://github.com/openecos-projects/ecc-tools/commit/1de3f00fbc45052f0f111360f4ec8cd198f1941f](https://github.com/openecos-projects/ecc-tools/commit/1de3f00fbc45052f0f111360f4ec8cd198f1941f).