### PR TITLE
fix(yosys): remove hardcoded synthesis timeout

### DIFF
--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import os
-import time
-
 import subprocess
 
 from chipcompiler.data import StateEnum, Workspace, WorkspaceStep
@@ -75,7 +73,6 @@ def run_step(workspace: Workspace,
                 env=yosys_env,
                 stdout=log_file,
                 stderr=subprocess.STDOUT,
-                timeout=600
             )
 
         if os.path.exists(step.output["verilog"]):
@@ -98,10 +95,6 @@ def run_step(workspace: Workspace,
             )
             return False
 
-    except subprocess.TimeoutExpired:
-        sub_flow.update_step(step_name="run yosys", state=StateEnum.Imcomplete)
-        print("Error: Yosys synthesis timed out")
-        return False
     except Exception as e:
         sub_flow.update_step(step_name="run yosys", state=StateEnum.Imcomplete)
         print(f"Error running yosys: {e}")

--- a/test/test_tools_yosys_runner.py
+++ b/test/test_tools_yosys_runner.py
@@ -60,12 +60,11 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
         })
         return True
 
-    def fake_run(cmd, cwd, env, stdout, stderr, timeout):
+    def fake_run(cmd, cwd, env, stdout, stderr):
         run_calls.append({
             "cmd": list(cmd),
             "cwd": cwd,
             "env": env,
-            "timeout": timeout,
         })
         if cmd == ["yosys", "yosys_synthesis.tcl"]:
             output_file.write_text("module top(); endmodule\n")
@@ -87,6 +86,7 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
     assert check_calls[0]["env"] == runtime_env
     assert len(run_calls) == 1
     assert run_calls[0]["cmd"] == ["yosys", "yosys_synthesis.tcl"]
+    assert run_calls[0]["cwd"] == str(script_dir)
     assert run_calls[0]["env"] == runtime_env
     assert ("run yosys", StateEnum.Success) in updates
     assert ("analysis", StateEnum.Success) in updates
@@ -108,7 +108,7 @@ def test_run_step_marks_invalid_when_slang_check_fails(tmp_path, monkeypatch):
         log_file.write("Error: yosys slang plugin check failed.\n")
         return False
 
-    def fake_run(cmd, cwd, env, stdout, stderr, timeout):
+    def fake_run(cmd, cwd, env, stdout, stderr):
         run_calls.append(list(cmd))
         raise AssertionError("Synthesis should not run when slang check fails")
 

--- a/test/test_tools_yosys_runner.py
+++ b/test/test_tools_yosys_runner.py
@@ -86,7 +86,7 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
     assert check_calls[0]["env"] == runtime_env
     assert len(run_calls) == 1
     assert run_calls[0]["cmd"] == ["yosys", "yosys_synthesis.tcl"]
-    assert run_calls[0]["cwd"] == str(script_dir)
+    assert run_calls[0]["cwd"] == step.script["dir"]
     assert run_calls[0]["env"] == runtime_env
     assert ("run yosys", StateEnum.Success) in updates
     assert ("analysis", StateEnum.Success) in updates


### PR DESCRIPTION
Other EDA tools run without time limits. The arbitrary 600s timeout caused false failures on large designs. Yosys typically finishes or crashes rather than hangs indefinitely, so no timeout is needed.