### PR TITLE
fix(bazel): resolve pyinstaller venv from ecc repo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,7 +65,10 @@ genrule(
         set -euo pipefail
 
         ECC_ROOT="$$(dirname "$(location ecc.spec)")"
-        export PYTHON_INTERPRETER="$$ECC_ROOT/.venv/bin/python"
+        if [[ -x "$$ECC_ROOT/.venv/bin/python" ]]; then
+            export PYTHON_INTERPRETER="$$ECC_ROOT/.venv/bin/python"
+        fi
+        export PYTHONPATH="$$ECC_ROOT:$${PYTHONPATH:-}"
         export ECOS_PYINSTALLER_MODE="onedir"
         DIST_DIR="$(@D)/dist"
         WORK_DIR="$(@D)/build_ecc_cli_bundle_work"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -64,7 +64,8 @@ genrule(
     cmd = """
         set -euo pipefail
 
-        export PYTHON_INTERPRETER=".venv/bin/python"
+        ECC_ROOT="$$(dirname "$(location ecc.spec)")"
+        export PYTHON_INTERPRETER="$$ECC_ROOT/.venv/bin/python"
         export ECOS_PYINSTALLER_MODE="onedir"
         DIST_DIR="$(@D)/dist"
         WORK_DIR="$(@D)/build_ecc_cli_bundle_work"


### PR DESCRIPTION
## Summary
- Resolve the PyInstaller Python interpreter relative to the ecc repository instead of the Bazel execution working directory.
- Keep the bundle rule usable when ecc is consumed as an external Bazel repo.

## Tests
- bazel build @ecc//:build_ecc_cli_bundle