### PR TITLE
feat(cli): add reset workspace flow command

### DIFF
--- a/chipcompiler/cli/commands/workspace.py
+++ b/chipcompiler/cli/commands/workspace.py
@@ -20,6 +20,7 @@ from chipcompiler.cli.workspace.service import (
     get_workspace_info,
     load_workspace,
     refresh_workspace_config,
+    reset_workspace_flow,
     run_workspace_flow,
     run_workspace_step,
     sync_workspace_config,
@@ -228,6 +229,14 @@ def run_flow_cmd(
     json_output: Annotated[bool, typer.Option("--json")] = False,
 ) -> None:
     _dispatch_runtime(lambda: run_workspace_flow(directory, rerun), json_output)
+
+
+@workspace_app.command("reset-flow", help="Clear workspace run artifacts using rerun reset logic")
+def reset_flow_cmd(
+    directory: Annotated[str, typer.Option("--directory")] = "",
+    json_output: Annotated[bool, typer.Option("--json")] = False,
+) -> None:
+    _dispatch_runtime(lambda: reset_workspace_flow(directory), json_output)
 
 
 @workspace_app.command("run-step", help="Run one workspace step")

--- a/chipcompiler/cli/workspace/service.py
+++ b/chipcompiler/cli/workspace/service.py
@@ -133,6 +133,39 @@ def run_workspace_flow(directory: str, rerun: bool) -> dict:
     )
 
 
+def reset_workspace_flow(directory: str) -> dict:
+    cmd = "reset_flow"
+    response_data = {"directory": os.path.abspath(directory) if directory else ""}
+    if not directory:
+        return workspace_response(
+            cmd,
+            "failed",
+            data=response_data,
+            message=["missing required field: directory"],
+        )
+
+    try:
+        workspace, engine_flow = load_workspace_runtime(directory)
+        _prepare_workspace_for_rerun(workspace, engine_flow)
+        response_data["directory"] = os.path.abspath(workspace.directory)
+    except WorkspaceValidationError as exc:
+        return workspace_response(cmd, "failed", data=response_data, message=[str(exc)])
+    except Exception as exc:
+        return workspace_response(
+            cmd,
+            "error",
+            data=response_data,
+            message=[f"reset workspace flow failed : {exc}"],
+        )
+
+    return workspace_response(
+        cmd,
+        "success",
+        data=response_data,
+        message=[f"reset workspace flow success : {response_data['directory']}"],
+    )
+
+
 def run_workspace_step(directory: str, step: str, rerun: bool) -> dict:
     cmd = "run_step"
     step = step or ""

--- a/test/cli/workspace/test_workspace_cli.py
+++ b/test/cli/workspace/test_workspace_cli.py
@@ -344,6 +344,32 @@ def test_refresh_config_cli_calls_workspace_refresh(monkeypatch, tmp_path, capsy
     assert refreshed == [os.path.abspath(ws)]
 
 
+def test_reset_flow_cli_clears_workspace_run_results(monkeypatch, tmp_path, capsys):
+    capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    prepared = []
+
+    def fake_prepare_workspace_for_rerun(workspace, engine_flow):
+        prepared.append((workspace.directory, engine_flow))
+
+    monkeypatch.setattr(
+        "chipcompiler.data.prepare_workspace_for_rerun",
+        fake_prepare_workspace_for_rerun,
+    )
+
+    rc = cli_main.run(["workspace", "reset-flow", "--directory", str(ws), "--json"])
+
+    data = _response(capsys)
+    assert rc == 0
+    assert data == {
+        "cmd": "reset_flow",
+        "response": "success",
+        "data": {"directory": os.path.abspath(ws)},
+        "message": [f"reset workspace flow success : {os.path.abspath(ws)}"],
+    }
+    assert capture["loaded"] == [str(ws)]
+    assert prepared == [(os.path.abspath(ws), DummyFlow.instances[0])]
+
+
 def test_sync_config_cli_rejects_path_outside_workspace_config(monkeypatch, tmp_path, capsys):
     _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
     outside = tmp_path / "outside.json"


### PR DESCRIPTION
## Summary

- Add `ecc workspace reset-flow` for clearing workspace run artifacts through the existing rerun reset logic.
- Return a machine-readable `reset_flow` response shape for desktop callers.

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Bazel, Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## What Changed

- Added `reset_workspace_flow()` to load a workspace and call the same `_prepare_workspace_for_rerun()` path used by rerun flow execution.
- Added the Typer command `ecc workspace reset-flow --directory <workspace> --json`.
- Added focused workspace CLI coverage for the new command.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [x] Focused pytest:
  - `.venv/bin/python -m pytest test/cli/workspace/test_workspace_cli.py::test_reset_flow_cli_clears_workspace_run_results -q`
  - `.venv/bin/python -m pytest test/cli/workspace/test_workspace_cli.py::test_refresh_config_cli_calls_workspace_refresh test/cli/workspace/test_workspace_cli.py::test_reset_flow_cli_clears_workspace_run_results test/cli/workspace/test_workspace_cli.py::test_workspace_help_uses_typer_app -q`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] `bazel build //:build_ecc_cli_bundle`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [x] Other:
  - `.venv/bin/ecc workspace reset-flow --help`

Skipped checks and reason:

- Full pytest, Ruff, Bazel, PyInstaller, Nix, and manual flow smoke were not run; this is a focused CLI/workspace command addition and the targeted CLI tests plus command help smoke cover the changed surface locally.

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, Bazel, or release artifact changed

Notes:

- Adds a new CLI command consumed by ECOS Studio desktop when managing RTL design files and clearing stale run results.
- Does not change dependency pins, version metadata, or nested submodules.

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
