### PR TITLE
feat: add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+default_install_hook_types:
+  - commit-msg
+
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.3.0
+    hooks:
+      - id: conventional-pre-commit
+        name: Check commit message format
+        stages:
+          - commit-msg
+        args:
+          - --verbose
+          - feat
+          - fix
+          - docs
+          - style
+          - refactor
+          - perf
+          - test
+          - build
+          - ci
+          - chore
+          - revert

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ ci: gate nix workflow paths
 Prefer scopes that match the changed area: `cli`, `runtime`, `tools`, `build`,
 `nix`, `ci`, `docs`, `dreamplace`, or `ecc-tools`.
 
+Install the local commit message hook before creating commits:
+
+```sh
+uv run prek install --config .pre-commit-config.yaml --hook-type commit-msg --overwrite
+```
+
+The hook uses `conventional-pre-commit` to check commit subjects against the
+same Conventional Commit style.
+
 ## Pull Requests
 
 Every PR should include:


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] `bazel build //:build_ecc_cli_bundle`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
