### PR TITLE
chore(ci): support Release branch, bump version to v0.1.0-alpha.5

### DIFF
--- a/.github/actions/build-pyinstaller-bundle/action.yml
+++ b/.github/actions/build-pyinstaller-bundle/action.yml
@@ -1,0 +1,79 @@
+name: Build PyInstaller Bundle
+description: Build, package, and smoke test the ECC PyInstaller CLI bundle.
+
+inputs:
+  artifact-path:
+    description: Path to write the packaged PyInstaller artifact.
+    required: false
+    default: dist/ecc.tar
+  artifact-format:
+    description: Artifact format. Supported values are "tar" and "tar.gz".
+    required: false
+    default: tar
+  smoke-dir:
+    description: Directory used to extract and smoke test the artifact.
+    required: false
+    default: dist/pyinstaller-smoke
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        ARTIFACT_FORMAT: ${{ inputs.artifact-format }}
+      run: |
+        case "$ARTIFACT_FORMAT" in
+          tar|tar.gz) ;;
+          *)
+            echo "::error::Unsupported artifact-format: $ARTIFACT_FORMAT"
+            exit 1
+            ;;
+        esac
+
+    - name: Build PyInstaller bundle
+      shell: bash
+      run: |
+        uv run --no-sync --managed-python pyinstaller ecc.spec --clean
+        mkdir -p dist/pyinstaller
+        tar -cf dist/pyinstaller/ecc.tar -C dist/ecc .
+
+    - name: Package PyInstaller artifact
+      shell: bash
+      env:
+        ARTIFACT_FORMAT: ${{ inputs.artifact-format }}
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+      run: |
+        mkdir -p "$(dirname "$ARTIFACT_PATH")"
+        case "$ARTIFACT_FORMAT" in
+          tar)
+            cp dist/pyinstaller/ecc.tar "$ARTIFACT_PATH"
+            ;;
+          tar.gz)
+            gzip -n -9 -c dist/pyinstaller/ecc.tar > "$ARTIFACT_PATH"
+            ;;
+        esac
+
+    - name: Smoke test PyInstaller artifact
+      shell: bash
+      env:
+        ARTIFACT_FORMAT: ${{ inputs.artifact-format }}
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        SMOKE_DIR: ${{ inputs.smoke-dir }}
+      run: |
+        rm -rf "$SMOKE_DIR"
+        mkdir -p "$SMOKE_DIR"
+
+        case "$ARTIFACT_FORMAT" in
+          tar)
+            tar -xf "$ARTIFACT_PATH" -C "$SMOKE_DIR"
+            ;;
+          tar.gz)
+            tar -xzf "$ARTIFACT_PATH" -C "$SMOKE_DIR"
+            ;;
+        esac
+
+        "$SMOKE_DIR/ecc" --help
+        "$SMOKE_DIR/ecc" --version
+        "$SMOKE_DIR/ecc" version --json
+        test -x "$SMOKE_DIR/_internal/torch/bin/torch_shm_manager"

--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -10,33 +10,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup Python 3.11
-      shell: bash
-      run: echo "/opt/python/cp311-cp311/bin" >> "$GITHUB_PATH"
-
     - name: Setup uv
       uses: astral-sh/setup-uv@v3
       with:
         version: latest
         enable-cache: "true"
 
+    - name: Setup uv-managed Python 3.11
+      shell: bash
+      run: uv python install 3.11
+
     - name: Trust GitHub workspace
       shell: bash
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-    - name: Install native build dependencies
+    - name: Install hosted native build dependencies
+      if: ${{ inputs.build-all == 'true' }}
       shell: bash
       run: |
-        dnf install -y epel-release dnf-plugins-core
-        dnf config-manager --set-enabled crb || true
-        dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-        dnf install -y \
-          cmake ninja-build pkgconfig patchelf mold lld \
-          boost-devel cairo-devel gflags-devel glog-devel \
-          flex flex-devel bison eigen3-devel gtest-devel \
-          tbb-devel hwloc-devel libcurl-devel libunwind-devel \
-          metis-devel gmp-devel tcl-devel \
-          unzip zip gh
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential cmake ninja-build pkg-config patchelf mold lld \
+          libboost-all-dev libcairo2-dev libgflags-dev libgoogle-glog-dev \
+          flex libfl-dev bison libeigen3-dev libgtest-dev libtbb-dev libhwloc-dev \
+          libcurl4-openssl-dev libunwind-dev libmetis-dev libgmp-dev \
+          tcl-dev unzip zip
 
     - name: Setup Rust
       if: ${{ inputs.build-all == 'true' }}
@@ -55,7 +53,7 @@ runs:
         set -euo pipefail
 
         mkdir -p dist/native-wheels
-        uv venv --python 3.11
+        uv venv --python 3.11 --managed-python
 
         download_wheel_artifact() {
           local repo="$1"
@@ -100,12 +98,12 @@ runs:
         if [ "${{ inputs.build-all }}" = "true" ]; then
           export SCCACHE_GHA_ENABLED="true"
           export CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
-          uv sync --frozen --all-groups --python 3.11 \
+          uv sync --frozen --all-groups --python 3.11 --managed-python \
             --no-build-isolation-package ecc-dreamplace \
             --no-build-isolation-package ecc-tools-bin \
             --verbose
         else
-          uv sync --frozen --all-groups --python 3.11 --inexact \
+          uv sync --frozen --all-groups --python 3.11 --managed-python --inexact \
             --no-install-package ecc-dreamplace \
             --no-install-package ecc-tools-bin
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ permissions:
   actions: read
   contents: read
 
-env:
-  UV_PYTHON_PREFERENCE: only-managed
-
 jobs:
   check-version:
     name: Check Version Consistency
@@ -52,8 +49,7 @@ jobs:
   test:
     name: Test
     needs: check-version
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_34_x86_64
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,8 +101,7 @@ jobs:
   build-pyinstaller:
     name: Build PyInstaller Bundle
     needs: check-version
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_34_x86_64
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,18 +126,10 @@ jobs:
           PY
 
       - name: Build PyInstaller bundle
-        run: |
-          uv run --no-sync pyinstaller ecc.spec --clean
-          tar -cf dist/ecc.tar -C dist/ecc .
-
-      - name: Smoke test PyInstaller bundle
-        run: |
-          mkdir -p dist/pyinstaller-smoke
-          tar -xf dist/ecc.tar -C dist/pyinstaller-smoke
-          dist/pyinstaller-smoke/ecc --help
-          dist/pyinstaller-smoke/ecc --version
-          dist/pyinstaller-smoke/ecc version --json
-          test -x dist/pyinstaller-smoke/_internal/torch/bin/torch_shm_manager
+        uses: ./.github/actions/build-pyinstaller-bundle
+        with:
+          artifact-path: dist/ecc.tar
+          artifact-format: tar
 
       - name: Upload PyInstaller artifact
         if: always()
@@ -152,4 +139,3 @@ jobs:
           if-no-files-found: ignore
           path: |
             dist/ecc.tar
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
     name: Build CLI Bundle
     needs: check-version
     runs-on: ubuntu-22.04
-    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,24 +45,10 @@ jobs:
         uses: ./.github/actions/setup-python-deps
 
       - name: Build PyInstaller bundle
-        run: |
-          uv run --no-sync pyinstaller ecc.spec --clean
-          tar -cf dist/ecc.tar -C dist/ecc .
-
-      - name: Package release artifact
-        run: |
-          mkdir -p dist/release
-          gzip -n -9 -c dist/ecc.tar \
-            > dist/release/ecc-cli-linux-x86_64.tar.gz
-
-      - name: Smoke test release artifact
-        run: |
-          mkdir -p dist/pyinstaller-smoke
-          tar -xzf dist/release/ecc-cli-linux-x86_64.tar.gz -C dist/pyinstaller-smoke
-          dist/pyinstaller-smoke/ecc --help
-          dist/pyinstaller-smoke/ecc --version
-          dist/pyinstaller-smoke/ecc version --json
-          test -x dist/pyinstaller-smoke/_internal/torch/bin/torch_shm_manager
+        uses: ./.github/actions/build-pyinstaller-bundle
+        with:
+          artifact-path: dist/release/ecc-cli-linux-x86_64.tar.gz
+          artifact-format: tar.gz
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4

--- a/chipcompiler/__init__.py
+++ b/chipcompiler/__init__.py
@@ -1,2 +1,2 @@
 # chipcompiler package
-__version__ = "0.1.0-alpha.4"
+__version__ = "0.1.0-alpha.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.8.5" ]
 
 [project]
 name = "ecc"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 readme = "README.md"
 authors = [
   { name = "Emin", email = "me@emin.chat" },


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
