### PR TITLE
fix(ci): download wheels from artifacts

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -10,10 +10,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
+    - name: Setup Python 3.11
+      shell: bash
+      run: echo "/opt/python/cp311-cp311/bin" >> "$GITHUB_PATH"
 
     - name: Setup uv
       uses: astral-sh/setup-uv@v3
@@ -21,19 +20,23 @@ runs:
         version: latest
         enable-cache: "true"
 
+    - name: Trust GitHub workspace
+      shell: bash
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
     - name: Install native build dependencies
-      if: ${{ inputs.build-all == 'true' }}
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          build-essential \
-          cmake ninja-build pkg-config patchelf mold lld \
-          libboost-all-dev libcairo2-dev libgflags-dev libgoogle-glog-dev \
-          flex libfl-dev bison libeigen3-dev libgtest-dev \
-          libtbb-dev libhwloc-dev libcurl4-openssl-dev libunwind-dev \
-          libmetis-dev libgmp-dev tcl-dev \
-          unzip zip
+        dnf install -y epel-release dnf-plugins-core
+        dnf config-manager --set-enabled crb || true
+        dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+        dnf install -y \
+          cmake ninja-build pkgconfig patchelf mold lld \
+          boost-devel cairo-devel gflags-devel glog-devel \
+          flex flex-devel bison eigen3-devel gtest-devel \
+          tbb-devel hwloc-devel libcurl-devel libunwind-devel \
+          metis-devel gmp-devel tcl-devel \
+          unzip zip gh
 
     - name: Setup Rust
       if: ${{ inputs.build-all == 'true' }}

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -3,7 +3,7 @@ description: Setup Python 3.11, uv, and install project dependencies.
 
 inputs:
   build-all:
-    description: Skip installing prebuilt native wheels and install all packages with uv sync.
+    description: Build native dependencies from source instead of downloading prebuilt native wheels.
     required: false
     default: "false"
 
@@ -20,6 +20,24 @@ runs:
       with:
         version: latest
         enable-cache: "true"
+
+    - name: Install native build dependencies
+      if: ${{ inputs.build-all == 'true' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          cmake ninja-build pkg-config patchelf mold lld \
+          libboost-all-dev libcairo2-dev libgflags-dev libgoogle-glog-dev \
+          flex libfl-dev bison libeigen3-dev libgtest-dev \
+          libtbb-dev libhwloc-dev libcurl4-openssl-dev libunwind-dev \
+          libmetis-dev libgmp-dev tcl-dev \
+          unzip zip
+
+    - name: Setup Rust
+      if: ${{ inputs.build-all == 'true' }}
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Install native tool wheels
       if: ${{ inputs.build-all != 'true' }}

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,6 +1,12 @@
 name: Setup Python Dependencies
 description: Setup Python 3.11, uv, and install project dependencies.
 
+inputs:
+  build-all:
+    description: Skip installing prebuilt native wheels and install all packages with uv sync.
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -16,6 +22,7 @@ runs:
         enable-cache: "true"
 
     - name: Install native tool wheels
+      if: ${{ inputs.build-all != 'true' }}
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
@@ -25,24 +32,53 @@ runs:
         mkdir -p dist/native-wheels
         uv venv --python 3.11
 
-        dreamplace_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' chipcompiler/thirdparty/ecc-dreamplace/pyproject.toml)"
-        ecc_tools_version="$(sed -n 's/^version = "\(.*\)"$/\1/p' chipcompiler/thirdparty/ecc-tools/pyproject.toml)"
+        download_wheel_artifact() {
+          local repo="$1"
+          local submodule_path="$2"
+          local artifact_name="$3"
+          local commit
+          local run_id
 
-        gh release download "v$dreamplace_version" \
-          --repo "openecos-projects/ecc-dreamplace" \
-          --pattern '*.whl' \
-          --dir dist/native-wheels
+          commit="$(git rev-parse "HEAD:${submodule_path}")"
+          run_id="$(
+            gh api "repos/${repo}/actions/workflows/ci.yml/runs?head_sha=${commit}&per_page=20" \
+              --jq '[.workflow_runs[] | select(.conclusion == "success") | .id][0] // empty'
+          )"
 
-        gh release download "v$ecc_tools_version" \
-          --repo "openecos-projects/ecc-tools" \
-          --pattern '*.whl' \
-          --dir dist/native-wheels
+          if [ -z "$run_id" ]; then
+            echo "::error::No successful CI artifact found for ${repo} at submodule commit ${commit}"
+            exit 1
+          fi
+
+          echo "Downloading ${artifact_name} from ${repo} CI run ${run_id} (${commit})"
+          gh run download "$run_id" \
+            --repo "$repo" \
+            --name "$artifact_name" \
+            --dir dist/native-wheels
+        }
+
+        download_wheel_artifact \
+          "openecos-projects/ecc-dreamplace" \
+          "chipcompiler/thirdparty/ecc-dreamplace" \
+          "ecc-dreamplace-wheel"
+
+        download_wheel_artifact \
+          "openecos-projects/ecc-tools" \
+          "chipcompiler/thirdparty/ecc-tools" \
+          "ecc-tools-wheel"
 
         uv pip install --python .venv/bin/python --no-deps dist/native-wheels/*.whl
 
     - name: Install Python dependencies
       shell: bash
       run: |
-        uv sync --frozen --all-groups --python 3.11 --inexact \
-          --no-install-package ecc-dreamplace \
-          --no-install-package ecc-tools-bin
+        if [ "${{ inputs.build-all }}" = "true" ]; then
+          uv sync --frozen --all-groups --python 3.11 \
+            --no-build-isolation-package ecc-dreamplace \
+            --no-build-isolation-package ecc-tools-bin \
+            --verbose
+        else
+          uv sync --frozen --all-groups --python 3.11 --inexact \
+            --no-install-package ecc-dreamplace \
+            --no-install-package ecc-tools-bin
+        fi

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -39,6 +39,10 @@ runs:
       if: ${{ inputs.build-all == 'true' }}
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Setup sccache
+      if: ${{ inputs.build-all == 'true' }}
+      uses: mozilla-actions/sccache-action@v0.0.9
+
     - name: Install native tool wheels
       if: ${{ inputs.build-all != 'true' }}
       shell: bash
@@ -91,6 +95,8 @@ runs:
       shell: bash
       run: |
         if [ "${{ inputs.build-all }}" = "true" ]; then
+          export SCCACHE_GHA_ENABLED="true"
+          export CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
           uv sync --frozen --all-groups --python 3.11 \
             --no-build-isolation-package ecc-dreamplace \
             --no-build-isolation-package ecc-tools-bin \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
     name: Test
     needs: check-version
     runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,6 +107,7 @@ jobs:
     name: Build PyInstaller Bundle
     needs: check-version
     runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      build-all:
+        description: Build native dependencies from source instead of downloading prebuilt native wheels.
+        required: false
+        type: boolean
+        default: false
   push:
     branches: [main]
   pull_request:
@@ -27,6 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -55,6 +62,8 @@ jobs:
 
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
+        with:
+          build-all: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['build-all'] == 'true' && 'true' || 'false' }}
 
       - name: Setup PDK
         run: |
@@ -105,6 +114,8 @@ jobs:
 
       - name: Setup Python dependencies
         uses: ./.github/actions/setup-python-deps
+        with:
+          build-all: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs['build-all'] == 'true' && 'true' || 'false' }}
 
       - name: Smoke test native toolchain wheels
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         default: 'v0.1.0-alpha.3'
 
 permissions:
+  actions: read
   contents: write
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     name: Build CLI Bundle
     needs: check-version
     runs-on: ubuntu-22.04
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/test/cli/commands/test_log.py
+++ b/test/cli/commands/test_log.py
@@ -533,46 +533,46 @@ class TestLogNoErrorsInDisclosure:
         assert "--errors" not in out
 
 
-class TestLogUnreadableFile:
-    """AC-9: Unreadable log files return non-zero with OS error."""
+# class TestLogUnreadableFile:
+#     """AC-9: Unreadable log files return non-zero with OS error."""
 
-    def test_unreadable_log_returns_nonzero(self, tmp_path, capsys, create_cli_project):
-        project_dir = create_cli_project()
-        run_dir = os.path.join(project_dir, "runs", "default")
-        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-        os.makedirs(step_dir, exist_ok=True)
-        log_path = os.path.join(step_dir, "synthesis.log")
-        with open(log_path, "w") as f:
-            f.write("content\n")
-        os.chmod(log_path, 0o000)
+#     def test_unreadable_log_returns_nonzero(self, tmp_path, capsys, create_cli_project):
+#         project_dir = create_cli_project()
+#         run_dir = os.path.join(project_dir, "runs", "default")
+#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+#         os.makedirs(step_dir, exist_ok=True)
+#         log_path = os.path.join(step_dir, "synthesis.log")
+#         with open(log_path, "w") as f:
+#             f.write("content\n")
+#         os.chmod(log_path, 0o000)
 
-        try:
-            rc = cli_main.run(["log", "synthesis", "--project", project_dir])
-            assert rc == 1
-            out = capsys.readouterr().out
-            assert "unreadable" in out
-        finally:
-            os.chmod(log_path, 0o644)
+#         try:
+#             rc = cli_main.run(["log", "synthesis", "--project", project_dir])
+#             assert rc == 1
+#             out = capsys.readouterr().out
+#             assert "unreadable" in out
+#         finally:
+#             os.chmod(log_path, 0o644)
 
-    def test_unreadable_log_jsonl(self, tmp_path, capsys, create_cli_project):
-        project_dir = create_cli_project()
-        run_dir = os.path.join(project_dir, "runs", "default")
-        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-        os.makedirs(step_dir, exist_ok=True)
-        log_path = os.path.join(step_dir, "synthesis.log")
-        with open(log_path, "w") as f:
-            f.write("content\n")
-        os.chmod(log_path, 0o000)
+#     def test_unreadable_log_jsonl(self, tmp_path, capsys, create_cli_project):
+#         project_dir = create_cli_project()
+#         run_dir = os.path.join(project_dir, "runs", "default")
+#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+#         os.makedirs(step_dir, exist_ok=True)
+#         log_path = os.path.join(step_dir, "synthesis.log")
+#         with open(log_path, "w") as f:
+#             f.write("content\n")
+#         os.chmod(log_path, 0o000)
 
-        try:
-            rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
-            assert rc == 1
-            record = json.loads(capsys.readouterr().out.strip())
-            assert record["log_status"] == "unreadable"
-            assert "source" in record
-            assert "error" in record
-        finally:
-            os.chmod(log_path, 0o644)
+#         try:
+#             rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
+#             assert rc == 1
+#             record = json.loads(capsys.readouterr().out.strip())
+#             assert record["log_status"] == "unreadable"
+#             assert "source" in record
+#             assert "error" in record
+#         finally:
+#             os.chmod(log_path, 0o644)
 
 
 class TestLogMultiSource:
@@ -955,26 +955,26 @@ class TestLogStepUnchanged:
             assert "tail" not in rec
 
 
-class TestLogListingUnreadable:
-    """Unreadable logs in listing mode must omit tail, keep path+inspect, no traceback."""
+# class TestLogListingUnreadable:
+#     """Unreadable logs in listing mode must omit tail, keep path+inspect, no traceback."""
 
-    def test_unreadable_step_log_in_listing(self, tmp_path, capsys, create_cli_project):
-        project_dir = create_cli_project()
-        run_dir = os.path.join(project_dir, "runs", "default")
-        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-        os.makedirs(step_dir, exist_ok=True)
-        log_path = os.path.join(step_dir, "synthesis.log")
-        with open(log_path, "w") as f:
-            f.write("content\n")
-        os.chmod(log_path, 0o000)
+#     def test_unreadable_step_log_in_listing(self, tmp_path, capsys, create_cli_project):
+#         project_dir = create_cli_project()
+#         run_dir = os.path.join(project_dir, "runs", "default")
+#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+#         os.makedirs(step_dir, exist_ok=True)
+#         log_path = os.path.join(step_dir, "synthesis.log")
+#         with open(log_path, "w") as f:
+#             f.write("content\n")
+#         os.chmod(log_path, 0o000)
 
-        try:
-            rc = cli_main.run(["log", "--project", project_dir])
-            assert rc == 0
-            out = capsys.readouterr().out
-            assert "tail:" not in out
-            assert "Synthesis_yosys" in out
-            assert "inspect:" in out
-            assert "Traceback" not in out
-        finally:
-            os.chmod(log_path, 0o644)
+#         try:
+#             rc = cli_main.run(["log", "--project", project_dir])
+#             assert rc == 0
+#             out = capsys.readouterr().out
+#             assert "tail:" not in out
+#             assert "Synthesis_yosys" in out
+#             assert "inspect:" in out
+#             assert "Traceback" not in out
+#         finally:
+#             os.chmod(log_path, 0o644)

--- a/test/cli/commands/test_log.py
+++ b/test/cli/commands/test_log.py
@@ -4,6 +4,18 @@ import os
 from chipcompiler.cli import main as cli_main
 
 
+def _make_path_unreadable(monkeypatch, unreadable_path):
+    real_open = open
+    unreadable_path = os.fspath(unreadable_path)
+
+    def open_unless_target(path, *args, **kwargs):
+        if os.fspath(path) == unreadable_path:
+            raise PermissionError("cannot read")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", open_unless_target)
+
+
 class TestLog:
     def test_log_step_errors(self, tmp_path, capsys, create_cli_project):
         project_dir = create_cli_project()
@@ -533,46 +545,42 @@ class TestLogNoErrorsInDisclosure:
         assert "--errors" not in out
 
 
-# class TestLogUnreadableFile:
-#     """AC-9: Unreadable log files return non-zero with OS error."""
+class TestLogUnreadableFile:
+    """AC-9: Unreadable log files return non-zero with OS error."""
 
-#     def test_unreadable_log_returns_nonzero(self, tmp_path, capsys, create_cli_project):
-#         project_dir = create_cli_project()
-#         run_dir = os.path.join(project_dir, "runs", "default")
-#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-#         os.makedirs(step_dir, exist_ok=True)
-#         log_path = os.path.join(step_dir, "synthesis.log")
-#         with open(log_path, "w") as f:
-#             f.write("content\n")
-#         os.chmod(log_path, 0o000)
+    def test_unreadable_log_returns_nonzero(
+        self, tmp_path, monkeypatch, capsys, create_cli_project
+    ):
+        project_dir = create_cli_project()
+        run_dir = os.path.join(project_dir, "runs", "default")
+        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+        os.makedirs(step_dir, exist_ok=True)
+        log_path = os.path.join(step_dir, "synthesis.log")
+        with open(log_path, "w") as f:
+            f.write("content\n")
+        _make_path_unreadable(monkeypatch, log_path)
 
-#         try:
-#             rc = cli_main.run(["log", "synthesis", "--project", project_dir])
-#             assert rc == 1
-#             out = capsys.readouterr().out
-#             assert "unreadable" in out
-#         finally:
-#             os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "synthesis", "--project", project_dir])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "unreadable" in out
 
-#     def test_unreadable_log_jsonl(self, tmp_path, capsys, create_cli_project):
-#         project_dir = create_cli_project()
-#         run_dir = os.path.join(project_dir, "runs", "default")
-#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-#         os.makedirs(step_dir, exist_ok=True)
-#         log_path = os.path.join(step_dir, "synthesis.log")
-#         with open(log_path, "w") as f:
-#             f.write("content\n")
-#         os.chmod(log_path, 0o000)
+    def test_unreadable_log_jsonl(self, tmp_path, monkeypatch, capsys, create_cli_project):
+        project_dir = create_cli_project()
+        run_dir = os.path.join(project_dir, "runs", "default")
+        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+        os.makedirs(step_dir, exist_ok=True)
+        log_path = os.path.join(step_dir, "synthesis.log")
+        with open(log_path, "w") as f:
+            f.write("content\n")
+        _make_path_unreadable(monkeypatch, log_path)
 
-#         try:
-#             rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
-#             assert rc == 1
-#             record = json.loads(capsys.readouterr().out.strip())
-#             assert record["log_status"] == "unreadable"
-#             assert "source" in record
-#             assert "error" in record
-#         finally:
-#             os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
+        assert rc == 1
+        record = json.loads(capsys.readouterr().out.strip())
+        assert record["log_status"] == "unreadable"
+        assert "source" in record
+        assert "error" in record
 
 
 class TestLogMultiSource:
@@ -955,26 +963,25 @@ class TestLogStepUnchanged:
             assert "tail" not in rec
 
 
-# class TestLogListingUnreadable:
-#     """Unreadable logs in listing mode must omit tail, keep path+inspect, no traceback."""
+class TestLogListingUnreadable:
+    """Unreadable logs in listing mode must omit tail, keep path+inspect, no traceback."""
 
-#     def test_unreadable_step_log_in_listing(self, tmp_path, capsys, create_cli_project):
-#         project_dir = create_cli_project()
-#         run_dir = os.path.join(project_dir, "runs", "default")
-#         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
-#         os.makedirs(step_dir, exist_ok=True)
-#         log_path = os.path.join(step_dir, "synthesis.log")
-#         with open(log_path, "w") as f:
-#             f.write("content\n")
-#         os.chmod(log_path, 0o000)
+    def test_unreadable_step_log_in_listing(
+        self, tmp_path, monkeypatch, capsys, create_cli_project
+    ):
+        project_dir = create_cli_project()
+        run_dir = os.path.join(project_dir, "runs", "default")
+        step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
+        os.makedirs(step_dir, exist_ok=True)
+        log_path = os.path.join(step_dir, "synthesis.log")
+        with open(log_path, "w") as f:
+            f.write("content\n")
+        _make_path_unreadable(monkeypatch, log_path)
 
-#         try:
-#             rc = cli_main.run(["log", "--project", project_dir])
-#             assert rc == 0
-#             out = capsys.readouterr().out
-#             assert "tail:" not in out
-#             assert "Synthesis_yosys" in out
-#             assert "inspect:" in out
-#             assert "Traceback" not in out
-#         finally:
-#             os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "--project", project_dir])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "tail:" not in out
+        assert "Synthesis_yosys" in out
+        assert "inspect:" in out
+        assert "Traceback" not in out

--- a/test/cli/rendering/test_log_view.py
+++ b/test/cli/rendering/test_log_view.py
@@ -1,5 +1,3 @@
-import os
-
 from chipcompiler.cli.inspection.log_view import (
     LineKind,
     annotate_log_lines,
@@ -852,17 +850,18 @@ class TestTailLinesForLog:
         result = tail_lines_for_log(str(log_file))
         assert result == ["abc", "done"]
 
-    # def test_unreadable_file_returns_empty(self, tmp_path):
-    #     from chipcompiler.cli.inspection.log_view import tail_lines_for_log
+    def test_unreadable_file_returns_empty(self, monkeypatch, tmp_path):
+        from chipcompiler.cli.inspection.log_view import tail_lines_for_log
 
-    #     log_file = tmp_path / "test.log"
-    #     log_file.write_text("content\n")
-    #     os.chmod(str(log_file), 0o000)
-    #     try:
-    #         result = tail_lines_for_log(str(log_file))
-    #         assert result == []
-    #     finally:
-    #         os.chmod(str(log_file), 0o644)
+        log_file = tmp_path / "test.log"
+        log_file.write_text("content\n")
+
+        def raise_permission_error(*args, **kwargs):
+            raise PermissionError("cannot read")
+
+        monkeypatch.setattr("builtins.open", raise_permission_error)
+        result = tail_lines_for_log(str(log_file))
+        assert result == []
 
 
 class TestListingTailRendering:

--- a/test/cli/rendering/test_log_view.py
+++ b/test/cli/rendering/test_log_view.py
@@ -852,17 +852,17 @@ class TestTailLinesForLog:
         result = tail_lines_for_log(str(log_file))
         assert result == ["abc", "done"]
 
-    def test_unreadable_file_returns_empty(self, tmp_path):
-        from chipcompiler.cli.inspection.log_view import tail_lines_for_log
+    # def test_unreadable_file_returns_empty(self, tmp_path):
+    #     from chipcompiler.cli.inspection.log_view import tail_lines_for_log
 
-        log_file = tmp_path / "test.log"
-        log_file.write_text("content\n")
-        os.chmod(str(log_file), 0o000)
-        try:
-            result = tail_lines_for_log(str(log_file))
-            assert result == []
-        finally:
-            os.chmod(str(log_file), 0o644)
+    #     log_file = tmp_path / "test.log"
+    #     log_file.write_text("content\n")
+    #     os.chmod(str(log_file), 0o000)
+    #     try:
+    #         result = tail_lines_for_log(str(log_file))
+    #         assert result == []
+    #     finally:
+    #         os.chmod(str(log_file), 0o644)
 
 
 class TestListingTailRendering:


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] `bazel build //:build_ecc_cli_bundle`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
