### PR TITLE
ci: enable pytest in CI, split pytest and build-wheel

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,20 +1,9 @@
 name: Setup Python Dependencies
-description: Checkout, setup Python 3.11, uv, and install project dependencies.
-
-inputs:
-  submodules:
-    description: Whether to checkout with submodules
-    required: false
-    default: 'true'
+description: Setup Python 3.11, uv, and install project dependencies.
 
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: ${{ inputs.submodules }}
-
     - name: Setup Python
       uses: actions/setup-python@v5
       with:

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,31 @@
+name: Setup Python Dependencies
+description: Checkout, setup Python 3.11, uv, and install project dependencies.
+
+inputs:
+  submodules:
+    description: Whether to checkout with submodules
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: ${{ inputs.submodules }}
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: latest
+        enable-cache: "true"
+
+    - name: Install Python dependencies
+      shell: bash
+      run: uv sync --frozen --all-groups --python 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,35 @@ jobs:
       - name: Check version
         uses: ./.github/actions/check-version
 
-  ci:
-    name: Checks And Build
+  pytest:
+    name: Test
+    needs: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+          enable-cache: "true"
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --all-groups --python 3.11
+
+      - name: Pytest
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing
+
+  build-wheel:
+    name: Build
     needs: check-version
     runs-on: ubuntu-latest
     steps:
@@ -97,9 +124,7 @@ jobs:
       # - name: Pyright
       #   run: uv run pyright chipcompiler
 
-      - name: Pytest
-        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing
-
+      
       - name: Build distributable wheel
         run: bazel run //:build_wheel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check version
         uses: ./.github/actions/check-version
 
-  pytest:
+  test:
     name: Test
     needs: check-version
     runs-on: ubuntu-latest
@@ -108,11 +108,6 @@ jobs:
 
       - name: Install Python dependencies
         run: uv sync --frozen --all-groups --python 3.11
-
-      - name: Install release wheels for native toolchains
-        run: |
-          uv pip install --python .venv/bin/python --no-deps "${ECC_DREAMPLACE_WHEEL_URL}"
-          uv pip install --python .venv/bin/python --no-deps "${ECC_TOOLS_WHEEL_URL}"
 
       - name: Smoke test native toolchain wheels
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
 
+      - name: Setup PDK
+        run: |
+          git clone --depth 1 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
+          cd chipcompiler/thirdparty/icsprout55-pdk && make unzip
+
       # - name: Ruff format check
       #   run: uv run ruff format --check chipcompiler test
 
@@ -62,7 +67,7 @@ jobs:
       #   run: uv run pyright chipcompiler
 
       - name: Pytest
-        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --cov=chipcompiler --cov-report=term-missing
 
   build-wheel:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ permissions:
 
 env:
   UV_PYTHON_PREFERENCE: only-managed
-  ECC_DREAMPLACE_WHEEL_URL: https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl
-  ECC_TOOLS_WHEEL_URL: https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.1/ecc_tools-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl
 
 jobs:
   check-version:
@@ -46,24 +44,8 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: latest
-          enable-cache: "true"
-
-      - name: Install Python dependencies
-        run: uv sync --frozen --all-groups --python 3.11
+      - name: Setup Python dependencies
+        uses: ./.github/actions/setup-python-deps
 
       - name: Ruff format check
         run: uv run ruff format --check chipcompiler test
@@ -82,21 +64,8 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: latest
-          enable-cache: "true"
+      - name: Setup Python dependencies
+        uses: ./.github/actions/setup-python-deps
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.14.0
@@ -105,9 +74,6 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-
-      - name: Install Python dependencies
-        run: uv sync --frozen --all-groups --python 3.11
 
       - name: Smoke test native toolchain wheels
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       #   run: uv run pyright chipcompiler
 
       - name: Pytest
-        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --cov=chipcompiler --cov-report=term-missing
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing
 
       - name: Build distributable wheel
         run: bazel run //:build_wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
       # - name: Pyright
       #   run: uv run pyright chipcompiler
 
-      # - name: Pytest
-      #   run: uv run pytest test/ --cov=chipcompiler --cov-report=term-missing
+      - name: Pytest
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --cov=chipcompiler --cov-report=term-missing
 
       - name: Build distributable wheel
         run: bazel run //:build_wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --frozen --all-groups --python 3.11
 
+      - name: Ruff format check
+        run: uv run ruff format --check chipcompiler test
+
+      - name: Ruff lint
+        run: uv run ruff check chipcompiler test
+
+      - name: Pyright
+        run: uv run pyright chipcompiler
+
       - name: Pytest
         run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing
 
@@ -115,16 +124,6 @@ jobs:
           print("ecc-tools and ecc-dreamplace imports passed")
           PY
 
-      # - name: Ruff format check
-      #   run: uv run ruff format --check chipcompiler test
-
-      # - name: Ruff lint
-      #   run: uv run ruff check chipcompiler test
-
-      # - name: Pyright
-      #   run: uv run pyright chipcompiler
-
-      
       - name: Build distributable wheel
         run: bazel run //:build_wheel
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,22 +67,17 @@ jobs:
       #   run: uv run pyright chipcompiler
 
       - name: Pytest
-        run: |
-          uv run pytest test/ \
-            --ignore=test/test_harden.py \
-            --ignore=test/test_tools.py \
-            --cov=chipcompiler \
-            --cov-report=term-missing \
-            --cov-report=term:skip-covered \
-            | tee pytest-output.txt
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --cov=chipcompiler --cov-report=
 
-      - name: Publish test summary
+      - name: Publish coverage summary
         if: always()
         run: |
-          echo '## Pytest Results' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          tail -30 pytest-output.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo '## Coverage Report'
+            echo '```'
+            uv run coverage report --skip-covered
+            echo '```'
+          } >> $GITHUB_STEP_SUMMARY
 
   build-wheel:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           {
             echo '## Coverage Report'
             echo '```'
-            uv run coverage report --skip-covered
+            uv run coverage report
             echo '```'
           } >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,22 @@ jobs:
       #   run: uv run pyright chipcompiler
 
       - name: Pytest
-        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --cov=chipcompiler --cov-report=term-missing
+        run: |
+          uv run pytest test/ \
+            --ignore=test/test_harden.py \
+            --ignore=test/test_tools.py \
+            --cov=chipcompiler \
+            --cov-report=term-missing \
+            --cov-report=term:skip-covered \
+            | tee pytest-output.txt
+
+      - name: Publish test summary
+        if: always()
+        run: |
+          echo '## Pytest Results' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -30 pytest-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
   build-wheel:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
 
-      - name: Ruff format check
-        run: uv run ruff format --check chipcompiler test
+      # - name: Ruff format check
+      #   run: uv run ruff format --check chipcompiler test
 
-      - name: Ruff lint
-        run: uv run ruff check chipcompiler test
+      # - name: Ruff lint
+      #   run: uv run ruff check chipcompiler test
 
-      - name: Pyright
-        run: uv run pyright chipcompiler
+      # - name: Pyright
+      #   run: uv run pyright chipcompiler
 
       - name: Pytest
         run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_tools.py --ignore=test/test_data_pdk.py --ignore=test/test_workspace.py --ignore=test/test_filelist.py --cov=chipcompiler --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
 
@@ -64,6 +69,11 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
 

--- a/test/cli/test_cli_main.py
+++ b/test/cli/test_cli_main.py
@@ -53,7 +53,6 @@ def _common_args(workspace, rtl, pdk_root):
 def _install_cli_mocks(monkeypatch):
     capture = {
         "create_kwargs": None,
-        "log_workspace_calls": 0,
     }
     workspace_obj = SimpleNamespace(name="workspace")
 
@@ -65,14 +64,9 @@ def _install_cli_mocks(monkeypatch):
         capture["create_kwargs"] = kwargs
         return workspace_obj
 
-    def fake_log_workspace(workspace):
-        assert workspace is workspace_obj
-        capture["log_workspace_calls"] += 1
-
     monkeypatch.setattr(cli_main, "create_workspace", fake_create_workspace)
     monkeypatch.setattr(cli_main, "EngineFlow", DummyFlow)
     monkeypatch.setattr(cli_main, "build_rtl2gds_flow", lambda: [("Synthesis", "yosys", "Unstart")])
-    monkeypatch.setattr(cli_main, "log_workspace", fake_log_workspace)
 
     return capture
 
@@ -97,7 +91,6 @@ def test_cli_rtl_mode_calls_create_workspace_correctly(tmp_path, monkeypatch):
     assert capture["create_kwargs"]["parameters"]["Frequency max [MHz]"] == 100.0
     assert DummyFlow.instances[0].create_called is True
     assert DummyFlow.instances[0].run_called is True
-    assert capture["log_workspace_calls"] == 1
 
 
 def test_cli_filelist_mode_calls_create_workspace_correctly(tmp_path, monkeypatch):

--- a/test/formal/test_param_merge.py
+++ b/test/formal/test_param_merge.py
@@ -269,7 +269,7 @@ def test_merge_against_real_template_preserves_untouched() -> None:
 
     update_parameters(source, target)
 
-    for key in ["PDK", "Core", "Floorplan", "PDN", "Cell padding x"]:
+    for key in ["PDK", "Core", "Die", "Cell padding x"]:
         assert target[key] == original[key], f"Key '{key}' was modified but should be preserved"
 
 
@@ -277,19 +277,17 @@ def test_merge_against_real_template_list_replace() -> None:
     """Concrete: list override replaces entirely, not appends."""
     template = get_parameters("ics55")
     target: dict[str, object] = deepcopy(template.data)
-    original_tracks_len: int = len(target["Floorplan"]["Tracks"])  # type: ignore[index]
+    original_core_size_len: int = len(target["Core"]["Size"])  # type: ignore[index]
 
-    new_tracks: list[dict[str, object]] = [
-        {"layer": "MET1", "x start": 0, "x step": 100, "y start": 0, "y step": 100}
-    ]
-    source: dict[str, object] = {"Floorplan": {"Tracks": new_tracks}}
+    new_core_size: list[int] = [100, 200]
+    source: dict[str, object] = {"Core": {"Size": new_core_size}}
 
     update_parameters(source, target)
 
-    assert target["Floorplan"]["Tracks"] == new_tracks, "List should be replaced entirely"  # type: ignore[index]
-    assert len(target["Floorplan"]["Tracks"]) == 1, (  # type: ignore[index]
-        f"Expected 1 track, got {len(target['Floorplan']['Tracks'])} "  # type: ignore[index]
-        f"(original had {original_tracks_len})"
+    assert target["Core"]["Size"] == new_core_size, "List should be replaced entirely"  # type: ignore[index]
+    assert len(target["Core"]["Size"]) == 2, (  # type: ignore[index]
+        f"Expected 2 elements, got {len(target['Core']['Size'])} "  # type: ignore[index]
+        f"(original had {original_core_size_len})"
     )
 
 

--- a/test/test_data_pdk.py
+++ b/test/test_data_pdk.py
@@ -6,10 +6,6 @@ import pytest
 
 from chipcompiler.data.pdk import get_pdk
 
-import os, sys
-current_dir = os.path.split(os.path.abspath(__file__))[0]
-root = current_dir.rsplit('/', 1)[0]
-sys.path.append(root)
 
 def _create_minimal_ics55_pdk(root: Path) -> Path:
     """Create the minimal ICS55 directory tree required by get_pdk()."""
@@ -48,8 +44,7 @@ def test_get_pdk_uses_namespaced_env(tmp_path, monkeypatch):
     monkeypatch.setenv("CHIPCOMPILER_ICS55_PDK_ROOT", str(env_root))
     monkeypatch.delenv("ICS55_PDK_ROOT", raising=False)
 
-    pdk = get_pdk(pdk_name= "ics55", 
-                  pdk_root="{}/../icsprout55-pdk".format(root))
+    pdk = get_pdk(pdk_name="ics55", pdk_root="")
 
     assert pdk.root == str(env_root.resolve())
 
@@ -59,8 +54,7 @@ def test_get_pdk_uses_legacy_env_when_namespaced_missing(tmp_path, monkeypatch):
     monkeypatch.delenv("CHIPCOMPILER_ICS55_PDK_ROOT", raising=False)
     monkeypatch.setenv("ICS55_PDK_ROOT", str(legacy_root))
 
-    pdk = get_pdk(pdk_name= "ics55", 
-                  pdk_root="{}/../icsprout55-pdk".format(root))
+    pdk = get_pdk(pdk_name="ics55", pdk_root="")
 
     assert pdk.root == str(legacy_root.resolve())
 

--- a/test/test_data_pdk.py
+++ b/test/test_data_pdk.py
@@ -13,7 +13,7 @@ sys.path.append(root)
 
 def _create_minimal_ics55_pdk(root: Path) -> Path:
     """Create the minimal ICS55 directory tree required by get_pdk()."""
-    tech_path = root / "prtech" / "techLEF" / "N551P6M.lef"
+    tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
     tech_path.parent.mkdir(parents=True, exist_ok=True)
     tech_path.write_text("VERSION 5.8 ;\n")
 

--- a/test/test_design_parameters.py
+++ b/test/test_design_parameters.py
@@ -33,10 +33,10 @@ def test_get_parameters_returns_independent_copies():
     second = get_parameters("ics55")
 
     first.data["Design"] = "mutated"
-    first.data["Floorplan"]["Tracks"][0]["x step"] = 999
+    first.data["Core"]["Margin"][0] = 999
 
     assert second.data["Design"] == ""
-    assert second.data["Floorplan"]["Tracks"][0]["x step"] == 200
+    assert second.data["Core"]["Margin"][0] == 2
 
 
 def test_ics55_template_has_dreamplace_padding_defaults():

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -7,7 +7,7 @@ from chipcompiler.data import create_workspace, load_workspace
 
 
 def _create_minimal_ics55_pdk(root: Path) -> Path:
-    tech_path = root / "prtech" / "techLEF" / "N551P6M.lef"
+    tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
     tech_path.parent.mkdir(parents=True, exist_ok=True)
     tech_path.write_text("VERSION 5.8 ;\n")
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -54,7 +54,7 @@ def test_create_workspace_persists_pdk_root_in_parameters(tmp_path):
     assert workspace.pdk.root == resolved_root
     assert workspace.parameters.data.get("PDK Root") == resolved_root
 
-    parameters_data = json.loads((workspace_dir / "parameters.json").read_text())
+    parameters_data = json.loads((workspace_dir / "home" / "parameters.json").read_text())
     assert parameters_data.get("PDK Root") == resolved_root
 
 


### PR DESCRIPTION
- Run unit tests excluding integration tests (test_harden, test_tools) that require the full EDA toolchain
- Split ci jobs into pytest and build-wheel
- Update tests to match latest ecc api