### PR TITLE
fix(dreamplace): support params override from workspace

### DIFF
--- a/chipcompiler/data/workspace.py
+++ b/chipcompiler/data/workspace.py
@@ -178,6 +178,8 @@ def init_workspace_config(workspace: Workspace) -> None:
     import os
     import shutil
     from copy import deepcopy
+
+    from chipcompiler.tools.ecc_dreamplace.parameter_overrides import apply_parameter_overrides
     from chipcompiler.utility import json_read, json_write
 
     if not workspace.config:
@@ -264,10 +266,7 @@ def init_workspace_config(workspace: Workspace) -> None:
     dreamplace = json_read(workspace.config["dreamplace"])
     dreamplace["lef_input"] = [workspace.pdk.tech, *workspace.pdk.lefs]
     dreamplace["base_design_name"] = workspace.design.name
-    dreamplace_overrides = workspace.parameters.data.get("DreamPlace", {})
-    if isinstance(dreamplace_overrides, dict):
-        for key, value in dreamplace_overrides.items():
-            dreamplace[key] = deepcopy(value)
+    dreamplace = apply_parameter_overrides(dreamplace, workspace.parameters.data)
     json_write(workspace.config["dreamplace"], dreamplace)
 
 

--- a/chipcompiler/tools/ecc_dreamplace/builder.py
+++ b/chipcompiler/tools/ecc_dreamplace/builder.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
-
-from chipcompiler.data import Workspace, WorkspaceStep
-from chipcompiler.data import build_workspace_config_paths
+from chipcompiler.data import Workspace, WorkspaceStep, build_workspace_config_paths
 from chipcompiler.tools.ecc import builder as ecc_builder
+from chipcompiler.tools.ecc_dreamplace.parameter_overrides import (
+    apply_parameter_overrides as _apply_parameter_overrides,
+)
 from chipcompiler.utility import json_read, json_write
 
 
@@ -14,25 +14,11 @@ def apply_parameter_overrides(
     base_params: dict,
     parameter_data: dict,
 ) -> dict:
-    """Apply direct DreamPlace overrides onto a DreamPlace config dictionary.
+    """Apply DreamPlace overrides onto a DreamPlace config dictionary.
 
-    Args:
-        base_params: The generated DreamPlace config contents.
-        parameter_data: The workspace ``home/parameters.json`` data.
-
-    Returns:
-        A copied config dictionary with ``DreamPlace`` values applied directly.
+    Kept as a compatibility entrypoint for external benchmark integrations.
     """
-    params = deepcopy(base_params)
-
-    dreamplace_overrides = parameter_data.get("DreamPlace", {})
-    if not isinstance(dreamplace_overrides, dict):
-        return params
-
-    for key, value in dreamplace_overrides.items():
-        params[key] = deepcopy(value)
-
-    return params
+    return _apply_parameter_overrides(base_params, parameter_data)
 
 
 def build_step(

--- a/chipcompiler/tools/ecc_dreamplace/builder.py
+++ b/chipcompiler/tools/ecc_dreamplace/builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from chipcompiler.data import Workspace, WorkspaceStep, build_workspace_config_paths
 from chipcompiler.tools.ecc import builder as ecc_builder
 from chipcompiler.tools.ecc_dreamplace.parameter_overrides import (
@@ -19,6 +21,21 @@ def apply_parameter_overrides(
     Kept as a compatibility entrypoint for external benchmark integrations.
     """
     return _apply_parameter_overrides(base_params, parameter_data)
+
+
+def _current_parameter_data(workspace: Workspace) -> dict:
+    parameter_path = workspace.parameters.path
+    if parameter_path and os.path.exists(parameter_path):
+        return json_read(parameter_path)
+
+    return workspace.parameters.data
+
+
+def _set_step_fields(params: dict, step: WorkspaceStep) -> dict:
+    params["def_input"] = step.input.get("def", "")
+    params["verilog_input"] = step.input.get("verilog", "")
+    params["result_dir"] = step.data.get(step.name, step.data["dir"])
+    return params
 
 
 def build_step(
@@ -59,8 +76,8 @@ def build_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
 
     params = json_read(workspace.config["dreamplace"])
 
-    params["def_input"] = step.input.get("def", "")
-    params["verilog_input"] = step.input.get("verilog", "")
-    params["result_dir"] = step.data.get(step.name, step.data["dir"])
+    params = _set_step_fields(params, step)
+    params = apply_parameter_overrides(params, _current_parameter_data(workspace))
+    params = _set_step_fields(params, step)
 
     json_write(workspace.config["dreamplace"], params)

--- a/chipcompiler/tools/ecc_dreamplace/builder.py
+++ b/chipcompiler/tools/ecc_dreamplace/builder.py
@@ -76,7 +76,6 @@ def build_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
 
     params = json_read(workspace.config["dreamplace"])
 
-    params = _set_step_fields(params, step)
     params = apply_parameter_overrides(params, _current_parameter_data(workspace))
     params = _set_step_fields(params, step)
 

--- a/chipcompiler/tools/ecc_dreamplace/module.py
+++ b/chipcompiler/tools/ecc_dreamplace/module.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 
-import importlib.machinery
 import json
 import logging
 import os
 import sys
 from contextlib import contextmanager
-from pathlib import Path
 
 from chipcompiler.data import StepEnum, Workspace, WorkspaceStep
 from chipcompiler.tools.ecc.module import ECCToolsModule
-    
+
+
 class DreamplaceModule:
     def __init__(
         self,
@@ -47,8 +45,6 @@ class DreamplaceModule:
         params.timing_opt_flag = 0
         params.timing_eval_flag = 0
         params.differentiable_timing_obj = 0
-        params.routability_opt_flag = 0
-        params.get_congestion_map = 0
 
         if legalize_only:
             params.global_place_flag = 0

--- a/chipcompiler/tools/ecc_dreamplace/parameter_overrides.py
+++ b/chipcompiler/tools/ecc_dreamplace/parameter_overrides.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+LEGACY_DREAMPLACE_PARAMETER_KEYS = {
+    "Target density": "target_density",
+    "Target overflow": "stop_overflow",
+    "Cell padding x": "cell_padding_x",
+    "Routability opt flag": "routability_opt_flag",
+}
+
+
+def apply_parameter_overrides(
+    base_params: dict,
+    parameter_data: dict,
+) -> dict:
+    """Apply workspace parameter overrides to a copied DreamPlace config."""
+    params = deepcopy(base_params)
+
+    for parameter_key, dreamplace_key in LEGACY_DREAMPLACE_PARAMETER_KEYS.items():
+        if parameter_key in parameter_data:
+            params[dreamplace_key] = deepcopy(parameter_data[parameter_key])
+
+    dreamplace_overrides = parameter_data.get("DreamPlace", {})
+    if isinstance(dreamplace_overrides, dict):
+        for key, value in dreamplace_overrides.items():
+            params[key] = deepcopy(value)
+
+    return params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "ecc-dreamplace==0.1.0a4",
-  "ecc-tools==0.1.0a3",
+  "ecc-tools==0.1.0a4",
   "fastapi>=0.109",
   "klayout>=0.30.2",
   "matplotlib>=3.4",
@@ -78,7 +78,7 @@ explicit = true
 
 [tool.uv.sources]
 ecc-dreamplace = { url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.4/ecc_dreamplace-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" }
-ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" }
+ecc-tools = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.4/ecc_tools-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" }
 torch = { index = "pytorch-cpu" }
 
 [tool.ruff]

--- a/test/formal/README.md
+++ b/test/formal/README.md
@@ -55,13 +55,13 @@ z3 proofs that `update_parameters()` recursive dict merge is correct.
 
 ### `test_param_propagation.py` -- Parameter to tool config pipeline
 
-Verifies parameters reach tool configs correctly through the builder pipeline.
+Verifies parameters reach tool configs correctly through builder/helper propagation.
 
 | Test | Method | Status |
 |------|--------|--------|
 | `test_key_spelling_matches_template` | String match against ICS55 template | XFAIL -- `"File list"` missing from template |
-| `test_dead_defaults` | z3 proves config defaults overwritten by builder | PASS (3 dead defaults found) |
-| `test_builder_forced_overrides` | z3 proves forced values are immutable | PASS |
+| `test_dead_defaults` | z3 proves config defaults overwritten by propagation | PASS (2 dead defaults found) |
+| `test_runtime_forced_overrides` | z3 proves forced values are immutable | PASS |
 | `test_propagation_z3` | z3 proves parameter reaches config field | PASS |
 
 ## Running
@@ -108,8 +108,7 @@ Documented by XFAIL tests with concrete z3 counterexamples:
 ### Parameter pipeline
 
 5. **"File list" key missing from template** -- yosys builder reads `"File list"` via `dict.get()` but ICS55 template does not define it
-6. **Dead config defaults** -- these JSON defaults are always overwritten by the builder:
-   - `dreamplace.json: target_density=0.8` -- overwritten with parameter default 0.3
-   - `dreamplace.json: routability_opt_flag=0` -- overwritten with parameter default 1
+6. **Dead config defaults** -- these JSON defaults are always overwritten by parameter propagation:
+   - `dreamplace.json: target_density=0.8` -- overwritten with parameter default 0.2
    - `no_default_config_fixfanout.json: max_fanout=32` -- overwritten with parameter default 20
-7. **Forced overrides** -- DreamPlace builder forces `timing_opt_flag`, `timing_eval_flag`, `with_sta`, `differentiable_timing_obj` to 0 regardless of parameters
+7. **Forced overrides** -- DreamPlace runtime forces timing-only fields `with_sta`, `timing_opt_flag`, `timing_eval_flag`, `differentiable_timing_obj` off regardless of parameters

--- a/test/formal/test_param_propagation.py
+++ b/test/formal/test_param_propagation.py
@@ -2,7 +2,7 @@
 Formal verification of parameter propagation through tool config builders.
 
 Verifies:
-1. Every dict.get() key in builders matches the ICS55 template exactly.
+1. Every direct workspace parameter key in builders/helpers matches the ICS55 template exactly.
 2. Parameters reach their target config fields after build.
 3. Dead defaults and forced overrides are documented.
 """
@@ -14,11 +14,13 @@ from typing import Any
 import pytest
 from z3 import ArithRef, Int, Real, Solver, unsat
 
-from chipcompiler.data import get_parameters
+from chipcompiler.data import OriginDesign, StepEnum, Workspace, WorkspaceStep, get_parameters
+from chipcompiler.tools.ecc_dreamplace.module import DreamplaceModule
+from chipcompiler.utility import json_write
 
-# Every parameter key accessed by dict.get() in builder files,
-# with the builder file and line where it is accessed.
-# Source: ecc/builder.py, ecc_dreamplace/builder.py, yosys/builder.py
+# Every direct workspace parameter key accessed by builder/helper code,
+# with the source file and line where it is accessed.
+# Source: ecc/builder.py, ecc_dreamplace/parameter_overrides.py, yosys/builder.py
 BUILDER_PARAM_KEYS: list[tuple[str, str, str]] = [
     # (key_string, builder_file, config_field)
     ("Bottom layer", "ecc/builder.py:244", "db.LayerSettings.routing_layer_1st"),
@@ -26,10 +28,26 @@ BUILDER_PARAM_KEYS: list[tuple[str, str, str]] = [
     ("Top layer", "ecc/builder.py:330", "RT.-top_routing_layer"),
     ("Max fanout", "ecc/builder.py:259", "no.max_fanout"),
     ("Global right padding", "ecc/builder.py:273", "PL.GP.global_right_padding"),
-    ("Target density", "ecc_dreamplace/builder.py:55", "dreamplace.target_density"),
-    ("Target overflow", "ecc_dreamplace/builder.py:58", "dreamplace.stop_overflow"),
-    ("Cell padding x", "ecc_dreamplace/builder.py:61", "dreamplace.cell_padding_x"),
-    ("Routability opt flag", "ecc_dreamplace/builder.py:64", "dreamplace.routability_opt_flag"),
+    (
+        "Target density",
+        "ecc_dreamplace/parameter_overrides.py:8",
+        "dreamplace.target_density",
+    ),
+    (
+        "Target overflow",
+        "ecc_dreamplace/parameter_overrides.py:9",
+        "dreamplace.stop_overflow",
+    ),
+    (
+        "Cell padding x",
+        "ecc_dreamplace/parameter_overrides.py:10",
+        "dreamplace.cell_padding_x",
+    ),
+    (
+        "Routability opt flag",
+        "ecc_dreamplace/parameter_overrides.py:11",
+        "dreamplace.routability_opt_flag",
+    ),
     ("Frequency max [MHz]", "yosys/builder.py:31", "yosys.clk_freq_mhz"),
     ("File list", "yosys/builder.py:38", "yosys.filelist"),
 ]
@@ -40,7 +58,7 @@ BUILDER_PARAM_KEYS: list[tuple[str, str, str]] = [
     strict=False,
 )
 def test_key_spelling_matches_template() -> None:
-    """Every parameter key used in dict.get() calls in builders must exist
+    """Every direct workspace parameter key used in config propagation must exist
     in the ICS55 template. A typo like 'target density' (lowercase) when
     the template has 'Target density' (capitalized) means the override
     silently falls back to the default."""
@@ -72,7 +90,7 @@ PARAM_CONFIG_DEFAULTS: list[tuple[str, float, float, str]] = [
     ("Target density", 0.2, 0.8, "dreamplace.target_density"),
     ("Target overflow", 0.1, 0.1, "dreamplace.stop_overflow"),
     ("Cell padding x", 600, 600, "dreamplace.cell_padding_x"),
-    ("Routability opt flag", 1, 0, "dreamplace.routability_opt_flag"),
+    ("Routability opt flag", 1, 1, "dreamplace.routability_opt_flag"),
     ("Max fanout", 20, 32, "no.max_fanout"),
     ("Global right padding", 0, 0, "PL.GP.global_right_padding"),
 ]
@@ -87,10 +105,10 @@ def test_dead_defaults(
     param_key: str, param_default: float, config_default: float, config_field: str
 ) -> None:
     """z3: if param_default != config_default, the JSON config default is dead
-    code (the builder always overwrites it with the parameter value).
+    code (parameter propagation always overwrites it with the parameter value).
 
     Query: can config end up with its own default while param differs?
-    UNSAT = config default is dead (builder always overwrites).
+    UNSAT = config default is dead (propagation always overwrites).
     """
     if param_default == config_default:
         pytest.skip("Defaults match -- config default is not dead")
@@ -99,7 +117,7 @@ def test_dead_defaults(
     config_val: ArithRef = Real("config_val")
 
     solver = Solver()
-    # Builder logic: config_val = param_val (always reads from parameters)
+    # Propagation logic: config_val = param_val (always reads from parameters)
     solver.add(config_val == param_val)
     # Can the config end up with its own default while param has a different value?
     solver.add(config_val == config_default)
@@ -108,16 +126,16 @@ def test_dead_defaults(
     result = solver.check()
     assert result == unsat, (
         f"Config default {config_default} for {config_field} is dead code: "
-        f"builder always overwrites with parameter value (param default={param_default})"
+        f"propagation always overwrites with parameter value (param default={param_default})"
     )
 
 
-# Forced overrides: builder sets these regardless of parameters.
+# Forced runtime overrides: DreamplaceModule._build_params sets these regardless of parameters.
 FORCED_OVERRIDES: list[tuple[str, int, str]] = [
-    ("timing_opt_flag", 0, "dreamplace/builder.py:67"),
-    ("timing_eval_flag", 0, "dreamplace/builder.py:68"),
-    ("with_sta", 0, "dreamplace/builder.py:69"),
-    ("differentiable_timing_obj", 0, "dreamplace/builder.py:70"),
+    ("with_sta", 0, "ecc_dreamplace/module.py:44"),
+    ("timing_opt_flag", 0, "ecc_dreamplace/module.py:45"),
+    ("timing_eval_flag", 0, "ecc_dreamplace/module.py:46"),
+    ("differentiable_timing_obj", 0, "ecc_dreamplace/module.py:47"),
 ]
 
 
@@ -126,9 +144,9 @@ FORCED_OVERRIDES: list[tuple[str, int, str]] = [
     FORCED_OVERRIDES,
     ids=[t[0] for t in FORCED_OVERRIDES],
 )
-def test_builder_forced_overrides(config_field: str, forced_value: int, source_line: str) -> None:
+def test_runtime_forced_overrides(config_field: str, forced_value: int, source_line: str) -> None:
     """z3: these config fields are always forced to a specific value by the
-    builder, regardless of any parameter setting. Verify the forced value
+    runtime module, regardless of any parameter setting. Verify the forced value
     is intentional by proving that no parameter can change it.
 
     Query: config_val != forced_value. Must be UNSAT.
@@ -146,13 +164,53 @@ def test_builder_forced_overrides(config_field: str, forced_value: int, source_l
     )
 
 
+class FakeDreamplaceParams:
+    def fromJson(self, config):
+        self.__dict__.update(config)
+
+
+def test_routability_runtime_flags_are_config_driven(tmp_path) -> None:
+    config_path = tmp_path / "dreamplace.json"
+    json_write(
+        str(config_path),
+        {
+            "routability_opt_flag": 1,
+            "get_congestion_map": 1,
+        },
+    )
+    workspace = Workspace(
+        directory=str(tmp_path / "workspace"),
+        design=OriginDesign(name="gcd"),
+        config={"dreamplace": str(config_path)},
+    )
+    result_dir = tmp_path / "data" / "pl"
+    step = WorkspaceStep(
+        name=StepEnum.PLACEMENT.value,
+        data={"dir": str(tmp_path / "data"), StepEnum.PLACEMENT.value: str(result_dir)},
+    )
+    module = DreamplaceModule(
+        workspace=workspace,
+        step=step,
+        ecc_module=None,
+        input_def="input.def",
+        input_verilog="input.v",
+        output_def="output.def",
+        output_verilog="output.v",
+    )
+
+    params = module._build_params(FakeDreamplaceParams, legalize_only=False)
+
+    assert params.routability_opt_flag == 1
+    assert params.get_congestion_map == 1
+
+
 # ---------------------------------------------------------------------------
 # z3: End-to-end parameter propagation model
 # ---------------------------------------------------------------------------
 
 # Complete parameter -> config propagation mapping.
 # (param_key, config_field, reads_param)
-# reads_param is True if the builder uses dict.get(param_key).
+# reads_param is True if the builder/helper propagates the parameter.
 PROPAGATION_MAP: list[tuple[str, str, bool]] = [
     ("Target density", "dreamplace.target_density", True),
     ("Target overflow", "dreamplace.stop_overflow", True),
@@ -181,7 +239,7 @@ def test_propagation_z3(param_key: str, config_field: str, reads_param: bool) ->
 
     Query: Exists(param_val): config_val != param_val
     UNSAT = parameter always propagates.
-    SAT = builder ignores parameter.
+    SAT = propagation ignores parameter.
     """
     param_val: ArithRef = Real("param_val")
     config_val: ArithRef = Real("config_val")
@@ -195,6 +253,6 @@ def test_propagation_z3(param_key: str, config_field: str, reads_param: bool) ->
         assert result == unsat, f"Parameter '{param_key}' should always propagate to {config_field}"
     else:
         pytest.fail(
-            f"Parameter '{param_key}' is NOT read by builder for {config_field} -- "
+            f"Parameter '{param_key}' is NOT propagated to {config_field} -- "
             f"it is dead in the template"
         )

--- a/test/test_ecc_dreamplace_config_permissions.py
+++ b/test/test_ecc_dreamplace_config_permissions.py
@@ -4,7 +4,7 @@ import stat
 from chipcompiler.data import PDK, OriginDesign, Parameters, StepEnum, Workspace
 from chipcompiler.data.workspace import init_workspace_config
 from chipcompiler.tools.ecc_dreamplace import builder as dreamplace_builder
-from chipcompiler.utility import json_read, json_write
+from chipcompiler.utility import json_read
 
 
 def test_workspace_config_generation_leaves_config_root_writable_after_read_only_copy(
@@ -88,3 +88,46 @@ def test_dreamplace_config_generation_writes_generated_fields_to_copied_config(
     assert data["verilog_input"] == "input.v"
     assert data["result_dir"] == step.data[step.name]
     assert data["base_design_name"] == "gcd"
+
+
+def test_workspace_config_generation_applies_flat_dreamplace_parameter_overrides(tmp_path):
+    workspace = Workspace(
+        directory=str(tmp_path / "workspace"),
+        design=OriginDesign(name="gcd"),
+        pdk=PDK(tech="tech.lef", lefs=["std.lef"]),
+        parameters=Parameters(
+            data={
+                "Target density": 0.65,
+                "Target overflow": 0.05,
+                "Cell padding x": 800,
+                "Routability opt flag": 1,
+            }
+        ),
+    )
+
+    init_workspace_config(workspace)
+
+    dreamplace_config = json_read(workspace.config["dreamplace"])
+    assert dreamplace_config["target_density"] == 0.65
+    assert dreamplace_config["stop_overflow"] == 0.05
+    assert dreamplace_config["cell_padding_x"] == 800
+    assert dreamplace_config["routability_opt_flag"] == 1
+
+
+def test_workspace_config_generation_nested_dreamplace_overrides_win_over_flat_keys(tmp_path):
+    workspace = Workspace(
+        directory=str(tmp_path / "workspace"),
+        design=OriginDesign(name="gcd"),
+        pdk=PDK(tech="tech.lef", lefs=["std.lef"]),
+        parameters=Parameters(
+            data={
+                "Routability opt flag": 1,
+                "DreamPlace": {"routability_opt_flag": 0},
+            }
+        ),
+    )
+
+    init_workspace_config(workspace)
+
+    dreamplace_config = json_read(workspace.config["dreamplace"])
+    assert dreamplace_config["routability_opt_flag"] == 0

--- a/test/test_ecc_dreamplace_config_permissions.py
+++ b/test/test_ecc_dreamplace_config_permissions.py
@@ -4,7 +4,7 @@ import stat
 from chipcompiler.data import PDK, OriginDesign, Parameters, StepEnum, Workspace
 from chipcompiler.data.workspace import init_workspace_config
 from chipcompiler.tools.ecc_dreamplace import builder as dreamplace_builder
-from chipcompiler.utility import json_read
+from chipcompiler.utility import json_read, json_write
 
 
 def test_workspace_config_generation_leaves_config_root_writable_after_read_only_copy(
@@ -131,3 +131,46 @@ def test_workspace_config_generation_nested_dreamplace_overrides_win_over_flat_k
 
     dreamplace_config = json_read(workspace.config["dreamplace"])
     assert dreamplace_config["routability_opt_flag"] == 0
+
+
+def test_dreamplace_step_config_refresh_reapplies_current_parameter_file(tmp_path, monkeypatch):
+    workspace = Workspace(
+        directory=str(tmp_path / "workspace"),
+        design=OriginDesign(name="gcd"),
+        pdk=PDK(tech="tech.lef", lefs=["std.lef"]),
+        parameters=Parameters(data={"Target density": 0.65}),
+    )
+    (tmp_path / "workspace" / "home").mkdir(parents=True)
+    workspace.parameters.path = str(tmp_path / "workspace" / "home" / "parameters.json")
+    step = dreamplace_builder.build_step(
+        workspace=workspace,
+        step_name=StepEnum.PLACEMENT.value,
+        input_def="input.def",
+        input_verilog="input.v",
+    )
+
+    init_workspace_config(workspace)
+    json_write(
+        workspace.parameters.path,
+        {
+            "Target density": 0.7,
+            "DreamPlace": {
+                "def_input": "stale.def",
+                "verilog_input": "stale.v",
+                "result_dir": "stale-output",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        dreamplace_builder.ecc_builder,
+        "build_step_config",
+        lambda _workspace, _step: None,
+    )
+
+    dreamplace_builder.build_step_config(workspace, step)
+
+    dreamplace_config = json_read(workspace.config["dreamplace"])
+    assert dreamplace_config["target_density"] == 0.7
+    assert dreamplace_config["def_input"] == "input.def"
+    assert dreamplace_config["verilog_input"] == "input.v"
+    assert dreamplace_config["result_dir"] == step.data[step.name]

--- a/test/test_ecc_dreamplace_module.py
+++ b/test/test_ecc_dreamplace_module.py
@@ -1,0 +1,55 @@
+from chipcompiler.data import OriginDesign, StepEnum, Workspace, WorkspaceStep
+from chipcompiler.tools.ecc_dreamplace.module import DreamplaceModule
+from chipcompiler.utility import json_write
+
+
+class FakeParams:
+    def fromJson(self, config):
+        self.__dict__.update(config)
+
+
+def test_build_params_preserves_routability_config_and_forces_timing_off(tmp_path):
+    config_path = tmp_path / "dreamplace.json"
+    json_write(
+        str(config_path),
+        {
+            "routability_opt_flag": 1,
+            "get_congestion_map": 1,
+            "with_sta": True,
+            "timing_opt_flag": 1,
+            "timing_eval_flag": 1,
+            "differentiable_timing_obj": 1,
+        },
+    )
+    workspace = Workspace(
+        directory=str(tmp_path / "workspace"),
+        design=OriginDesign(name="gcd"),
+        config={"dreamplace": str(config_path)},
+    )
+    result_dir = tmp_path / "data" / "pl"
+    step = WorkspaceStep(
+        name=StepEnum.PLACEMENT.value,
+        data={"dir": str(tmp_path / "data"), StepEnum.PLACEMENT.value: str(result_dir)},
+    )
+    module = DreamplaceModule(
+        workspace=workspace,
+        step=step,
+        ecc_module=None,
+        input_def="input.def",
+        input_verilog="input.v",
+        output_def="output.def",
+        output_verilog="output.v",
+    )
+
+    params = module._build_params(FakeParams, legalize_only=False)
+
+    assert params.routability_opt_flag == 1
+    assert params.get_congestion_map == 1
+    assert params.with_sta is False
+    assert params.timing_opt_flag == 0
+    assert params.timing_eval_flag == 0
+    assert params.differentiable_timing_obj == 0
+    assert params.def_input == "input.def"
+    assert params.verilog_input == "input.v"
+    assert params.result_dir == str(result_dir)
+    assert params.base_design_name == "gcd"

--- a/test/test_ecc_dreamplace_parameter_overrides.py
+++ b/test/test_ecc_dreamplace_parameter_overrides.py
@@ -1,0 +1,77 @@
+from chipcompiler.tools.ecc_dreamplace.parameter_overrides import (
+    apply_parameter_overrides,
+)
+
+
+def test_flat_legacy_keys_map_to_dreamplace_fields():
+    base = {
+        "target_density": 0.8,
+        "stop_overflow": 0.1,
+        "cell_padding_x": 600,
+        "routability_opt_flag": 0,
+    }
+    parameter_data = {
+        "Target density": 0.65,
+        "Target overflow": 0.05,
+        "Cell padding x": 800,
+        "Routability opt flag": 1,
+    }
+
+    result = apply_parameter_overrides(base, parameter_data)
+
+    assert result["target_density"] == 0.65
+    assert result["stop_overflow"] == 0.05
+    assert result["cell_padding_x"] == 800
+    assert result["routability_opt_flag"] == 1
+
+
+def test_nested_dreamplace_overrides_are_applied():
+    base = {"routability_opt_flag": 0, "target_density": 0.8}
+    parameter_data = {
+        "DreamPlace": {
+            "routability_opt_flag": 1,
+            "target_density": 0.7,
+        },
+    }
+
+    result = apply_parameter_overrides(base, parameter_data)
+
+    assert result["routability_opt_flag"] == 1
+    assert result["target_density"] == 0.7
+
+
+def test_nested_dreamplace_overrides_win_over_flat_keys():
+    base = {"routability_opt_flag": 0}
+    parameter_data = {
+        "Routability opt flag": 1,
+        "DreamPlace": {"routability_opt_flag": 0},
+    }
+
+    result = apply_parameter_overrides(base, parameter_data)
+
+    assert result["routability_opt_flag"] == 0
+
+
+def test_non_dict_dreamplace_value_keeps_flat_mappings():
+    base = {"routability_opt_flag": 0}
+    parameter_data = {
+        "Routability opt flag": 1,
+        "DreamPlace": "invalid",
+    }
+
+    result = apply_parameter_overrides(base, parameter_data)
+
+    assert result["routability_opt_flag"] == 1
+
+
+def test_apply_parameter_overrides_copies_inputs():
+    base = {"nested": {"value": 1}}
+    parameter_data = {"DreamPlace": {"list_value": [1, 2, 3]}}
+
+    result = apply_parameter_overrides(base, parameter_data)
+
+    result["nested"]["value"] = 2
+    result["list_value"].append(4)
+
+    assert base == {"nested": {"value": 1}}
+    assert parameter_data == {"DreamPlace": {"list_value": [1, 2, 3]}}

--- a/uv.lock
+++ b/uv.lock
@@ -472,7 +472,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ecc-dreamplace", url = "https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.4/ecc_dreamplace-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" },
-    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" },
+    { name = "ecc-tools", url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.4/ecc_tools-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" },
     { name = "fastapi", specifier = ">=0.109" },
     { name = "klayout", specifier = ">=0.30.2" },
     { name = "matplotlib", specifier = ">=3.4" },
@@ -558,10 +558,10 @@ requires-dist = [
 
 [[package]]
 name = "ecc-tools"
-version = "0.1.0a3"
-source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl" }
+version = "0.1.0a4"
+source = { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.4/ecc_tools-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl" }
 wheels = [
-    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.3/ecc_tools-0.1.0a3-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:90445c53ff711e767246f7eb5e2d12a23584afd61bd6d7505e1a59b96132a341" },
+    { url = "https://github.com/openecos-projects/ecc-tools/releases/download/v0.1.0-alpha.4/ecc_tools-0.1.0a4-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:b06e46e5a7e8bd116d607e08654c2f2f13fcd6a500f2804de96994195d34a74c" },
 ]
 
 [[package]]


### PR DESCRIPTION
Previously, due to [2fa930c](https://github.com/openecos-projects/ecc/commit/2fa930c9f7a158f2d3e6480b34faad51cda703ac), the parameter override mechanism was removed to maintain compatibility with the benchmark parameter configuration approach.

Now, a benchmark-compatible parameter override method is reintroduced.
