### PR TITLE
fix(yosys): read gzip netlists in checklist

### DIFF
--- a/chipcompiler/tools/yosys/checklist.py
+++ b/chipcompiler/tools/yosys/checklist.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import gzip
 import os
-from pathlib import Path
 
 from chipcompiler.data import Checklist, CheckState, StepEnum, Workspace, WorkspaceStep
 from chipcompiler.utility import json_read
+from chipcompiler.utility.gzip import read_text_maybe_gzip
 
 
 class YosysChecklist:
@@ -116,21 +115,6 @@ class YosysChecklist:
 
 
 class YosysSynthesisChecklist(YosysChecklist):
-    def read_text(self, path: str | os.PathLike) -> str:
-        if not path:
-            return ""
-
-        path_obj = Path(path)
-        try:
-            if path_obj.suffix == ".gz":
-                with gzip.open(path_obj, "rt", encoding="utf-8", errors="ignore") as file:
-                    return file.read()
-
-            with path_obj.open("r", encoding="utf-8", errors="ignore") as file:
-                return file.read()
-        except (OSError, gzip.BadGzipFile, EOFError):
-            return ""
-
     def check_file(self,
                    path : str,
                    text_tokens : list | None = None) -> bool:
@@ -140,7 +124,11 @@ class YosysSynthesisChecklist(YosysChecklist):
         if not text_tokens:
             return True
 
-        content = self.read_text(path)
+        try:
+            content = read_text_maybe_gzip(path)
+        except (OSError, EOFError):
+            return False
+
         return all(token in content for token in text_tokens)
 
     def to_float(self,
@@ -156,8 +144,15 @@ class YosysSynthesisChecklist(YosysChecklist):
         metrics = json_read(self.workspace_step.analysis.get("metrics", ""))
         stat = json_read(self.workspace_step.feature.get("stat", ""))
 
-        log_text = self.read_text(self.workspace_step.log.get("file", ""))
-        netlist_text = self.read_text(self.workspace_step.output.get("verilog", ""))
+        try:
+            log_text = read_text_maybe_gzip(self.workspace_step.log.get("file", ""))
+        except (OSError, EOFError):
+            log_text = ""
+
+        try:
+            netlist_text = read_text_maybe_gzip(self.workspace_step.output.get("verilog", ""))
+        except (OSError, EOFError):
+            netlist_text = ""
 
         input_verilog = self.workspace_step.input.get("verilog", "")
         filelist = (

--- a/chipcompiler/tools/yosys/checklist.py
+++ b/chipcompiler/tools/yosys/checklist.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
+import gzip
 import os
+from pathlib import Path
 
-from chipcompiler.data import (
-    Workspace, WorkspaceStep, Checklist, StepEnum, CheckState
-)
+from chipcompiler.data import Checklist, CheckState, StepEnum, Workspace, WorkspaceStep
 from chipcompiler.utility import json_read
+
 
 class YosysChecklist:
     CHECKLIST_ITEMS = {
@@ -116,6 +116,21 @@ class YosysChecklist:
 
 
 class YosysSynthesisChecklist(YosysChecklist):
+    def read_text(self, path: str | os.PathLike) -> str:
+        if not path:
+            return ""
+
+        path_obj = Path(path)
+        try:
+            if path_obj.suffix == ".gz":
+                with gzip.open(path_obj, "rt", encoding="utf-8", errors="ignore") as file:
+                    return file.read()
+
+            with path_obj.open("r", encoding="utf-8", errors="ignore") as file:
+                return file.read()
+        except (OSError, gzip.BadGzipFile, EOFError):
+            return ""
+
     def check_file(self,
                    path : str,
                    text_tokens : list | None = None) -> bool:
@@ -125,12 +140,7 @@ class YosysSynthesisChecklist(YosysChecklist):
         if not text_tokens:
             return True
 
-        try:
-            with open(path, "r", encoding="utf-8", errors="ignore") as file:
-                content = file.read()
-        except OSError:
-            return False
-
+        content = self.read_text(path)
         return all(token in content for token in text_tokens)
 
     def to_float(self,
@@ -146,19 +156,8 @@ class YosysSynthesisChecklist(YosysChecklist):
         metrics = json_read(self.workspace_step.analysis.get("metrics", ""))
         stat = json_read(self.workspace_step.feature.get("stat", ""))
 
-        try:
-            with open(self.workspace_step.log.get("file", ""),
-                      "r", encoding="utf-8", errors="ignore") as file:
-                log_text = file.read()
-        except OSError:
-            log_text = ""
-
-        try:
-            with open(self.workspace_step.output.get("verilog", ""),
-                      "r", encoding="utf-8", errors="ignore") as file:
-                netlist_text = file.read()
-        except OSError:
-            netlist_text = ""
+        log_text = self.read_text(self.workspace_step.log.get("file", ""))
+        netlist_text = self.read_text(self.workspace_step.output.get("verilog", ""))
 
         input_verilog = self.workspace_step.input.get("verilog", "")
         filelist = (

--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -1,12 +1,35 @@
 #!/usr/bin/env python
+import gzip
 import os
 import subprocess
+from pathlib import Path
 
 from chipcompiler.data import StateEnum, Workspace, WorkspaceStep
 from chipcompiler.tools.yosys.checklist import YosysChecklist
 from chipcompiler.tools.yosys.metrics import build_step_metrics
 from chipcompiler.tools.yosys.subflow import YosysSubFlow
 from chipcompiler.tools.yosys.utility import check_slang_plugin, get_yosys_runtime
+
+
+def _read_netlist_text(path: str) -> str:
+    path_obj = Path(path)
+    if path_obj.suffix == ".gz":
+        with gzip.open(path_obj, "rt", encoding="utf-8", errors="ignore") as src:
+            return src.read()
+
+    with path_obj.open("r", encoding="utf-8", errors="ignore") as src:
+        return src.read()
+
+
+def _write_netlist_text(path: str, text: str) -> None:
+    path_obj = Path(path)
+    if path_obj.suffix == ".gz":
+        with gzip.open(path_obj, "wt", encoding="utf-8") as dst:
+            dst.write(text)
+        return
+
+    with path_obj.open("w", encoding="utf-8") as dst:
+        dst.write(text)
 
 
 def _remove_parameter_overrides(text: str) -> str:
@@ -44,13 +67,9 @@ def _write_fixed_netlist(src_path: str, dst_path: str) -> bool:
     if not src_path or not dst_path or not os.path.exists(src_path):
         return False
 
-    with open(src_path, "r", encoding="utf-8", errors="ignore") as src:
-        text = src.read()
-
+    text = _read_netlist_text(src_path)
     fixed = _remove_parameter_overrides(text)
-
-    with open(dst_path, "w", encoding="utf-8") as dst:
-        dst.write(fixed)
+    _write_netlist_text(dst_path, fixed)
 
     return True
 

--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -1,35 +1,13 @@
 #!/usr/bin/env python
-import gzip
 import os
 import subprocess
-from pathlib import Path
 
 from chipcompiler.data import StateEnum, Workspace, WorkspaceStep
 from chipcompiler.tools.yosys.checklist import YosysChecklist
 from chipcompiler.tools.yosys.metrics import build_step_metrics
 from chipcompiler.tools.yosys.subflow import YosysSubFlow
 from chipcompiler.tools.yosys.utility import check_slang_plugin, get_yosys_runtime
-
-
-def _read_netlist_text(path: str) -> str:
-    path_obj = Path(path)
-    if path_obj.suffix == ".gz":
-        with gzip.open(path_obj, "rt", encoding="utf-8", errors="ignore") as src:
-            return src.read()
-
-    with path_obj.open("r", encoding="utf-8", errors="ignore") as src:
-        return src.read()
-
-
-def _write_netlist_text(path: str, text: str) -> None:
-    path_obj = Path(path)
-    if path_obj.suffix == ".gz":
-        with gzip.open(path_obj, "wt", encoding="utf-8") as dst:
-            dst.write(text)
-        return
-
-    with path_obj.open("w", encoding="utf-8") as dst:
-        dst.write(text)
+from chipcompiler.utility.gzip import read_text_maybe_gzip, write_text_maybe_gzip
 
 
 def _remove_parameter_overrides(text: str) -> str:
@@ -67,9 +45,9 @@ def _write_fixed_netlist(src_path: str, dst_path: str) -> bool:
     if not src_path or not dst_path or not os.path.exists(src_path):
         return False
 
-    text = _read_netlist_text(src_path)
+    text = read_text_maybe_gzip(src_path)
     fixed = _remove_parameter_overrides(text)
-    _write_netlist_text(dst_path, fixed)
+    write_text_maybe_gzip(dst_path, fixed)
 
     return True
 

--- a/chipcompiler/utility/gzip.py
+++ b/chipcompiler/utility/gzip.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import gzip
+import os
+from pathlib import Path
+
+
+def read_text_maybe_gzip(
+    path: str | os.PathLike,
+    encoding: str = "utf-8",
+    errors: str = "ignore",
+) -> str:
+    path_obj = Path(path)
+    if path_obj.suffix == ".gz":
+        with gzip.open(path_obj, "rt", encoding=encoding, errors=errors) as file:
+            return file.read()
+
+    with path_obj.open("r", encoding=encoding, errors=errors) as file:
+        return file.read()
+
+
+def write_text_maybe_gzip(
+    path: str | os.PathLike,
+    text: str,
+    encoding: str = "utf-8",
+) -> None:
+    path_obj = Path(path)
+    if path_obj.suffix == ".gz":
+        with gzip.open(path_obj, "wt", encoding=encoding) as file:
+            file.write(text)
+        return
+
+    with path_obj.open("w", encoding=encoding) as file:
+        file.write(text)

--- a/test/tools/yosys/test_checklist.py
+++ b/test/tools/yosys/test_checklist.py
@@ -1,0 +1,64 @@
+import gzip
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from chipcompiler.tools.yosys.checklist import YosysSynthesisChecklist
+
+
+def _write_text(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_synthesis_checklist_reads_gzip_mapped_netlist(tmp_path):
+    rtl = _write_text(tmp_path / "rtl" / "top.v", "module top; endmodule\n")
+    lib = _write_text(tmp_path / "lib" / "std.lib", "library(std) {}\n")
+    log = _write_text(tmp_path / "Synthesis_yosys" / "log" / "Synthesis.log", "End of script.\n")
+    metrics = _write_json(
+        tmp_path / "Synthesis_yosys" / "analysis" / "Synthesis_metrics.json",
+        {"Cell number": 1, "Cell area": 1.0},
+    )
+    stat = _write_json(
+        tmp_path / "Synthesis_yosys" / "feature" / "Synthesis_stat.json",
+        {
+            "modules": {"top": {}},
+            "design": {"num_cells": 1, "area": 1.0},
+            "invocation": "stat -liberty std.lib",
+        },
+    )
+    netlist = tmp_path / "Synthesis_yosys" / "output" / "top_Synthesis.v.gz"
+    netlist.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(netlist, "wt", encoding="utf-8") as file:
+        file.write("module top();\n  BUFX4 u0();\nendmodule\n")
+
+    checklist_path = tmp_path / "Synthesis_yosys" / "checklist.json"
+    workspace = SimpleNamespace(
+        design=SimpleNamespace(input_filelist="", top_module="top", name="top"),
+        parameters=SimpleNamespace(data={"Frequency max [MHz]": 100}),
+        pdk=SimpleNamespace(libs=[str(lib)]),
+        home=SimpleNamespace(update_checklist=lambda **kwargs: None),
+    )
+    step = SimpleNamespace(
+        name="Synthesis",
+        input={"verilog": str(rtl)},
+        analysis={"metrics": str(metrics)},
+        feature={"stat": str(stat)},
+        log={"file": str(log)},
+        output={"verilog": str(netlist)},
+        checklist={"path": str(checklist_path)},
+    )
+
+    assert YosysSynthesisChecklist(workspace, step).check() is True
+
+    data = json.loads(checklist_path.read_text(encoding="utf-8"))
+    netlist_item = next(item for item in data["checklist"] if item["type"] == "Netlist")
+    assert netlist_item["state"] == "Passed"
+    assert netlist_item["info"] == ""

--- a/test/tools/yosys/test_runner.py
+++ b/test/tools/yosys/test_runner.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import gzip
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -146,3 +147,19 @@ def test_run_step_marks_invalid_when_yosys_is_missing(tmp_path, monkeypatch):
     assert result is False
     assert ("run yosys", StateEnum.Invalid) in updates
     assert "yosys is not available" in log_file.read_text()
+
+
+def test_write_fixed_netlist_handles_gzip_paths(tmp_path):
+    source = tmp_path / "source.v.gz"
+    destination = tmp_path / "fixed.v.gz"
+    with gzip.open(source, "wt", encoding="utf-8") as file:
+        file.write("module top;\n  CELL #(.WIDTH(1)) u0();\nendmodule\n")
+
+    assert runner._write_fixed_netlist(str(source), str(destination)) is True
+
+    with gzip.open(destination, "rt", encoding="utf-8") as file:
+        fixed = file.read()
+
+    assert "module top" in fixed
+    assert "#(" not in fixed
+    assert "endmodule" in fixed

--- a/test/utility/test_gzip.py
+++ b/test/utility/test_gzip.py
@@ -1,0 +1,27 @@
+import gzip
+
+from chipcompiler.utility.gzip import read_text_maybe_gzip, write_text_maybe_gzip
+
+
+def test_read_text_maybe_gzip_reads_plain_text(tmp_path):
+    path = tmp_path / "netlist.v"
+    path.write_text("module top; endmodule\n", encoding="utf-8")
+
+    assert read_text_maybe_gzip(path) == "module top; endmodule\n"
+
+
+def test_read_text_maybe_gzip_reads_gzip_text(tmp_path):
+    path = tmp_path / "netlist.v.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as file:
+        file.write("module top; endmodule\n")
+
+    assert read_text_maybe_gzip(path) == "module top; endmodule\n"
+
+
+def test_write_text_maybe_gzip_writes_gzip_text(tmp_path):
+    path = tmp_path / "netlist.v.gz"
+
+    write_text_maybe_gzip(path, "module top; endmodule\n")
+
+    with gzip.open(path, "rt", encoding="utf-8") as file:
+        assert file.read() == "module top; endmodule\n"

--- a/uv.lock
+++ b/uv.lock
@@ -517,7 +517,7 @@ dev = [
 
 [[package]]
 name = "ecc-dreamplace"
-version = "0.1.0a6"
+version = "0.1.0a5"
 source = { editable = "chipcompiler/thirdparty/ecc-dreamplace" }
 dependencies = [
     { name = "cairocffi" },


### PR DESCRIPTION
## What Changed
  - Added shared gzip/plain text helpers in `chipcompiler/utility/gzip.py: read_text_maybe_gzip` and `write_text_maybe_gzip`.
  - Updated Yosys checklist and fixed-netlist generation to use the shared helpers.
  - Added utility tests for gzip/plain text I/O.
  - Kept the change scoped to Yosys; DreamPlace’s plain `read_text` was not migrated.

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
