### PR TITLE
test: avoid chmod for unreadable log tests

### DIFF
--- a/test/cli/commands/test_log.py
+++ b/test/cli/commands/test_log.py
@@ -4,6 +4,18 @@ import os
 from chipcompiler.cli import main as cli_main
 
 
+def _make_path_unreadable(monkeypatch, unreadable_path):
+    real_open = open
+    unreadable_path = os.fspath(unreadable_path)
+
+    def open_unless_target(path, *args, **kwargs):
+        if os.fspath(path) == unreadable_path:
+            raise PermissionError("cannot read")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", open_unless_target)
+
+
 class TestLog:
     def test_log_step_errors(self, tmp_path, capsys, create_cli_project):
         project_dir = create_cli_project()
@@ -536,7 +548,9 @@ class TestLogNoErrorsInDisclosure:
 class TestLogUnreadableFile:
     """AC-9: Unreadable log files return non-zero with OS error."""
 
-    def test_unreadable_log_returns_nonzero(self, tmp_path, capsys, create_cli_project):
+    def test_unreadable_log_returns_nonzero(
+        self, tmp_path, monkeypatch, capsys, create_cli_project
+    ):
         project_dir = create_cli_project()
         run_dir = os.path.join(project_dir, "runs", "default")
         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
@@ -544,17 +558,14 @@ class TestLogUnreadableFile:
         log_path = os.path.join(step_dir, "synthesis.log")
         with open(log_path, "w") as f:
             f.write("content\n")
-        os.chmod(log_path, 0o000)
+        _make_path_unreadable(monkeypatch, log_path)
 
-        try:
-            rc = cli_main.run(["log", "synthesis", "--project", project_dir])
-            assert rc == 1
-            out = capsys.readouterr().out
-            assert "unreadable" in out
-        finally:
-            os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "synthesis", "--project", project_dir])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "unreadable" in out
 
-    def test_unreadable_log_jsonl(self, tmp_path, capsys, create_cli_project):
+    def test_unreadable_log_jsonl(self, tmp_path, monkeypatch, capsys, create_cli_project):
         project_dir = create_cli_project()
         run_dir = os.path.join(project_dir, "runs", "default")
         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
@@ -562,17 +573,14 @@ class TestLogUnreadableFile:
         log_path = os.path.join(step_dir, "synthesis.log")
         with open(log_path, "w") as f:
             f.write("content\n")
-        os.chmod(log_path, 0o000)
+        _make_path_unreadable(monkeypatch, log_path)
 
-        try:
-            rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
-            assert rc == 1
-            record = json.loads(capsys.readouterr().out.strip())
-            assert record["log_status"] == "unreadable"
-            assert "source" in record
-            assert "error" in record
-        finally:
-            os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "synthesis", "--jsonl", "--project", project_dir])
+        assert rc == 1
+        record = json.loads(capsys.readouterr().out.strip())
+        assert record["log_status"] == "unreadable"
+        assert "source" in record
+        assert "error" in record
 
 
 class TestLogMultiSource:
@@ -958,7 +966,9 @@ class TestLogStepUnchanged:
 class TestLogListingUnreadable:
     """Unreadable logs in listing mode must omit tail, keep path+inspect, no traceback."""
 
-    def test_unreadable_step_log_in_listing(self, tmp_path, capsys, create_cli_project):
+    def test_unreadable_step_log_in_listing(
+        self, tmp_path, monkeypatch, capsys, create_cli_project
+    ):
         project_dir = create_cli_project()
         run_dir = os.path.join(project_dir, "runs", "default")
         step_dir = os.path.join(run_dir, "Synthesis_yosys", "log")
@@ -966,15 +976,12 @@ class TestLogListingUnreadable:
         log_path = os.path.join(step_dir, "synthesis.log")
         with open(log_path, "w") as f:
             f.write("content\n")
-        os.chmod(log_path, 0o000)
+        _make_path_unreadable(monkeypatch, log_path)
 
-        try:
-            rc = cli_main.run(["log", "--project", project_dir])
-            assert rc == 0
-            out = capsys.readouterr().out
-            assert "tail:" not in out
-            assert "Synthesis_yosys" in out
-            assert "inspect:" in out
-            assert "Traceback" not in out
-        finally:
-            os.chmod(log_path, 0o644)
+        rc = cli_main.run(["log", "--project", project_dir])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "tail:" not in out
+        assert "Synthesis_yosys" in out
+        assert "inspect:" in out
+        assert "Traceback" not in out

--- a/test/cli/rendering/test_log_view.py
+++ b/test/cli/rendering/test_log_view.py
@@ -1,5 +1,3 @@
-import os
-
 from chipcompiler.cli.inspection.log_view import (
     LineKind,
     annotate_log_lines,
@@ -852,17 +850,18 @@ class TestTailLinesForLog:
         result = tail_lines_for_log(str(log_file))
         assert result == ["abc", "done"]
 
-    def test_unreadable_file_returns_empty(self, tmp_path):
+    def test_unreadable_file_returns_empty(self, monkeypatch, tmp_path):
         from chipcompiler.cli.inspection.log_view import tail_lines_for_log
 
         log_file = tmp_path / "test.log"
         log_file.write_text("content\n")
-        os.chmod(str(log_file), 0o000)
-        try:
-            result = tail_lines_for_log(str(log_file))
-            assert result == []
-        finally:
-            os.chmod(str(log_file), 0o644)
+
+        def raise_permission_error(*args, **kwargs):
+            raise PermissionError("cannot read")
+
+        monkeypatch.setattr("builtins.open", raise_permission_error)
+        result = tail_lines_for_log(str(log_file))
+        assert result == []
 
 
 class TestListingTailRendering:


### PR DESCRIPTION
## Summary

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

-

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] `bazel build //:build_ecc_cli_bundle`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
