### PR TITLE
docs: update for development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,15 +2,23 @@
 
 ECC is the EDA toolchain component of ECOS Studio, orchestrating EDA tools (Yosys, ECC-Tools, OpenROAD, Magic, KLayout) for RTL-to-GDS flows. See `docs/architecture.md` for architecture details and `docs/development.md` for workflows.
 
-For setup, testing, code quality, and Bazel commands, see [docs/development.md](docs/development.md).
+For setup, testing, and code quality commands, see [docs/development.md](docs/development.md).
 
 # Workflow
 
-`bazel run //:prepare_dev` performs: venv creation (`uv sync`) -> ECC-Tools runtime install -> DreamPlace `.so` install (built via `@ecc-dreamplace` module). After setup: `source .venv/bin/activate`. Use `--jobs=1` on memory-constrained machines.
+If Nix is available, enter the dev shell before syncing:
 
-Release builds download a pre-built DreamPlace wheel from GitHub Releases instead of building from source. The CI workflow uses `uv pip install --no-deps <wheel-url>` directly.
+```bash
+nix develop
+uv sync --no-build-isolation-package ecc-dreamplace --no-binary-package ecc-tools-bin --verbose
+source .venv/bin/activate
+```
 
-For integrating thirdparty tools into the build system, see [docs/development.md](docs/development.md#integrating-a-thirdparty-tool-into-the-build-system).
+If Nix is not available, skip `nix develop` and run the `uv sync` command in the
+normal shell. `ecc` is editable, so source changes are picked up on the next
+import.
+
+For integrating thirdparty tools, see [docs/development.md](docs/development.md#integrating-a-thirdparty-tool).
 
 # Gotchas
 
@@ -19,9 +27,6 @@ For integrating thirdparty tools into the build system, see [docs/development.md
 - Steps run in `multiprocessing.Process`; state persisted in `workspace.flow.json`
 - File chaining: each step reads previous step's `output/`; first step uses `workspace.design.origin_verilog/origin_def`
 - `uv.lock` is source of truth for Python deps; `requirements_lock.txt` is auto-generated and gitignored
-- Use `--config=ghproxy` for Bazel on restricted networks
-- **Bazel 8 Bzlmod**: This project uses Bzlmod (`MODULE.bazel`), not legacy `WORKSPACE`. `new_local_repository` etc. must be loaded via `use_repo_rule()`, never used as bare globals. Do not use `WORKSPACE`-era idioms.
-- **Do not assume Bazel/Starlark APIs exist** -- always verify against the exact Bazel version (currently 8.x) before using an API. For example, `watch_tree` has no `exclude` parameter. If an API doesn't work, investigate alternatives instead of retrying with guessed parameters.
 
 # Behavioral Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ builds, tests, and debug workflows, use the [Development Guide](docs/development
 
 - `chipcompiler/` - ECC Python package, CLI, flow runtime, tool wrappers, and packaging helpers.
 - `test/` - Unit, CLI, runtime, integration-style, and formal tests.
-- `bazel/`, `BUILD.bazel`, `MODULE.bazel` - Bazel and Bzlmod build integration.
 - `nix/`, `flake.nix`, `flake.lock` - Nix packaging and development shell.
 - `chipcompiler/thirdparty/` - Third-party source checkouts and generated/native integration points.
 - `.github/` - CI, release, version checks, issue templates, and PR template.
@@ -23,11 +22,15 @@ change.
 
 Use one of the setup paths in [docs/development.md](docs/development.md):
 
-- `bazel run //:prepare_dev` for the full Bazel-managed development setup.
-- `nix develop` for the Nix development shell.
+- `nix develop` for the optional Nix development shell.
+- `uv sync --no-build-isolation-package ecc-dreamplace --no-binary-package ecc-tools-bin --verbose`
+  for the ECC workspace.
 
 `uv.lock` is the source of truth for Python dependency resolution. Do not
 hand-edit lockfiles.
+
+`ecc` is installed as an editable package. Source edits are picked up on the
+next import.
 
 ## Branches And Commits
 
@@ -42,7 +45,7 @@ ci: gate nix workflow paths
 ```
 
 Prefer scopes that match the changed area: `cli`, `runtime`, `tools`, `build`,
-`nix`, `ci`, `docs`, `dreamplace`, or `ecc-tools`.
+`nix`, `ci`, or `docs`.
 
 Install the local commit message hook before creating commits:
 
@@ -62,7 +65,7 @@ Every PR should include:
 - The exact validation commands that were run.
 - Any skipped validation and the reason.
 - Runtime or packaging impact, especially CLI output contracts, workspace layout,
-  native wrappers, PyInstaller, Nix, Bazel, or release artifacts.
+  native wrappers, PyInstaller, Nix, or release artifacts.
 
 If the PR changes a user-facing command, include before/after command examples or
 output shape where useful. If the PR changes machine-readable output, describe
@@ -82,8 +85,8 @@ blast radius is larger.
   touched package/test paths.
 - Native toolchain or wrapper changes: verify the wrapper path actually used at
   runtime, not only the low-level native module import.
-- PyInstaller packaging changes: build `//:build_ecc_cli_bundle` and smoke the
-  extracted `ecc` binary with `--help`, `--version`, and `version --json`.
+- PyInstaller packaging changes: build the release artifact and smoke the
+  resulting `ecc` binary with `--help`, `--version`, and `version --json`.
 - Nix changes: verify the affected Nix output or explain why local Nix
   evaluation/build was not available.
 - CI or release changes: validate YAML syntax and run the narrowest available
@@ -100,15 +103,8 @@ the PR.
 Keep dependency and version surfaces in sync:
 
 - `pyproject.toml` and `uv.lock` for Python dependency changes.
-- `MODULE.bazel` and generated Bazel lock/module state for Bazel module changes.
 - `flake.nix` and `flake.lock` for Nix input changes.
 - Version metadata and release workflow inputs when changing release versions.
-
-ECC pins `ecc-tools` and `ecc-dreamplace` to exact Python wheel versions through
-`pyproject.toml` and GitHub Release wheel URLs. Changing a nested local checkout
-does not change the runtime package that `uv sync` installs. For dependency-level
-debugging, build or publish the local wheel first, update the dependency source
-or install input to that wheel, then reinstall/sync before testing.
 
 When a submodule bump suggests a dependency pin change, verify that the matching
 wheel or release artifact exists before updating parent dependency metadata.
@@ -119,17 +115,11 @@ Treat third-party repositories as separate projects:
 
 - Commit fixes in the nested project first when the fix belongs there.
 - Update the parent gitlink separately and document the new commit.
-- Keep `ecc-dreamplace` and `ecc-tools` source state aligned with the package or
-  release version being tested.
 - Do not rely on unpublished local commits for merge-ready parent PRs.
-
-For source debugging of DreamPlace or ECC-Tools, follow the modes described in
-[docs/development.md](docs/development.md) and make clear in the PR whether the
-runtime used an installed wheel or a source-tree override.
 
 ## Generated Files
 
 Do not commit local caches, virtual environments, generated build output, or
 temporary workspaces. In particular, keep `.venv`, `.pytest_cache`,
-`bazel-*`, `dist/`, generated release bundles, and local PDK/resource payloads
-out of commits unless a file is intentionally part of a release or fixture.
+`dist/`, generated release bundles, and local PDK/resource payloads out of
+commits unless a file is intentionally part of a release or fixture.

--- a/README.cn.md
+++ b/README.cn.md
@@ -32,10 +32,10 @@ GUI（ECOS Studio）已迁移至 [ecos-studio](https://github.com/0xharry/ecos-s
 
 ### CLI 流程运行
 
-可以使用 `nix run .#cli -- ...` 创建 ECC 项目，校验 `ecc.toml`，并执行完整 RTL2GDS 流程。
+可以使用 `nix run . -- ...` 创建 ECC 项目，校验 `ecc.toml`，并执行完整 RTL2GDS 流程。
 
 ```bash
-nix run .#cli -- init gcd
+nix run . -- init gcd
 cp ./rtl/gcd.v gcd/rtl/gcd.v
 ```
 
@@ -61,11 +61,11 @@ run = "default"
 然后校验并运行：
 
 ```bash
-nix run .#cli -- check --project gcd
-nix run .#cli -- run --project gcd
-nix run .#cli -- status --project gcd
-nix run .#cli -- metrics --project gcd
-nix run .#cli -- log --project gcd
+nix run . -- check --project gcd
+nix run . -- run --project gcd
+nix run . -- status --project gcd
+nix run . -- metrics --project gcd
+nix run . -- log --project gcd
 ```
 
 ## 功能特性

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ The GUI (ECOS Studio) has been moved to the [ecos-studio](https://github.com/0xh
 
 ### CLI Flow Runner
 
-Use `nix run .#cli -- ...` to create an ECC project, validate its `ecc.toml`,
+Use `nix run . -- ...` to create an ECC project, validate its `ecc.toml`,
 and run the full RTL2GDS flow.
 
 ```bash
-nix run .#cli -- init gcd
+nix run . -- init gcd
 cp ./rtl/gcd.v gcd/rtl/gcd.v
 ```
 
@@ -62,11 +62,11 @@ run = "default"
 Then validate and run:
 
 ```bash
-nix run .#cli -- check --project gcd
-nix run .#cli -- run --project gcd
-nix run .#cli -- status --project gcd
-nix run .#cli -- metrics --project gcd
-nix run .#cli -- log --project gcd
+nix run . -- check --project gcd
+nix run . -- run --project gcd
+nix run . -- status --project gcd
+nix run . -- metrics --project gcd
+nix run . -- log --project gcd
 ```
 
 ## Features

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,231 +4,89 @@ Development environment setup and workflows for ECOS Chip Compiler.
 
 ## Installation
 
-### Option 1: Bazel Dev Setup (Recommended)
+ECC is managed with `uv`. The main ECC workspace installs `ecc` from the local
+source tree in editable mode.
 
-If not using Nix, set up the full development environment with a single command:
+If Nix is available, enter the development shell before running `uv sync`:
 
 ```bash
-bazel run //:prepare_dev
+nix develop
 ```
 
-This runs two steps:
-1. `uv sync --frozen --all-groups --python 3.11` — creates the Python venv and installs the locked `ecc-dreamplace` and `ecc-tools` wheels
-2. Builds and extracts the ECC runtime bundle → `chipcompiler/tools/ecc/bin/`
-3. Builds and installs DreamPlace operators (source build, dev only) → `chipcompiler/thirdparty/ecc-dreamplace/dreamplace/ops/`
+If Nix is not available, run the same `uv sync` commands in your normal shell
+after installing the required system packages for native builds.
 
-ECC-Tools and DreamPlace are built in parallel by Bazel. On memory-constrained machines, limit parallelism:
+### ECC Workspace
+
+From the `ecc` repository root:
+
 ```bash
-bazel run //:prepare_dev --jobs=1
+uv sync --no-build-isolation-package ecc-dreamplace --no-binary-package ecc-tools-bin --verbose
+source .venv/bin/activate
 ```
 
-### Option 2: Nix Development Shell
+This creates the Python virtual environment and installs:
+
+- `ecc` from the local source tree.
+- `ecc-dreamplace` from `chipcompiler/thirdparty/ecc-dreamplace`.
+- `ecc-tools-bin` from `chipcompiler/thirdparty/ecc-tools`.
+
+`ecc` is editable, so Python source edits are picked up on the next import.
+
+### Auto-load With direnv
 
 ```bash
-nix develop  # Provides Python 3.11+, uv, Yosys, ECC-Tools, dependencies
-```
-
-Auto-load with direnv:
-```bash
-echo "use flake" > .envrc
 direnv allow
 ```
 
-Shell hook runs `uv sync --frozen --all-groups --python 3.11` and activates venv. Binary cache at [serve.eminrepo.cc](https://serve.eminrepo.cc).
+`direnv` enters the Nix development shell automatically when you `cd` into the
+repository.
 
-## Bazel Build System
+## Package Builds
 
-Bazel is used for reproducible release builds and ECC-Tools C++ compilation. Requires Bazel 8+ and `uv` on PATH.
+Build Python packages with uv:
 
-```bash
-bazel build //chipcompiler/thirdparty:ecc_py_cmake       # ECC-Tools C++ build
-bazel run //bazel/scripts:install_dreamplace              # Build + install DreamPlace .so (via @ecc-dreamplace)
-bazel run //bazel/scripts:clean_dreamplace                # Remove installed DreamPlace artifacts
-bazel run //bazel/scripts:prepare_dev                     # Full dev environment setup (ECC + DreamPlace)
-```
-
-Use `--config=ghproxy` behind restricted networks. For `git_override` deps (e.g. `ecos-bazel`), configure git mirror directly:
-
-```bash
-git config --global url."https://ghfast.top/https://github.com/".insteadOf "https://github.com/"
-bazel build --config=ghproxy //...
-```
-
-Python deps are managed via `uv.lock` — Bazel consumes it automatically through `uv_export`. To update: edit `pyproject.toml`, run `uv lock`.
-
-## Release Builds
-
-### PyInstaller CLI Release Artifact
-
-Tagged ECC releases publish a Linux x86_64 PyInstaller onedir CLI bundle:
-
-```text
-ecc-cli-linux-x86_64.tar.gz
-```
-
-Build the release artifact locally with:
-
-```bash
-bazel build //:build_ecc_cli_bundle
-mkdir -p dist/release
-gzip -n -9 -c bazel-bin/build_ecc_cli_bundle/ecc.tar \
-  > dist/release/ecc-cli-linux-x86_64.tar.gz
-```
-
-The archive extracts to an `ecc` executable and `_internal/` runtime directory.
-After extraction:
-
-```bash
-./ecc --version
-```
-
-Release notes for tagged ECC releases are generated with `git-cliff` using
-[`ecc/.github/cliff.toml`](../.github/cliff.toml). The release workflow appends
-the generated changelog before the CLI artifact checksum block that is published
-to GitHub Releases.
-
-### Manual Python Package
 ```bash
 uv build
 ```
 
-### Manual Bazel Wheel Build (ECC Runtime + auditwheel)
+Wheel and source distributions are written to `dist/`.
 
-For developer validation, build a portable wheel with Bazel-managed ECC runtime
-and hermetic uv/Python:
+## Debugging
 
-```bash
-bazel build //:raw_wheel   # Sandboxed, cacheable — produces raw .whl
-bazel run //:build_wheel   # auditwheel repair + smoke test
-```
+For normal debugging:
 
-Artifacts:
-- Raw wheels: `dist/wheel/raw/`
-- Repaired wheels: `dist/wheel/repaired/`
-- auditwheel report: `dist/wheel/reports/show.txt`
+1. Sync the ECC workspace with the ECC command above.
+2. Activate `.venv`.
+3. Run the CLI, tests, or debugger using `.venv/bin/python`.
 
-Requirements:
-- Linux x86_64
-- `auditwheel` (installed via dev deps)
+No extra `PYTHONPATH` override is required for normal ECC development. When a
+process imports `ecc` again, Python code is read from the source tree.
 
-Common failures:
-- `auditwheel` missing: run `uv sync --frozen --all-groups --python 3.11`
-- `ecc_py*.so` missing after bundle extraction: build/install runtime (`bazel run //:prepare_dev`)
-- auditwheel policy mismatch (e.g. glibc symbols too new): rebuild on older compatible base or adjust target policy
-- missing runtime libraries: inspect `dist/wheel/reports/show.txt`
-
-### DreamPlace Wheel Build
-
-DreamPlace has its own standalone build, CI/CD, and release pipeline.
-
-- **Default dev mode**: `uv sync --frozen --all-groups --python 3.11` installs the locked DreamPlace and ECC-Tools wheels into `.venv`.
-  `bazel run //:prepare_dev` still builds the source-tree operators so source debug mode can override imports when needed.
-
-- **Release mode**: A pre-built wheel is downloaded from
-  [GitHub Releases](https://github.com/openecos-projects/ecc-dreamplace/releases).
-  The parent `Makefile` (`make build`) fetches it automatically via the
-  `_download_dreamplace_wheel` target. The CI workflow installs it directly:
-
-  ```bash
-  uv pip install --no-deps https://github.com/openecos-projects/ecc-dreamplace/releases/download/v0.1.0-alpha.1/ecc_dreamplace-0.1.0a1-py3-none-manylinux_2_34_x86_64.whl
-  ```
-
-### DreamPlace Debug Modes
-
-ECC currently uses two different DreamPlace modes during development:
-
-- **Default mode**: `ecc-dreamplace` is installed into `.venv` from a wheel. Runtime imports resolve to
-  `.venv/lib/python3.11/site-packages/dreamplace/`.
-- **Source debug mode**: Debugger startup prepends
-  `chipcompiler/thirdparty/ecc-dreamplace` to `PYTHONPATH`, so `import dreamplace`
-  resolves to the submodule source tree instead.
-
-Use the default mode for normal development and release-like validation. Use source
-debug mode when you need breakpoints and stepping to land in
-`chipcompiler/thirdparty/ecc-dreamplace/dreamplace/*.py`.
-
-#### Default Mode
-
-- `uv sync --frozen --all-groups --python 3.11` keeps the runtime aligned with the locked wheel.
-- LSP configuration such as `python.analysis.extraPaths` can improve source navigation, but it does not change runtime imports.
-- Python breakpoints land in the files that are actually imported at runtime, which are normally under `.venv/lib/python3.11/site-packages/dreamplace/`.
-
-#### Source Debug Mode
-
-This mode keeps the installed wheel untouched and only overrides module resolution for
-the debug session.
-
-1. Build and install DreamPlace operators into the source tree:
-
-   ```bash
-   bazel run //bazel/scripts:install_dreamplace
-   ```
-
-2. Launch the debugger with `PYTHONPATH` pointing at the submodule root:
-
-   ```json
-   {
-     "name": "ECC Debug (dreamplace source)",
-     "type": "debugpy",
-     "request": "launch",
-     "program": "${workspaceFolder}/chipcompiler/cli/main.py",
-     "cwd": "${workspaceFolder}",
-     "python": "${workspaceFolder}/.venv/bin/python",
-     "justMyCode": false,
-     "subProcess": true,
-     "console": "integratedTerminal",
-     "env": {
-       "PYTHONPATH": "${workspaceFolder}/chipcompiler/thirdparty/ecc-dreamplace:${env:PYTHONPATH}"
-     }
-   }
-   ```
-
-This works because `chipcompiler/thirdparty/ecc-dreamplace` contains the `dreamplace/`
-package root. When it appears before `site-packages` on `PYTHONPATH`, Python imports
-the submodule source tree first.
-
-`subProcess: true` is recommended because ECC flow steps run in `multiprocessing.Process`.
-
-#### Behavior And Limits
-
-- Breakpoints in `chipcompiler/thirdparty/ecc-dreamplace/dreamplace/*.py` will hit in source debug mode.
-- Source edits only take effect in source debug mode. In default mode, runtime still uses the installed wheel copy.
-- This override is aimed at Python code. It does not provide C++ or `.so` source-level debugging.
-- If source debug mode fails with missing DreamPlace operators, rerun `bazel run //bazel/scripts:install_dreamplace`.
-- If you only need editor navigation and not runtime overrides, prefer LSP-only configuration such as `python.analysis.extraPaths`.
-
-#### Optional LSP-Only Navigation
-
-If you want jump-to-definition into the submodule source while keeping runtime behavior
-unchanged, add the source roots to your IDE configuration instead of `PYTHONPATH`:
+Optional IDE indexing configuration:
 
 ```json
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.analysis.extraPaths": [
-    "${workspaceFolder}/chipcompiler/thirdparty/ecc-dreamplace",
-    "${workspaceFolder}/chipcompiler/thirdparty/ecc-tools"
-  ]
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }
 ```
 
-This improves indexing and navigation only. Debugger and runtime imports still follow
-the installed interpreter environment.
-
+This improves navigation only. Runtime behavior follows the active uv
+environment.
 
 ## Code Quality
 
 ```bash
-# Format & lint (recommended)
+# Format and lint
 uv run ruff format chipcompiler/ test/
 uv run ruff check chipcompiler/ test/
 
 # Type check
-uv run ty check              # Recommended (configured in pyproject.toml)
+uv run ty check
 uv run pyright chipcompiler/
 uv run mypy chipcompiler/
 
-# Legacy
+# Legacy formatters
 uv run black chipcompiler/ test/
 uv run isort chipcompiler/ test/
 ```
@@ -236,19 +94,21 @@ uv run isort chipcompiler/ test/
 ## Testing
 
 ```bash
-uv run pytest test/                                    # All tests
-uv run pytest test/test_tools_yosys_utility.py -v     # Specific file
-uv run pytest test/ --cov=chipcompiler --cov-report=term-missing  # Coverage
-uv run pytest test/formal/ -v                          # Formal verification tests only
+uv run pytest test/
+uv run pytest test/test_tools_yosys_utility.py -v
+uv run pytest test/ --cov=chipcompiler --cov-report=term-missing
+uv run pytest test/formal/ -v
 ```
 
 ### Formal Verification
 
-z3-based formal verification. See [test/formal/README.md](../test/formal/README.md) for details on the approach, test inventory, and known bugs found.
+z3-based formal verification. See [test/formal/README.md](../test/formal/README.md)
+for details on the approach, test inventory, and known bugs found.
 
 ## Add a New EDA Tool
 
 ### 1. Create Structure
+
 ```bash
 mkdir -p chipcompiler/tools/<tool_name>/{configs,scripts}
 touch chipcompiler/tools/<tool_name>/{__init__.py,builder.py,runner.py,utility.py}
@@ -256,7 +116,8 @@ touch chipcompiler/tools/<tool_name>/{__init__.py,builder.py,runner.py,utility.p
 
 ### 2. Implement Interface
 
-**builder.py:**
+`builder.py`:
+
 ```python
 from chipcompiler.data import Workspace, WorkspaceStep, StepEnum
 
@@ -271,7 +132,8 @@ def build_step_config(workspace_step: WorkspaceStep) -> None:
     workspace_step.write_config(config)
 ```
 
-**runner.py:**
+`runner.py`:
+
 ```python
 import subprocess
 from chipcompiler.data import WorkspaceStep, StateEnum
@@ -287,7 +149,9 @@ def run_step(workspace_step: WorkspaceStep) -> StateEnum:
     try:
         result = subprocess.run(
             ["<tool_name>", "-c", workspace_step.config_file],
-            cwd=workspace_step.path, capture_output=True, timeout=workspace_step.timeout
+            cwd=workspace_step.path,
+            capture_output=True,
+            timeout=workspace_step.timeout,
         )
         return StateEnum.Success if result.returncode == 0 else StateEnum.Incomplete
     except Exception as e:
@@ -295,7 +159,8 @@ def run_step(workspace_step: WorkspaceStep) -> StateEnum:
         return StateEnum.Incomplete
 ```
 
-**__init__.py:**
+`__init__.py`:
+
 ```python
 from .builder import build_step, build_step_space, build_step_config
 from .runner import is_eda_exist, run_step
@@ -303,74 +168,68 @@ from .runner import is_eda_exist, run_step
 __all__ = ["build_step", "build_step_space", "build_step_config", "is_eda_exist", "run_step"]
 ```
 
-### 3. Add Configs & Scripts
-- JSON templates in `configs/`
-- TCL/Python/Shell scripts in `scripts/`
+### 3. Add Configs And Scripts
 
-### 4. Integrate into Flow
+- JSON templates in `configs/`.
+- TCL, Python, or shell scripts in `scripts/`.
+
+### 4. Integrate Into Flow
+
 Update `EngineFlow.build_default_steps()` or use `add_step()`.
 
 ### 5. Write Tests
+
 ```python
-# test/test_tools_<tool_name>.py
 import pytest
 from chipcompiler.tools.<tool_name> import is_eda_exist, run_step
 
 @pytest.mark.skipif(not is_eda_exist(), reason="<tool_name> not installed")
 def test_run_step():
-    # Test implementation
     pass
 ```
 
-## Integrating a Thirdparty Tool into the Build System
+## Integrating a Thirdparty Tool
 
-ECC uses a dual-build strategy: **uv-managed Python deps** for dev, **Bazel** (+ Nix) for release. Reference `ecc-dreamplace` as a working example.
+ECC uses uv for Python dependency resolution. Treat thirdparty repositories as
+separate projects and keep their package-specific setup instructions in those
+repositories.
 
-**Principle**: Avoid modifying the thirdparty tool's own build system (CMakeLists, setup.py, etc.). Prefer solving build issues from the Bazel side or ECC's build configuration (cache entries, env vars, wrapper scripts).
+### 1. Python Dependencies
 
-### 1. Python deps
+Add the package to root `pyproject.toml`, then run:
 
-Add the package to root `pyproject.toml`, choose either a local workspace source or a locked wheel URL under `[tool.uv.sources]`, then `uv lock`.
+```bash
+uv lock
+```
 
-### 2. Dev build
+Then sync the ECC workspace with the command in [Installation](#installation).
 
-If the tool has compiled artifacts (`.so`, generated configs):
-- Add a Bazel build target in `chipcompiler/thirdparty/BUILD.bazel`
-- Create `bazel/scripts/install-<tool>.sh` with manifest-based install/clean (see `install-dreamplace.sh`)
-- Register `install_<tool>` and `clean_<tool>` targets in `bazel/scripts/BUILD.bazel`
-- Wire into `prepare-dev.sh` with explicit `RUNFILES_DIR="${RF}"`
+### 2. Runtime Integration
 
-### 3. Release build
-
-Add runtime artifacts to `//chipcompiler:chipcompiler_runtime_data` (consumed by `raw_wheel`). For Nix, add to flake build inputs.
-
-### 4. Bazel sandbox deps
-
-Add the tool's extra to `uv_export(extras=[...])` in `MODULE.bazel`; reference as `@pypi//<pkg>` in BUILD files.
-
-### 5. EDA tool module
-
-Create `chipcompiler/tools/<tool>/` with `__init__.py`, `builder.py`, `runner.py`. Each tool must implement `is_eda_exist`, `build_step`, `run_step`. Integrate into flow via `EngineFlow.build_default_steps()` or `add_step()`. See [Add a New EDA Tool](#add-a-new-eda-tool) above for the full interface and code examples.
-
-### Pitfalls
-
-- **Runfiles**: child scripts called from `prepare-dev.sh` cannot resolve `RUNFILES_DIR` from `BASH_SOURCE[0]` — pass it explicitly
-- **File ownership**: use `cp --no-preserve=ownership` and `tar --no-same-owner` when extracting Bazel outputs to avoid root-owned files in devcontainer builds
+Create `chipcompiler/tools/<tool>/` with `__init__.py`, `builder.py`, and
+`runner.py`. Each tool must implement `is_eda_exist`, `build_step`, and
+`run_step`. Integrate into the flow through `EngineFlow.build_default_steps()`
+or `add_step()`.
 
 ## CLI Usage
 
 For command-line automation and scripting, run CLI via Nix:
 
 ```bash
-# Create a project skeleton with ecc.toml, rtl/, constraints/, and runs/
-nix run .#cli -- init gcd
+nix run . -- init gcd
+nix run . -- check --project gcd
+nix run . -- run --project gcd
+nix run . -- status --project gcd
+nix run . -- metrics --project gcd
+nix run . -- log --project gcd
+```
 
-# After editing gcd/ecc.toml and adding RTL files
-nix run .#cli -- check --project gcd
-nix run .#cli -- run --project gcd
-nix run .#cli -- status --project gcd
-nix run .#cli -- metrics --project gcd
-nix run .#cli -- log --project gcd
+Or run through the active uv environment:
+
+```bash
+uv run ecc init gcd
+uv run ecc check --project gcd
+uv run ecc run --project gcd
 ```
 
 The project config is the CLI input surface:
@@ -396,70 +255,70 @@ For filelist mode, set `design.rtl` to a single filelist path, for example
 `rtl = ["rtl/filelist.f"]`. Multiple RTL sources should be listed in the
 filelist rather than as multiple `design.rtl` entries.
 
-If you need an interactive environment for development, use `nix develop`.
+## Runtime Resolution
 
-REST API reference: Examples: **[examples/gcd](examples/gcd/README.md)**
-
-### Yosys Runtime Resolution
+### Yosys
 
 Resolution priority in `chipcompiler/tools/yosys/utility.py`:
-1. Bundled runtime (`CHIPCOMPILER_OSS_CAD_DIR`)
-2. System PATH (`yosys`)
+
+1. Bundled runtime through `CHIPCOMPILER_OSS_CAD_DIR`.
+2. System PATH through `yosys`.
 
 Runtime handling:
-- `get_yosys_command()` - Side-effect-free detection
-- `get_yosys_runtime()` - Returns `(command, env)` for subprocess (no global `os.environ` mutation)
-- `check_slang_plugin()` - Preflight check: `yosys -p "plugin -i slang"`
 
-#### Troubleshooting: Yosys executable not found
+- `get_yosys_command()` performs side-effect-free detection.
+- `get_yosys_runtime()` returns `(command, env)` for subprocess use.
+- `check_slang_plugin()` runs the preflight check `yosys -p "plugin -i slang"`.
 
-If you see this error:
-
-```
-RuntimeError: Yosys executable not found in system PATH, and CHIPCOMPILER_OSS_CAD_DIR is not set.
-Please install yosys or set CHIPCOMPILER_OSS_CAD_DIR to the OSS CAD Suite root directory.
-```
-
-Download the [OSS CAD Suite](https://github.com/YosysHQ/oss-cad-suite-build/releases) pre-built package for your platform, extract it, and set the environment variable:
+If Yosys is not found, download the
+[OSS CAD Suite](https://github.com/YosysHQ/oss-cad-suite-build/releases)
+pre-built package for your platform, extract it, and set:
 
 ```bash
-# Download and extract (example for Linux x86_64)
-wget https://github.com/YosysHQ/oss-cad-suite-build/releases/download/<version>/oss-cad-suite-linux-x64-<date>.tgz
-tar -xzf oss-cad-suite-linux-x64-<date>.tgz
-
-# Set the environment variable
 export CHIPCOMPILER_OSS_CAD_DIR=/path/to/oss-cad-suite
+```
 
-# Or add yosys to PATH directly
+Or add Yosys to PATH directly:
+
+```bash
 source /path/to/oss-cad-suite/environment
 ```
 
-### PDK Runtime Resolution
+### PDK
 
 Resolution priority for `get_pdk("ics55")` in `chipcompiler/data/pdk.py`:
-1. Explicit `pdk_root` argument
-2. `CHIPCOMPILER_ICS55_PDK_ROOT` env var
-3. Legacy `ICS55_PDK_ROOT` env var
-4. In-repo default: `chipcompiler/thirdparty/icsprout55-pdk`
 
-Backend supports `POST /api/workspace/set_pdk_root` to set runtime path. Workspace creation persists resolved root in `parameters.json` as `PDK Root`.
+1. Explicit `pdk_root` argument.
+2. `CHIPCOMPILER_ICS55_PDK_ROOT` environment variable.
+3. Legacy `ICS55_PDK_ROOT` environment variable.
+4. In-repo default: `chipcompiler/thirdparty/icsprout55-pdk`.
 
-Example: `CHIPCOMPILER_ICS55_PDK_ROOT=/path/to/pdk chipcompiler`
+Backend supports `POST /api/workspace/set_pdk_root` to set runtime path.
+Workspace creation persists resolved root in `parameters.json` as `PDK Root`.
+
+Example:
+
+```bash
+CHIPCOMPILER_ICS55_PDK_ROOT=/path/to/pdk uv run ecc
+```
 
 ## Common Workflows
 
 ### Debug Flow Step
-1. Check `workspace_step.logs/` for tool output
-2. Inspect `workspace_step.config/` for configs
-3. Verify `workspace_step.input/` files
-4. Run individual step: `EngineFlow.run_step()`
+
+1. Check `workspace_step.logs/` for tool output.
+2. Inspect `workspace_step.config/` for configs.
+3. Verify `workspace_step.input/` files.
+4. Run individual step with `EngineFlow.run_step()`.
 
 ### Modify Flow Sequence
-1. Edit `EngineFlow.build_default_steps()` or use `add_step()`
-2. Persist: `flow.save()` → `workspace.flow.json`
-3. Run: `flow.run_steps()` (skips successful steps)
-4. Reset: `clear_states()` to re-run
+
+1. Edit `EngineFlow.build_default_steps()` or use `add_step()`.
+2. Persist with `flow.save()` to `workspace.flow.json`.
+3. Run with `flow.run_steps()`; successful steps are skipped.
+4. Use `clear_states()` to re-run.
 
 ## Related Documentation
 
 - [Architecture](architecture.md) - System design and patterns
+- [Examples](examples/) - Example projects and CLI usage


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] `bazel build //:build_ecc_cli_bundle`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
