### PR TITLE
fix(cli): initialize DB for workspace run-step

### DIFF
--- a/chipcompiler/cli/app.py
+++ b/chipcompiler/cli/app.py
@@ -5,9 +5,9 @@ from typing import Annotated
 import click
 import typer
 
+from chipcompiler.cli.commands import workspace as workspace_commands
 from chipcompiler.cli.commands.param import param_app
 from chipcompiler.cli.commands.project import register_project_commands
-from chipcompiler.cli.commands.workspace import workspace_app
 from chipcompiler.cli.core.version_info import root_version_line, version_payload, version_text
 
 app = typer.Typer(
@@ -52,10 +52,14 @@ def version_cmd(
 
 register_project_commands(app)
 app.add_typer(param_app, name="param")
-app.add_typer(workspace_app, name="workspace")
+app.add_typer(workspace_commands.workspace_app, name="workspace")
 
 
-def invoke_typer_app(argv: Sequence[str]) -> int:
+def invoke_typer_app(
+    argv: Sequence[str],
+    *,
+    keep_workspace_json_stdio_redirect: bool = False,
+) -> int:
     if not argv:
         command = typer.main.get_command(app)
         click.echo(command.get_help(click.Context(command, info_name="ecc")), err=True)
@@ -63,11 +67,14 @@ def invoke_typer_app(argv: Sequence[str]) -> int:
 
     command = typer.main.get_command(app)
     try:
-        result = command.main(
-            args=list(argv),
-            prog_name="ecc",
-            standalone_mode=False,
-        )
+        with workspace_commands.keep_json_stdio_redirect(
+            keep_workspace_json_stdio_redirect
+        ):
+            result = command.main(
+                args=list(argv),
+                prog_name="ecc",
+                standalone_mode=False,
+            )
     except click.exceptions.Exit as exc:
         return int(exc.exit_code or 0)
     except click.ClickException as exc:

--- a/chipcompiler/cli/commands/workspace.py
+++ b/chipcompiler/cli/commands/workspace.py
@@ -1,6 +1,8 @@
+import json
+import os
 import sys
 from collections.abc import Callable
-from contextlib import redirect_stdout
+from contextlib import contextmanager, redirect_stdout, suppress
 from typing import Annotated
 
 import typer
@@ -27,17 +29,144 @@ workspace_app = typer.Typer(
     help="Manage legacy runtime workspaces",
 )
 
+_KEEP_JSON_STDIO_REDIRECT = False
 
-def _finish(result: dict, json_output: bool) -> None:
-    render_workspace_response(result, json_output)
+
+@contextmanager
+def keep_json_stdio_redirect(enabled: bool):
+    global _KEEP_JSON_STDIO_REDIRECT
+
+    previous = _KEEP_JSON_STDIO_REDIRECT
+    _KEEP_JSON_STDIO_REDIRECT = enabled
+    try:
+        yield
+    finally:
+        _KEEP_JSON_STDIO_REDIRECT = previous
+
+
+def _finish(result: dict, json_output: bool, output_stream=None) -> None:
+    if json_output and output_stream is not None:
+        print(json.dumps(result, ensure_ascii=False), file=output_stream)
+    else:
+        render_workspace_response(result, json_output)
     raise typer.Exit(code=exit_code_for_response(result["response"]))
 
 
-def _call_runtime(callback: Callable[[], dict], json_output: bool) -> dict:
-    if not json_output:
-        return callback()
-    with redirect_stdout(sys.stderr):
-        return callback()
+@contextmanager
+def _preserve_cli_stdio():
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdout_fd = None
+    saved_stderr_fd = None
+
+    for stream in (sys.stdout, sys.stderr):
+        with suppress(Exception):
+            stream.flush()
+
+    try:
+        saved_stdout_fd = os.dup(1)
+        saved_stderr_fd = os.dup(2)
+    except OSError:
+        if saved_stdout_fd is not None:
+            os.close(saved_stdout_fd)
+        try:
+            yield
+        finally:
+            sys.stdout = saved_stdout
+            sys.stderr = saved_stderr
+        return
+
+    try:
+        yield
+    finally:
+        for stream in (sys.stdout, sys.stderr):
+            with suppress(Exception):
+                stream.flush()
+
+        try:
+            os.dup2(saved_stdout_fd, 1)
+            os.dup2(saved_stderr_fd, 2)
+        finally:
+            os.close(saved_stdout_fd)
+            os.close(saved_stderr_fd)
+            sys.stdout = saved_stdout
+            sys.stderr = saved_stderr
+
+
+@contextmanager
+def _json_runtime_stdio():
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdout_fd = None
+    saved_stderr_fd = None
+    output_stream = None
+    close_output_stream = False
+
+    for stream in (sys.stdout, sys.stderr):
+        with suppress(Exception):
+            stream.flush()
+
+    try:
+        saved_stdout_fd = os.dup(1)
+        saved_stderr_fd = os.dup(2)
+        try:
+            saved_stdout_file_fd = saved_stdout.fileno()
+        except (AttributeError, OSError, ValueError):
+            output_stream = saved_stdout
+        else:
+            if saved_stdout_file_fd == 1:
+                output_stream = os.fdopen(
+                    os.dup(saved_stdout_fd),
+                    "w",
+                    encoding=getattr(saved_stdout, "encoding", None) or "utf-8",
+                    buffering=1,
+                    closefd=True,
+                )
+                close_output_stream = True
+            else:
+                output_stream = saved_stdout
+        os.dup2(2, 1)
+        sys.stdout = sys.stderr
+    except OSError:
+        for fd in (saved_stdout_fd, saved_stderr_fd):
+            if fd is not None:
+                os.close(fd)
+        if close_output_stream and output_stream is not None:
+            output_stream.close()
+        with redirect_stdout(sys.stderr):
+            yield None
+        return
+
+    try:
+        yield output_stream
+    finally:
+        for stream in (sys.stdout, sys.stderr):
+            with suppress(Exception):
+                stream.flush()
+
+        try:
+            if not (close_output_stream and _KEEP_JSON_STDIO_REDIRECT):
+                os.dup2(saved_stdout_fd, 1)
+                os.dup2(saved_stderr_fd, 2)
+        finally:
+            os.close(saved_stdout_fd)
+            os.close(saved_stderr_fd)
+            if close_output_stream and output_stream is not None:
+                output_stream.close()
+            sys.stdout = saved_stdout
+            sys.stderr = saved_stderr
+
+
+def _dispatch_runtime(callback: Callable[[], dict], json_output: bool) -> None:
+    if json_output:
+        with _json_runtime_stdio() as output_stream:
+            result = callback()
+            _finish(result, json_output, output_stream=output_stream)
+        return
+
+    with _preserve_cli_stdio():
+        result = callback()
+    _finish(result, json_output)
 
 
 @workspace_app.command("create", help="Create a legacy runtime workspace")
@@ -76,7 +205,8 @@ def create_cmd(
     except InputError as exc:
         result = workspace_response("create_workspace", exc.response, message=[str(exc)])
     else:
-        result = _call_runtime(lambda: create_workspace_from_request(request), json_output)
+        _dispatch_runtime(lambda: create_workspace_from_request(request), json_output)
+        return
     _finish(result, json_output)
 
 
@@ -85,7 +215,7 @@ def load_cmd(
     directory: Annotated[str, typer.Option("--directory")] = "",
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    _finish(_call_runtime(lambda: load_workspace(directory), json_output), json_output)
+    _dispatch_runtime(lambda: load_workspace(directory), json_output)
 
 
 @workspace_app.command("run-flow", help="Run the workspace flow")
@@ -94,7 +224,7 @@ def run_flow_cmd(
     rerun: Annotated[bool, typer.Option("--rerun")] = False,
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    _finish(_call_runtime(lambda: run_workspace_flow(directory, rerun), json_output), json_output)
+    _dispatch_runtime(lambda: run_workspace_flow(directory, rerun), json_output)
 
 
 @workspace_app.command("run-step", help="Run one workspace step")
@@ -104,8 +234,7 @@ def run_step_cmd(
     rerun: Annotated[bool, typer.Option("--rerun")] = False,
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    result = _call_runtime(lambda: run_workspace_step(directory, step, rerun), json_output)
-    _finish(result, json_output)
+    _dispatch_runtime(lambda: run_workspace_step(directory, step, rerun), json_output)
 
 
 @workspace_app.command("get-info", help="Show workspace or step runtime information")
@@ -115,8 +244,7 @@ def get_info_cmd(
     info_id: Annotated[str, typer.Option("--id")] = "",
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    result = _call_runtime(lambda: get_workspace_info(directory, step, info_id), json_output)
-    _finish(result, json_output)
+    _dispatch_runtime(lambda: get_workspace_info(directory, step, info_id), json_output)
 
 
 @workspace_app.command("get-home", help="Show workspace home-page data")
@@ -124,4 +252,4 @@ def get_home_cmd(
     directory: Annotated[str, typer.Option("--directory")] = "",
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
-    _finish(_call_runtime(lambda: get_workspace_home(directory), json_output), json_output)
+    _dispatch_runtime(lambda: get_workspace_home(directory), json_output)

--- a/chipcompiler/cli/main.py
+++ b/chipcompiler/cli/main.py
@@ -2,16 +2,23 @@ import sys
 from collections.abc import Sequence
 
 
-def run(argv: Sequence[str] | None = None) -> int:
+def run(
+    argv: Sequence[str] | None = None,
+    *,
+    _keep_workspace_json_stdio_redirect: bool = False,
+) -> int:
     raw = list(argv) if argv is not None else sys.argv[1:]
 
     from chipcompiler.cli.app import invoke_typer_app
 
-    return invoke_typer_app(raw)
+    return invoke_typer_app(
+        raw,
+        keep_workspace_json_stdio_redirect=_keep_workspace_json_stdio_redirect,
+    )
 
 
 def main() -> None:
-    sys.exit(run())
+    sys.exit(run(_keep_workspace_json_stdio_redirect=True))
 
 
 if __name__ == "__main__":

--- a/chipcompiler/cli/workspace/service.py
+++ b/chipcompiler/cli/workspace/service.py
@@ -8,7 +8,6 @@ from chipcompiler.cli.workspace.request import (
     write_filelist,
 )
 from chipcompiler.cli.workspace.response import workspace_response
-from chipcompiler.data import StateEnum
 
 
 def create_workspace_from_request(request: WorkspaceCreateRequest) -> dict:
@@ -158,15 +157,18 @@ def run_workspace_step(directory: str, step: str, rerun: bool) -> dict:
         workspace_step = engine_flow.get_workspace_step(step)
         if workspace_step is None:
             state = engine_flow.run_step(step, rerun)
-        elif not rerun and engine_flow.check_state(
-            name=workspace_step.name,
-            tool=workspace_step.tool,
-            state=StateEnum.Success,
-        ):
-            state = engine_flow.run_step(workspace_step, rerun)
         else:
-            _init_db_engine_for_workspace_step(engine_flow, workspace_step)
-            state = engine_flow.run_step(workspace_step, rerun)
+            from chipcompiler.data.step import StateEnum
+
+            if not rerun and engine_flow.check_state(
+                name=workspace_step.name,
+                tool=workspace_step.tool,
+                state=StateEnum.Success,
+            ):
+                state = engine_flow.run_step(workspace_step, rerun)
+            else:
+                _init_db_engine_for_workspace_step(engine_flow, workspace_step)
+                state = engine_flow.run_step(workspace_step, rerun)
     except WorkspaceValidationError as exc:
         return workspace_response(cmd, "failed", data=response_data, message=[str(exc)])
     except Exception as exc:

--- a/chipcompiler/cli/workspace/service.py
+++ b/chipcompiler/cli/workspace/service.py
@@ -165,7 +165,7 @@ def run_workspace_step(directory: str, step: str, rerun: bool) -> dict:
         ):
             state = engine_flow.run_step(workspace_step, rerun)
         else:
-            engine_flow.init_db_engine()
+            _init_db_engine_for_workspace_step(engine_flow, workspace_step)
             state = engine_flow.run_step(workspace_step, rerun)
     except WorkspaceValidationError as exc:
         return workspace_response(cmd, "failed", data=response_data, message=[str(exc)])
@@ -313,6 +313,19 @@ def build_flow_for_workspace(workspace, create_step_workspaces: bool = True):
     if create_step_workspaces:
         engine_flow.create_step_workspaces()
     return engine_flow
+
+
+def _init_db_engine_for_workspace_step(engine_flow, workspace_step):
+    engine_db = getattr(engine_flow, "engine_db", None)
+    if engine_db is None:
+        from chipcompiler.engine import EngineDB
+
+        engine_db = EngineDB(workspace=engine_flow.workspace)
+        engine_flow.engine_db = engine_db
+    elif engine_db.has_init():
+        return True
+
+    return engine_db.create_db_engine(step=workspace_step)
 
 
 def _workspace_step_from_flow(workspace, name: str):

--- a/chipcompiler/cli/workspace/service.py
+++ b/chipcompiler/cli/workspace/service.py
@@ -8,6 +8,7 @@ from chipcompiler.cli.workspace.request import (
     write_filelist,
 )
 from chipcompiler.cli.workspace.response import workspace_response
+from chipcompiler.data import StateEnum
 
 
 def create_workspace_from_request(request: WorkspaceCreateRequest) -> dict:
@@ -154,7 +155,18 @@ def run_workspace_step(directory: str, step: str, rerun: bool) -> dict:
 
     try:
         workspace, engine_flow = load_workspace_runtime(directory)
-        state = engine_flow.run_step(step, rerun)
+        workspace_step = engine_flow.get_workspace_step(step)
+        if workspace_step is None:
+            state = engine_flow.run_step(step, rerun)
+        elif not rerun and engine_flow.check_state(
+            name=workspace_step.name,
+            tool=workspace_step.tool,
+            state=StateEnum.Success,
+        ):
+            state = engine_flow.run_step(workspace_step, rerun)
+        else:
+            engine_flow.init_db_engine()
+            state = engine_flow.run_step(workspace_step, rerun)
     except WorkspaceValidationError as exc:
         return workspace_response(cmd, "failed", data=response_data, message=[str(exc)])
     except Exception as exc:

--- a/nix/python/ecc-dreamplace/default.nix
+++ b/nix/python/ecc-dreamplace/default.nix
@@ -22,7 +22,7 @@
   setuptools,
   shapely,
   torch,
-  uv-build,
+  hatchling,
   wheel,
 }:
 
@@ -94,14 +94,9 @@ buildPythonPackage {
 
   src = rootSrc;
 
-  build-system = [ uv-build ];
+  build-system = [ hatchling ];
 
   buildInputs = runtimeInputs;
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'uv_build>=0.10.9,<0.12' 'uv_build>=0.10.0,<0.12'
-  '';
 
   preBuild = ''
     cp -r ${runtime}/dreamplace/. dreamplace/

--- a/nix/python/ecc-dreamplace/default.nix
+++ b/nix/python/ecc-dreamplace/default.nix
@@ -32,7 +32,7 @@ let
   rootSrc = fetchFromGitHub {
     owner = "openecos-projects";
     repo = "ecc-dreamplace";
-    rev = "v${version}";
+    rev = "1e9d038870efa0141b6122e120456c7eb05c8fee";
     hash = "sha256-EoxYaAwSnr/PwRnUxeeZrrqJx4VNwEARjP8HapAfFlQ=";
     fetchSubmodules = true;
   };

--- a/nix/python/ecc-tools/default.nix
+++ b/nix/python/ecc-tools/default.nix
@@ -30,19 +30,18 @@
 }:
 
 let
-  version = "0.1.0-alpha.3";
+  version = "0.1.0-alpha.4";
 
   src = fetchFromGitHub {
     owner = "openecos-projects";
     repo = "ecc-tools";
-    rev = "984c032e90f3fb2620b7c1ebeefc6fff583d385f";
-    hash = "sha256-j4cLgJqSaGHJPw80U9CdZuDh9uWkl1P1lmp2+xmtj2o=";
+    rev = "af793d33efe91c37f42bfe00eb737427de43715a";
+    hash = "sha256-wD3mGge2vhGoXDIpanyRZGl1tTRmQJodDOmp8Lw2aC0=";
   };
 
   installDeps =
     lib.pipe
       {
-        iir-rust = "src/operation/iIR/source/iir-rust/iir";
         sdf_parser = "src/database/manager/parser/sdf/sdf_parse";
         vcd_parser = "src/database/manager/parser/vcd/vcd_parser";
         verilog-parser = "src/database/manager/parser/verilog/verilog-rust/verilog-parser";

--- a/test/cli/test_typer_cli.py
+++ b/test/cli/test_typer_cli.py
@@ -194,8 +194,9 @@ def test_run_set_remains_repeatable(monkeypatch, tmp_path):
 def test_workspace_routes_through_root_typer(monkeypatch):
     seen = {}
 
-    def fake_invoke(argv):
+    def fake_invoke(argv, *, keep_workspace_json_stdio_redirect=False):
         seen["argv"] = argv
+        seen["keep_workspace_json_stdio_redirect"] = keep_workspace_json_stdio_redirect
         return 17
 
     monkeypatch.setattr("chipcompiler.cli.app.invoke_typer_app", fake_invoke)
@@ -204,6 +205,48 @@ def test_workspace_routes_through_root_typer(monkeypatch):
 
     assert rc == 17
     assert seen["argv"] == ["workspace", "create", "--pdk-root", "/pdk"]
+    assert seen["keep_workspace_json_stdio_redirect"] is False
+
+
+def test_run_default_argv_keeps_programmatic_stdio_redirect_disabled(monkeypatch):
+    seen = {}
+
+    def fake_invoke(argv, *, keep_workspace_json_stdio_redirect=False):
+        seen["argv"] = argv
+        seen["keep_workspace_json_stdio_redirect"] = keep_workspace_json_stdio_redirect
+        return 17
+
+    monkeypatch.setattr(cli_main.sys, "argv", ["ecc", "workspace", "load", "--json"])
+    monkeypatch.setattr("chipcompiler.cli.app.invoke_typer_app", fake_invoke)
+
+    rc = cli_main.run()
+
+    assert rc == 17
+    assert seen["argv"] == ["workspace", "load", "--json"]
+    assert seen["keep_workspace_json_stdio_redirect"] is False
+
+
+def test_main_enables_cli_stdio_redirect(monkeypatch):
+    seen = {}
+
+    def fake_invoke(argv, *, keep_workspace_json_stdio_redirect=False):
+        seen["argv"] = argv
+        seen["keep_workspace_json_stdio_redirect"] = keep_workspace_json_stdio_redirect
+        return 17
+
+    monkeypatch.setattr(cli_main.sys, "argv", ["ecc", "workspace", "load", "--json"])
+    monkeypatch.setattr("chipcompiler.cli.app.invoke_typer_app", fake_invoke)
+
+    try:
+        cli_main.main()
+    except SystemExit as exc:
+        code = exc.code
+    else:
+        raise AssertionError("main() did not exit")
+
+    assert code == 17
+    assert seen["argv"] == ["workspace", "load", "--json"]
+    assert seen["keep_workspace_json_stdio_redirect"] is True
 
 
 def test_old_top_level_workspace_form_is_root_parser_error(capsys):

--- a/test/cli/test_workspace_cli.py
+++ b/test/cli/test_workspace_cli.py
@@ -5,12 +5,35 @@ from types import SimpleNamespace
 from chipcompiler.cli import main as cli_main
 from chipcompiler.data import StateEnum
 
+DEFAULT_WORKSPACE_STEP_SPECS = (
+    ("Synthesis", "yosys"),
+    ("Floorplan", "ecc"),
+)
+
+
+class DummyEngineDB:
+    def __init__(self, flow):
+        self.flow = flow
+        self.engine = None
+        self.initialized = False
+
+    def has_init(self):
+        return self.initialized
+
+    def create_db_engine(self, step):
+        self.flow.init_db_engine_calls += 1
+        self.flow.init_db_engine_steps.append(None if step is None else step.name)
+        self.flow.call_order.append(("init_db_engine",))
+        self.initialized = True
+        return True
+
 
 class DummyFlow:
     instances = []
     next_run_states = []
     fail_create_step_workspaces = False
     successful_steps = set()
+    workspace_step_specs = DEFAULT_WORKSPACE_STEP_SPECS
 
     def __init__(self, workspace):
         self.workspace = workspace
@@ -20,11 +43,12 @@ class DummyFlow:
         self.run_steps_calls = []
         self.run_calls = []
         self.init_db_engine_calls = 0
+        self.init_db_engine_steps = []
         self.call_order = []
         self.workspace_steps = [
-            SimpleNamespace(name="Synthesis", tool="yosys"),
-            SimpleNamespace(name="Floorplan", tool="ecc"),
+            SimpleNamespace(name=name, tool=tool) for name, tool in self.workspace_step_specs
         ]
+        self.engine_db = DummyEngineDB(self)
         DummyFlow.instances.append(self)
 
     def has_init(self):
@@ -45,8 +69,12 @@ class DummyFlow:
         self.cleared = True
 
     def init_db_engine(self):
-        self.init_db_engine_calls += 1
-        self.call_order.append(("init_db_engine",))
+        workspace_step = None
+        for step in self.workspace_steps:
+            if step.name not in self.successful_steps:
+                workspace_step = step
+                break
+        return self.engine_db.create_db_engine(workspace_step)
 
     def run_steps(self, rerun=False):
         self.run_steps_calls.append(rerun)
@@ -113,6 +141,7 @@ def _install_runtime_mocks(monkeypatch, tmp_path):
     DummyFlow.next_run_states = []
     DummyFlow.fail_create_step_workspaces = False
     DummyFlow.successful_steps = set()
+    DummyFlow.workspace_step_specs = DEFAULT_WORKSPACE_STEP_SPECS
 
     def fake_create_workspace(**kwargs):
         capture["create_kwargs"] = kwargs
@@ -546,6 +575,7 @@ def test_run_step_initializes_engine_db_before_step(monkeypatch, tmp_path, capsy
     assert data["cmd"] == "run_step"
     assert data["response"] == "success"
     assert flow.init_db_engine_calls == 1
+    assert flow.init_db_engine_steps == ["Synthesis"]
     assert flow.call_order == [
         ("init_db_engine",),
         ("run_step", "Synthesis", False),
@@ -574,6 +604,7 @@ def test_run_step_rerun_initializes_engine_db_before_step(monkeypatch, tmp_path,
     assert rc == 0
     assert data["cmd"] == "run_step"
     assert data["response"] == "success"
+    assert flow.init_db_engine_steps == ["Floorplan"]
     assert flow.call_order == [
         ("init_db_engine",),
         ("run_step", "Floorplan", True),
@@ -596,6 +627,45 @@ def test_run_step_skip_success_does_not_initialize_engine_db(monkeypatch, tmp_pa
     assert data["response"] == "success"
     assert flow.init_db_engine_calls == 0
     assert flow.call_order == [("run_step", "Synthesis", False)]
+
+
+def test_run_step_rerun_initializes_engine_db_from_requested_successful_step(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    DummyFlow.workspace_step_specs = (
+        ("Synthesis", "yosys"),
+        ("Floorplan", "ecc"),
+        ("fixFanout", "ecc"),
+    )
+    DummyFlow.successful_steps = {"Synthesis", "Floorplan"}
+
+    rc = cli_main.run(
+        [
+            "workspace",
+            "run-step",
+            "--directory",
+            str(ws),
+            "--step",
+            "Floorplan",
+            "--rerun",
+            "--json",
+        ]
+    )
+
+    data = _response(capsys)
+    flow = DummyFlow.instances[0]
+    assert rc == 0
+    assert data["cmd"] == "run_step"
+    assert data["response"] == "success"
+    assert flow.init_db_engine_steps == ["Floorplan"]
+    assert flow.call_order == [
+        ("init_db_engine",),
+        ("run_step", "Floorplan", True),
+    ]
+    assert flow.run_steps_calls == []
 
 
 def test_run_flow_rerun_clears_states_and_stops_on_failure(monkeypatch, tmp_path, capsys):

--- a/test/cli/test_workspace_cli.py
+++ b/test/cli/test_workspace_cli.py
@@ -10,6 +10,7 @@ class DummyFlow:
     instances = []
     next_run_states = []
     fail_create_step_workspaces = False
+    successful_steps = set()
 
     def __init__(self, workspace):
         self.workspace = workspace
@@ -18,6 +19,8 @@ class DummyFlow:
         self.cleared = False
         self.run_steps_calls = []
         self.run_calls = []
+        self.init_db_engine_calls = 0
+        self.call_order = []
         self.workspace_steps = [
             SimpleNamespace(name="Synthesis", tool="yosys"),
             SimpleNamespace(name="Floorplan", tool="ecc"),
@@ -41,6 +44,10 @@ class DummyFlow:
     def clear_states(self):
         self.cleared = True
 
+    def init_db_engine(self):
+        self.init_db_engine_calls += 1
+        self.call_order.append(("init_db_engine",))
+
     def run_steps(self, rerun=False):
         self.run_steps_calls.append(rerun)
         success = True
@@ -54,6 +61,7 @@ class DummyFlow:
     def run_step(self, workspace_step, rerun=False):
         name = workspace_step if isinstance(workspace_step, str) else workspace_step.name
         self.run_calls.append((name, rerun))
+        self.call_order.append(("run_step", name, rerun))
         if DummyFlow.next_run_states:
             return DummyFlow.next_run_states.pop(0)
         return StateEnum.Success
@@ -63,6 +71,11 @@ class DummyFlow:
             if step.name == name:
                 return step
         return None
+
+    def check_state(self, name, tool, state):
+        return getattr(state, "value", state) == StateEnum.Success.value and name in (
+            self.successful_steps
+        )
 
 
 def _response(capsys):
@@ -99,6 +112,7 @@ def _install_runtime_mocks(monkeypatch, tmp_path):
     DummyFlow.instances = []
     DummyFlow.next_run_states = []
     DummyFlow.fail_create_step_workspaces = False
+    DummyFlow.successful_steps = set()
 
     def fake_create_workspace(**kwargs):
         capture["create_kwargs"] = kwargs
@@ -517,6 +531,71 @@ def test_run_step_maps_success_and_failure(monkeypatch, tmp_path, capsys):
     assert rc == 1
     assert data["response"] == "failed"
     assert data["data"] == {"step": "Synthesis", "state": "Incomplete"}
+
+
+def test_run_step_initializes_engine_db_before_step(monkeypatch, tmp_path, capsys):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+
+    rc = cli_main.run(
+        ["workspace", "run-step", "--directory", str(ws), "--step", "Synthesis", "--json"]
+    )
+
+    data = _response(capsys)
+    flow = DummyFlow.instances[0]
+    assert rc == 0
+    assert data["cmd"] == "run_step"
+    assert data["response"] == "success"
+    assert flow.init_db_engine_calls == 1
+    assert flow.call_order == [
+        ("init_db_engine",),
+        ("run_step", "Synthesis", False),
+    ]
+    assert flow.run_steps_calls == []
+
+
+def test_run_step_rerun_initializes_engine_db_before_step(monkeypatch, tmp_path, capsys):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+
+    rc = cli_main.run(
+        [
+            "workspace",
+            "run-step",
+            "--directory",
+            str(ws),
+            "--step",
+            "Floorplan",
+            "--rerun",
+            "--json",
+        ]
+    )
+
+    data = _response(capsys)
+    flow = DummyFlow.instances[0]
+    assert rc == 0
+    assert data["cmd"] == "run_step"
+    assert data["response"] == "success"
+    assert flow.call_order == [
+        ("init_db_engine",),
+        ("run_step", "Floorplan", True),
+    ]
+    assert flow.run_steps_calls == []
+
+
+def test_run_step_skip_success_does_not_initialize_engine_db(monkeypatch, tmp_path, capsys):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    DummyFlow.successful_steps = {"Synthesis"}
+
+    rc = cli_main.run(
+        ["workspace", "run-step", "--directory", str(ws), "--step", "Synthesis", "--json"]
+    )
+
+    data = _response(capsys)
+    flow = DummyFlow.instances[0]
+    assert rc == 0
+    assert data["cmd"] == "run_step"
+    assert data["response"] == "success"
+    assert flow.init_db_engine_calls == 0
+    assert flow.call_order == [("run_step", "Synthesis", False)]
 
 
 def test_run_flow_rerun_clears_states_and_stops_on_failure(monkeypatch, tmp_path, capsys):

--- a/test/cli/test_workspace_cli.py
+++ b/test/cli/test_workspace_cli.py
@@ -1,5 +1,8 @@
 import json
 import os
+import subprocess
+import sys
+from contextlib import redirect_stdout, suppress
 from types import SimpleNamespace
 
 from chipcompiler.cli import main as cli_main
@@ -666,6 +669,153 @@ def test_run_step_rerun_initializes_engine_db_from_requested_successful_step(
         ("run_step", "Floorplan", True),
     ]
     assert flow.run_steps_calls == []
+
+
+def test_workspace_json_output_survives_runtime_stdio_redirect(
+    monkeypatch,
+    tmp_path,
+    capfd,
+):
+    from chipcompiler.cli.commands import workspace as workspace_commands
+    from chipcompiler.utility.log import redirect_stdio_to_file
+
+    log_path = tmp_path / "step.log"
+    redirected_streams = []
+
+    def fake_run_workspace_step(directory, step, rerun):
+        os.write(1, b"runtime-fd-output\n")
+        redirected_streams.append(redirect_stdio_to_file(str(log_path)))
+        print("runtime-output")
+        return {
+            "cmd": "run_step",
+            "response": "success",
+            "data": {"step": step, "state": "Success"},
+            "message": [f"run step {step} success : {directory}"],
+        }
+
+    monkeypatch.setattr(workspace_commands, "run_workspace_step", fake_run_workspace_step)
+
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
+    try:
+        rc = cli_main.run(
+            [
+                "workspace",
+                "run-step",
+                "--directory",
+                str(tmp_path / "workspace"),
+                "--step",
+                "Synthesis",
+                "--json",
+            ]
+        )
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_stdout_fd, 1)
+        os.dup2(saved_stderr_fd, 2)
+        os.close(saved_stdout_fd)
+        os.close(saved_stderr_fd)
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+        for stream in redirected_streams:
+            with suppress(Exception):
+                stream.close()
+
+    capture = capfd.readouterr()
+    out = capture.out
+    data = json.loads(out)
+    assert rc == 0
+    assert data["cmd"] == "run_step"
+    assert data["response"] == "success"
+    assert data["data"] == {"step": "Synthesis", "state": "Success"}
+    assert "runtime-fd-output" not in out
+    assert "runtime-fd-output" in capture.err
+    assert "runtime-output" in log_path.read_text()
+
+
+def test_workspace_json_output_restores_stdout_for_programmatic_run(tmp_path):
+    env = os.environ.copy()
+    env["MPLCONFIGDIR"] = str(tmp_path / "mplconfig")
+    workspace_dir = str(tmp_path / "workspace")
+    script = f"""
+from chipcompiler.cli import main as cli_main
+from chipcompiler.cli.commands import workspace as workspace_commands
+
+workspace_commands.load_workspace = lambda directory: {{
+    "cmd": "load_workspace",
+    "response": "success",
+    "data": {{"directory": directory}},
+    "message": [],
+}}
+
+rc = cli_main.run(["workspace", "load", "--directory", {workspace_dir!r}, "--json"])
+print("after-programmatic-run")
+raise SystemExit(rc)
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=os.getcwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    out_lines = completed.stdout.splitlines()
+    assert completed.returncode == 0
+    assert json.loads(out_lines[0])["response"] == "success"
+    assert out_lines[1:] == ["after-programmatic-run"]
+    assert "after-programmatic-run" not in completed.stderr
+
+
+def test_workspace_json_output_honors_redirected_stdout(
+    monkeypatch,
+    tmp_path,
+    capfd,
+):
+    from chipcompiler.cli.commands import workspace as workspace_commands
+
+    monkeypatch.setattr(
+        workspace_commands,
+        "load_workspace",
+        lambda directory: {
+            "cmd": "load_workspace",
+            "response": "success",
+            "data": {"directory": directory},
+            "message": [],
+        },
+    )
+    output_path = tmp_path / "stdout.json"
+
+    saved_stdout = sys.stdout
+    saved_stderr = sys.stderr
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
+    try:
+        with output_path.open("w") as stream, redirect_stdout(stream):
+            rc = cli_main.run(
+                ["workspace", "load", "--directory", str(tmp_path / "workspace"), "--json"]
+            )
+        capture = capfd.readouterr()
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_stdout_fd, 1)
+        os.dup2(saved_stderr_fd, 2)
+        os.close(saved_stdout_fd)
+        os.close(saved_stderr_fd)
+        sys.stdout = saved_stdout
+        sys.stderr = saved_stderr
+
+    redirected_output = output_path.read_text()
+    assert rc == 0
+    assert redirected_output.startswith("{")
+    assert json.loads(redirected_output)["response"] == "success"
+    assert capture.out == ""
 
 
 def test_run_flow_rerun_clears_states_and_stops_on_failure(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
  ## Summary

  Fixes direct `ecc workspace run-step` execution so pending or rerun steps initialize the ECC DB wrapper before invoking the step runner, while preserving existing `run-flow`, unknown-step, and
  already-successful skip behavior.

  This also keeps workspace `--json` stdout clean when runtime code redirects process stdio to step logs, and aligns the Nix-packaged thirdparty tool pins with the current alpha.4 sources.

  ## Changes

  - Initialize the DB engine for real `workspace run-step` execution without changing `EngineFlow.run_step()`.
  - Avoid DB initialization when a non-rerun step is already `Success`.
  - Keep runtime log output out of JSON stdout for workspace commands.
  - Keep programmatic `cli_main.run()` stdio restoration behavior separate from installed CLI process behavior.
  - Update Nix packaging for `ecc-dreamplace` and `ecc-tools` alpha.4.

  ## Verification

  - `ruff` passed
  - focused CLI/formal tests passed
  - full pytest passed: `823 passed, 9 skipped, 1 deselected, 13 xfailed`
  - `nix build .#cli` passed
  - packaged CLI smoke passed for `workspace create`, `run-step Synthesis`, and `run-step Floorplan`
  - `codex review --base main` reported no introduced bugs