### PR TITLE
feat(rcx): pass pdk selector to ecc-tools

### DIFF
--- a/chipcompiler/data/workspace.py
+++ b/chipcompiler/data/workspace.py
@@ -258,6 +258,7 @@ def init_workspace_config(workspace: Workspace) -> None:
     json_write(workspace.config[f"{StepEnum.ROUTING.value}"], router)
 
     rcx = json_read(workspace.config[f"{StepEnum.RCX.value}"])
+    rcx["pdk"] = "ics55" if workspace.pdk.name == "ics55" else ""
     rcx["mapping_file"] = workspace.pdk.mapping_file
     corners = deepcopy(workspace.pdk.corners)
     rcx["corners"] = corners

--- a/chipcompiler/tools/ecc/configs/rcx.json
+++ b/chipcompiler/tools/ecc/configs/rcx.json
@@ -1,4 +1,5 @@
 {
+    "pdk": "",
     "thread_num": 64,
     "output": "/RCX_ecc/output",
     "mapping_file": "/corners/ICsprout_55LLULP_1P6M_5lc_V1p1_cell.map",

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -890,7 +890,9 @@ class ECCToolsModule:
     ########################################################################
     # RCX api
     ########################################################################
-    def init_rcx(self, config: str):
+    def init_rcx(self, config: str, pdk: str = ""):
+        if pdk:
+            return self.ecc.init_rcx(config=config, pdk=pdk)
         return self.ecc.init_rcx(config=config)
     
     def run_rcx(self):

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -791,7 +791,10 @@ def run_rcx(workspace: Workspace,
             sub_flow.update_step(step_name=EccSubFlowEnum.run_rcx.value, state=StateEnum.Imcomplete)
             result = False
         else:
-            ecc_module.init_rcx(config=workspace.config.get(StepEnum.RCX.value, ""))
+            rcx_config_path = workspace.config.get(StepEnum.RCX.value, "")
+            rcx_config = json_read(rcx_config_path)
+            rcx_pdk = str(rcx_config.get("pdk", "") or "").strip()
+            ecc_module.init_rcx(config=rcx_config_path, pdk=rcx_pdk)
             ecc_module.run_rcx()
             ecc_module.report_rcx()
             sub_flow.update_step(step_name=EccSubFlowEnum.run_rcx.value, state=StateEnum.Success)

--- a/test/test_ecc_tools_module.py
+++ b/test/test_ecc_tools_module.py
@@ -4,6 +4,33 @@
 from chipcompiler.tools.ecc.module import ECCToolsModule
 
 
+class FakeEcc:
+    def __init__(self):
+        self.calls = []
+
+    def init_rcx(self, **kwargs):
+        self.calls.append(kwargs)
+        return True
+
+
 def test_ecc_tools_module_imports_installed_native_extension():
     module = ECCToolsModule()
     assert module.get_ecc() is not None
+
+
+def test_init_rcx_passes_pdk_when_configured():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+
+    assert module.init_rcx(config="/tmp/rcx.json", pdk="ics55") is True
+
+    assert module.ecc.calls == [{"config": "/tmp/rcx.json", "pdk": "ics55"}]
+
+
+def test_init_rcx_omits_empty_pdk_for_backward_compatibility():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+
+    assert module.init_rcx(config="/tmp/rcx.json") is True
+
+    assert module.ecc.calls == [{"config": "/tmp/rcx.json"}]


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [x] `bazel build //:build_ecc_cli_bundle`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [x] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
