### PR TITLE
fix: prevent runtime write filelist to workspace before creation

### DIFF
--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -50,11 +50,15 @@ class WorkspaceRuntimeApi:
         if not request.directory:
             raise RuntimeApiError("invalid_request", "missing required field: directory")
 
+        temp_filelist_dir = None
         input_filelist = request.filelist
         if not input_filelist:
             rtl_paths = _normalize_rtl_list(request.rtl_list or [])
             if rtl_paths:
-                input_filelist = _write_filelist(request.directory, rtl_paths)
+                temp_filelist_dir = tempfile.TemporaryDirectory(
+                    prefix="ecc-workspace-filelist-"
+                )
+                input_filelist = _write_filelist(temp_filelist_dir.name, rtl_paths)
 
         import chipcompiler.data as data_api
 
@@ -73,6 +77,8 @@ class WorkspaceRuntimeApi:
         finally:
             if pdk_json_temp_path is not None:
                 pdk_json_temp_path.unlink(missing_ok=True)
+            if temp_filelist_dir is not None:
+                temp_filelist_dir.cleanup()
         if workspace is None:
             raise RuntimeApiError(
                 "command_failed",

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -160,8 +160,13 @@ def _workspace(directory: Path):
     )
 
 
-def _install_runtime_mocks(monkeypatch, tmp_path):
-    capture = {"create_kwargs": None, "loaded": []}
+def _install_runtime_mocks(monkeypatch, tmp_path, *, create_workspace_files=True):
+    capture = {
+        "create_kwargs": None,
+        "input_filelist_lines": [],
+        "loaded": [],
+        "workspace_entries_when_create_called": [],
+    }
     DummyFlow.instances = []
     DummyFlow.next_run_states = []
     DummyFlow.next_init_success = True
@@ -170,6 +175,16 @@ def _install_runtime_mocks(monkeypatch, tmp_path):
 
     def fake_create_workspace(**kwargs):
         capture["create_kwargs"] = kwargs
+        input_filelist = kwargs.get("input_filelist")
+        if input_filelist and Path(input_filelist).exists():
+            capture["input_filelist_lines"] = Path(input_filelist).read_text(
+                encoding="utf-8"
+            ).splitlines()
+        workspace_dir = Path(kwargs["directory"])
+        if workspace_dir.is_dir():
+            capture["workspace_entries_when_create_called"] = sorted(
+                path.name for path in workspace_dir.iterdir()
+            )
         return _workspace(Path(kwargs["directory"]))
 
     def fake_load_workspace(directory):
@@ -187,10 +202,11 @@ def _install_runtime_mocks(monkeypatch, tmp_path):
     )
 
     ws = tmp_path / "workspace"
-    (ws / "home").mkdir(parents=True)
-    (ws / "home" / "parameters.json").write_text("{}")
-    (ws / "home" / "flow.json").write_text(json.dumps({"steps": []}))
-    (ws / "home" / "home.json").write_text("{}")
+    if create_workspace_files:
+        (ws / "home").mkdir(parents=True)
+        (ws / "home" / "parameters.json").write_text("{}")
+        (ws / "home" / "flow.json").write_text(json.dumps({"steps": []}))
+        (ws / "home" / "home.json").write_text("{}")
     return capture, ws
 
 
@@ -240,6 +256,37 @@ def test_create_workspace_returns_plain_runtime_result_and_session(monkeypatch, 
     assert isinstance(capture["create_kwargs"]["pdk_json"], str)
     assert DummyFlow.instances[0].created
     assert api.sessions.get_session(result["workspaceId"]).directory == ws.resolve()
+
+
+def test_create_workspace_writes_rtl_list_filelist_outside_workspace(
+    monkeypatch,
+    tmp_path,
+):
+    capture, ws = _install_runtime_mocks(
+        monkeypatch,
+        tmp_path,
+        create_workspace_files=False,
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    rtl_paths = [str(project / "a.v"), str(project / "b.v")]
+    api = WorkspaceRuntimeApi()
+
+    api.create_workspace(
+        WorkspaceCreateRequest(
+            directory=str(ws),
+            pdk="ics55",
+            parameters={"Design": "gcd"},
+            rtl_list=rtl_paths,
+        )
+    )
+
+    input_filelist = Path(capture["create_kwargs"]["input_filelist"])
+    assert input_filelist.name == "filelist"
+    assert not input_filelist.is_relative_to(ws)
+    assert capture["input_filelist_lines"] == rtl_paths
+    assert capture["workspace_entries_when_create_called"] == []
+    assert not (ws / "filelist").exists()
 
 
 def test_create_workspace_materializes_inline_pdk_json_before_data_api(monkeypatch, tmp_path):


### PR DESCRIPTION
## What Changed

  - Generate runtime `rtl_list` filelists under `TemporaryDirectory(prefix="ecc-workspace-filelist-")`.
  - Clean up the temporary filelist directory after `data.create_workspace()` returns or raises.
  - Add a regression test confirming:
    - generated filelist basename remains `filelist`
    - generated filelist is outside the target workspace
    - target workspace is still empty when `data.create_workspace()` is called
    - `<workspace>/filelist` is not created by runtime pre-processing

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
