### PR TITLE
fix(runner): write feature summary to correct path

### DIFF
--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -74,7 +74,7 @@ def save_data(workspace: Workspace,
     ecc_module.verilog_save(output_verilog=step.output.get("verilog", ""))
     ecc_module.gds_save(output_path=step.output.get("gds", ""))
     ecc_module.json_save(path=step.output.get("json", ""))
-    ecc_module.feature_sammry(json_path=step.feature.get("summary", ""))
+    ecc_module.feature_sammry(json_path=step.feature.get("db", ""))
     if feature_step:
         ecc_module.feature_step(step=step.name,
                             json_path=step.feature.get("step", ""))


### PR DESCRIPTION
 so die/core size gets updated

feature_sammry was called with step.feature.get('summary', '') but the dict has no 'summary' key — only 'db', 'step', 'map'. This meant the feature summary JSON was never written to disk, so json_read() for the db path always returned empty, and the die/core size parameter update was silently skipped. Changed to use the 'db' key which matches the path read later for parameter extraction.