### PR TITLE
chore: cleanup more bazel content treewide

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,10 +50,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
 # Install Rust (for Tauri).
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 
-# Install Bazel
-RUN wget https://github.com/bazelbuild/bazel/releases/download/8.5.0/bazel-8.5.0-linux-x86_64 -O /usr/local/bin/bazel \
-    && chmod +x /usr/local/bin/bazel
-
 # Install uv (Python package manager used by project).
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ln -s /root/.local/bin/uv /usr/local/bin/uv
@@ -73,9 +69,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     rm -rf .venv \
-    && uv sync --frozen --all-groups --python 3.11
-
-RUN bazel run //:install_dev
+    && uv sync --no-build-isolation-package ecc-dreamplace --no-build-isolation-package ecc-tools-bin --verbose
 
 ENV VIRTUAL_ENV="/workspace/.venv"
 ENV PATH="/workspace/.venv/bin:${PATH}"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,16 +40,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js (LTS) and pnpm.
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs \
-    && npm install -g pnpm \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Rust (for Tauri).
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
 # Install uv (Python package manager used by project).
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ln -s /root/.local/bin/uv /usr/local/bin/uv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,6 @@
   "containerEnv": {
     "PROJECT_ROOT": "${containerWorkspaceFolder}"
   },
-  "postCreateCommand": "bazel run //:prepare_dev",
+  "postCreateCommand": "uv sync --no-build-isolation-package ecc-dreamplace --no-build-isolation-package ecc-tools-bin --verbose && source .venv/bin/activate",
   "remoteUser": "root"
 }

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -28,7 +28,7 @@ class ECCToolsModule:
                 candidates = sorted(p.name for p in ecc_bin_dir.glob("ecc_py*.so"))
                 raise ImportError(
                     "ecc-tools is not installed. Install the ecc-tools wheel or "
-                    "build from source with: bazel run //:prepare_dev. "
+                    "build from source "
                     f"Import error: {exc}. "
                     f"Available ecc_py binaries in {ecc_bin_dir}: {candidates}"
                 ) from exc


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
