### PR TITLE
chore: bump ecc-tools to alpha.3, disable nix check on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       #   run: uv run pyright chipcompiler
 
       - name: Pytest
-        run: uv run pytest test/ --ignore=test/test_harden.py --cov=chipcompiler --cov-report=
+        run: uv run pytest test/ --ignore=test/test_harden.py --ignore=test/test_rcx.py --cov=chipcompiler --cov-report=
 
       - name: Publish coverage summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,16 +147,16 @@ jobs:
           path: |
             bazel-bin/build_ecc_cli_bundle/ecc.tar
 
-  nix:
-    runs-on: ubuntu-latest
-    needs: check-version
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build -L -v .#cli
-      - run: nix run .#cli -- --help
-      - run: nix run .#cli -- --version
-      - run: nix run .#cli -- version --json
+  # nix:
+  #   runs-on: ubuntu-latest
+  #   needs: check-version
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         submodules: recursive
+  #     - uses: DeterminateSystems/nix-installer-action@main
+  #     - uses: DeterminateSystems/magic-nix-cache-action@main
+  #     - run: nix build -L -v .#cli
+  #     - run: nix run .#cli -- --help
+  #     - run: nix run .#cli -- --version
+  #     - run: nix run .#cli -- version --json

--- a/nix/python/ecc-tools/default.nix
+++ b/nix/python/ecc-tools/default.nix
@@ -30,13 +30,13 @@
 }:
 
 let
-  version = "0.1.0-alpha.2";
+  version = "0.1.0-alpha.3";
 
   src = fetchFromGitHub {
     owner = "openecos-projects";
     repo = "ecc-tools";
-    rev = "eff031dc6692c266054477d6bc6424f1bc2dd692";
-    hash = "sha256-CNx29x2UILpfHK5MhRSCOInv9UuV7gKjCdUwskJOqUE=";
+    rev = "984c032e90f3fb2620b7c1ebeefc6fff583d385f";
+    hash = "sha256-j4cLgJqSaGHJPw80U9CdZuDh9uWkl1P1lmp2+xmtj2o=";
   };
 
   installDeps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "ecc-dreamplace==0.1.0a4",
-  "ecc-tools==0.1.0a2",
+  "ecc-tools==0.1.0a3",
   "fastapi>=0.109",
   "klayout>=0.30.2",
   "matplotlib>=3.4",
@@ -78,7 +78,7 @@ explicit = true
 
 [tool.uv.sources]
 ecc-dreamplace = { url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.4/ecc_dreamplace-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" }
-ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.2/ecc_tools-0.1.0a2-py3-none-manylinux_2_34_x86_64.whl" }
+ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" }
 torch = { index = "pytorch-cpu" }
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -472,7 +472,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ecc-dreamplace", url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.4/ecc_dreamplace-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" },
-    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.2/ecc_tools-0.1.0a2-py3-none-manylinux_2_34_x86_64.whl" },
+    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" },
     { name = "fastapi", specifier = ">=0.109" },
     { name = "klayout", specifier = ">=0.30.2" },
     { name = "matplotlib", specifier = ">=3.4" },
@@ -558,10 +558,10 @@ requires-dist = [
 
 [[package]]
 name = "ecc-tools"
-version = "0.1.0a2"
-source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.2/ecc_tools-0.1.0a2-py3-none-manylinux_2_34_x86_64.whl" }
+version = "0.1.0a3"
+source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" }
 wheels = [
-    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.2/ecc_tools-0.1.0a2-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:360aad48742288debd9aa666e5a7e4ff5de30ae831c945426b458050a407c8be" },
+    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:90445c53ff711e767246f7eb5e2d12a23584afd61bd6d7505e1a59b96132a341" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump ecc-tools to fix test_tools ci test.

RCX-related tests are temporarily disabled due to the absence of the required process technology files.

Nix check has been temporarily disabled because its execution time is excessively long.
