### PR TITLE
fix(ci): build on manylinux_2_34_x86_64

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -25,16 +25,18 @@ runs:
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Install hosted native build dependencies
-      if: ${{ inputs.build-all == 'true' }}
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          build-essential cmake ninja-build pkg-config patchelf mold lld \
-          libboost-all-dev libcairo2-dev libgflags-dev libgoogle-glog-dev \
-          flex libfl-dev bison libeigen3-dev libgtest-dev libtbb-dev libhwloc-dev \
-          libcurl4-openssl-dev libunwind-dev libmetis-dev libgmp-dev \
-          tcl-dev unzip zip
+        dnf install -y epel-release dnf-plugins-core
+        dnf config-manager --set-enabled crb || true
+        dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+        dnf install -y \
+          cmake ninja-build pkgconfig patchelf mold lld \
+          boost-devel cairo-devel gflags-devel glog-devel \
+          flex flex-devel bison eigen3-devel gtest-devel \
+          tbb-devel hwloc-devel libcurl-devel libunwind-devel \
+          metis-devel gmp-devel tcl-devel \
+          unzip zip gh
 
     - name: Setup Rust
       if: ${{ inputs.build-all == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
   test:
     name: Test
     needs: check-version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,7 +102,8 @@ jobs:
   build-pyinstaller:
     name: Build PyInstaller Bundle
     needs: check-version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
   build:
     name: Build CLI Bundle
     needs: check-version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: quay.io/pypa/manylinux_2_34_x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What Changed

- build ci artifacts on manylinux_2_34_x86_64

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [x] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [x] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
