### PR TITLE
feat: add signoff package function for gui

### DIFF
--- a/chipcompiler/data/workspace.py
+++ b/chipcompiler/data/workspace.py
@@ -764,6 +764,7 @@ def update_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
     if step.name == StepEnum.RCX.value:
         rcx = json_read(workspace.config[f"{StepEnum.RCX.value}"])
         rcx_output_dir = path_text(step.output.get("dir"))
+        spef_design_name = workspace.design.top_module or workspace.design.name
         rcx["output"] = rcx_output_dir
         for corner in rcx.get("corners", []):
             corner_name = corner.get("name", "")
@@ -773,7 +774,7 @@ def update_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
                     {
                         _rcx_temperature_key(temperature): (
                             f"{rcx_output_dir}/"
-                            f"{workspace.design.name}_{corner_name}_"
+                            f"{spef_design_name}_{corner_name}_"
                             f"{_rcx_temperature_token(temperature)}.spef"
                         )
                     }

--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -9,6 +9,18 @@ from pathlib import Path
 
 from chipcompiler.data import StateEnum, StepEnum, Workspace
 
+STA_REPORT_FILENAMES = (
+    "qor_summary.rpt",
+    "timing_max_in2out.rpt",
+    "timing_max_in2reg.rpt",
+    "timing_max_reg2out.rpt",
+    "timing_max_reg2reg.rpt",
+    "timing_min_in2out.rpt",
+    "timing_min_in2reg.rpt",
+    "timing_min_reg2out.rpt",
+    "timing_min_reg2reg.rpt",
+)
+
 
 @dataclass(frozen=True)
 class SignoffPackageOptions:
@@ -16,6 +28,7 @@ class SignoffPackageOptions:
     archive: bool = True
     include_debug: bool = False
     allow_incomplete: bool = False
+    materialize: bool = True
 
 
 @dataclass
@@ -27,7 +40,19 @@ class SignoffPackageResult:
     summary_path: str | None = None
     copied: list[dict] = field(default_factory=list)
     missing_required: list[str] = field(default_factory=list)
+    missing_optional: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    issues: list["SignoffPackageIssue"] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SignoffPackageIssue:
+    kind: str
+    label: str
+    location: str
+    reason: str
+    required: bool
+    destination: str
 
 
 class SignoffPackageCollector:
@@ -59,18 +84,20 @@ class SignoffPackageCollector:
 
         package_root = Path(options.output_dir) if options.output_dir else workspace_dir / "signoff"
         package_dir = package_root / f"{design}_signoff_package"
-        if package_dir.exists():
-            shutil.rmtree(package_dir)
-        package_dir.mkdir(parents=True, exist_ok=True)
+        if options.materialize:
+            if package_dir.exists():
+                shutil.rmtree(package_dir)
+            package_dir.mkdir(parents=True, exist_ok=True)
 
         copied: list[dict] = []
         missing_required: list[str] = []
+        missing_optional: list[str] = []
         warnings: list[str] = []
+        issues: list[SignoffPackageIssue] = []
 
-        def add_file(role: str,
-                     source: Path | None,
-                     destination: str,
-                     required: bool = False) -> None:
+        def add_file(
+            role: str, source: Path | None, destination: str, required: bool = False
+        ) -> None:
             self._add_file(
                 workspace_dir=workspace_dir,
                 package_dir=package_dir,
@@ -80,6 +107,9 @@ class SignoffPackageCollector:
                 required=required,
                 copied=copied,
                 missing_required=missing_required,
+                missing_optional=missing_optional,
+                issues=issues,
+                materialize=options.materialize,
             )
 
         flow_path = workspace_dir / "home" / "flow.json"
@@ -91,6 +121,16 @@ class SignoffPackageCollector:
         for step_name, state in required_steps.items():
             if state != StateEnum.Success.value:
                 missing_required.append(f"flow step {step_name} is {state or 'missing'}")
+                issues.append(
+                    SignoffPackageIssue(
+                        kind="flow",
+                        label=f"{step_name} flow step",
+                        location=step_name,
+                        reason=f"State is {state or 'missing'}",
+                        required=True,
+                        destination=f"flow step {step_name}",
+                    )
+                )
 
         config_dir = workspace_dir / "config"
         required_configs = {
@@ -101,6 +141,16 @@ class SignoffPackageCollector:
         }
         if not config_dir.is_dir():
             missing_required.append("config directory")
+            issues.append(
+                SignoffPackageIssue(
+                    kind="resource",
+                    label="Config directory",
+                    location="config",
+                    reason="Required directory does not exist",
+                    required=True,
+                    destination="config directory",
+                )
+            )
         else:
             for config_file in sorted(path for path in config_dir.rglob("*") if path.is_file()):
                 rel = config_file.relative_to(config_dir).as_posix()
@@ -113,27 +163,57 @@ class SignoffPackageCollector:
             for config_name in sorted(required_configs):
                 if not (config_dir / config_name).is_file():
                     missing_required.append(f"config/{config_name}")
+                    issues.append(
+                        SignoffPackageIssue(
+                            kind="resource",
+                            label=f"Config {config_name}",
+                            location=f"config/{config_name}",
+                            reason="Required file is missing or empty",
+                            required=True,
+                            destination=f"config/{config_name}",
+                        )
+                    )
 
         db_config = self._read_json(config_dir / "db_default_config.json")
-        origin_verilog = self._find_one(
+        origin_verilog, origin_verilog_reason = self._find_one(
             workspace_dir / "origin",
             preferred_name=f"{design}.v",
             pattern="*.v",
-            missing_label="origin Verilog",
-            missing_required=missing_required,
         )
+        if origin_verilog is None:
+            missing_required.append("origin Verilog")
+            issues.append(
+                SignoffPackageIssue(
+                    kind="resource",
+                    label="Origin Verilog",
+                    location=f"origin/{design}.v",
+                    reason=origin_verilog_reason,
+                    required=True,
+                    destination=f"initial/{design}.v",
+                )
+            )
         origin_sdc = self._path_from_config(
             workspace_dir,
             db_config.get("INPUT", {}).get("sdc_path", ""),
         )
         if origin_sdc is None:
-            origin_sdc = self._find_one(
+            origin_sdc, origin_sdc_reason = self._find_one(
                 workspace_dir / "origin",
                 preferred_name=f"{design}.sdc",
                 pattern="*.sdc",
-                missing_label="origin SDC",
-                missing_required=missing_required,
             )
+            if origin_sdc is None:
+                missing_required.append("origin SDC")
+                issues.append(
+                    SignoffPackageIssue(
+                        kind="resource",
+                        label="Origin SDC",
+                        location=f"origin/{design}.sdc",
+                        reason=origin_sdc_reason,
+                        required=True,
+                        destination=f"initial/{design}.sdc",
+                    )
+                )
 
         add_file(
             role="harden.gds",
@@ -154,23 +234,15 @@ class SignoffPackageCollector:
             required=True,
         )
         add_file(
-            role="harden.lib_check_sources",
-            source=(
-                workspace_dir
-                / "Harden_ecc"
-                / "output"
-                / f"{design}_Harden.lib.check_sources.tsv"
-            ),
-            destination=f"harden/{design}.lib.check_sources.tsv",
-        )
-        add_file(
             role="harden.image",
             source=workspace_dir / "Harden_ecc" / "output" / f"{design}_Harden.png",
             destination=f"harden/{design}.png",
         )
 
-        add_file("initial.verilog", origin_verilog, f"initial/{design}.v", required=True)
-        add_file("initial.sdc", origin_sdc, f"initial/{design}.sdc", required=True)
+        if origin_verilog is not None:
+            add_file("initial.verilog", origin_verilog, f"initial/{design}.v", required=True)
+        if origin_sdc is not None:
+            add_file("initial.sdc", origin_sdc, f"initial/{design}.sdc", required=True)
         add_file(
             "initial.parameters",
             workspace_dir / "home" / "parameters.json",
@@ -221,22 +293,22 @@ class SignoffPackageCollector:
                 f"{self._temperature_token(item['temperature'])}/"
                 f"{item['rcx_corner']}"
             )
-            qor_summary = report_dir / "qor_summary.rpt"
-            add_file(
-                role="final.sta_report",
-                source=qor_summary,
-                destination=f"{report_dest}/{qor_summary.name}",
-                required=True,
-            )
+            for report_name in STA_REPORT_FILENAMES:
+                add_file(
+                    role="final.sta_report",
+                    source=report_dir / report_name,
+                    destination=f"{report_dest}/{report_name}",
+                    required=True,
+                )
             for report_path in sorted(report_dir.glob("*.rpt")):
-                if report_path == qor_summary:
+                if report_path.name in STA_REPORT_FILENAMES:
                     continue
                 add_file(
                     role="final.sta_report",
                     source=report_path,
                     destination=f"{report_dest}/{report_path.name}",
                 )
-            item["report"] = f"{report_dest}/{qor_summary.name}"
+            item["report"] = f"{report_dest}/qor_summary.rpt"
 
         rcx_output_dir = workspace_dir / "RCX_ecc" / "output"
         spef_paths = sorted(rcx_output_dir.glob("*.spef")) if rcx_output_dir.is_dir() else []
@@ -265,6 +337,16 @@ class SignoffPackageCollector:
                 )
         else:
             missing_required.append("RCX SPEF files")
+            issues.append(
+                SignoffPackageIssue(
+                    kind="resource",
+                    label="RCX SPEF files",
+                    location="RCX_ecc/output",
+                    reason="No SPEF files were found",
+                    required=True,
+                    destination="RCX SPEF files",
+                )
+            )
 
         add_file("status.flow", flow_path, "final/reports/flow.json", required=True)
         add_file(
@@ -283,6 +365,9 @@ class SignoffPackageCollector:
                     destination_dir=f"final/reports/{step_name}/{kind}",
                     role=f"report.{kind}",
                     copied=copied,
+                    missing_optional=missing_optional,
+                    issues=issues,
+                    materialize=options.materialize,
                 )
 
         if options.include_debug:
@@ -290,23 +375,21 @@ class SignoffPackageCollector:
                 workspace_dir=workspace_dir,
                 package_dir=package_dir,
                 copied=copied,
+                missing_optional=missing_optional,
+                issues=issues,
+                materialize=options.materialize,
             )
 
         checklist_counts = self._checklist_counts(checklist_data)
         if checklist_counts.get("warning", 0) or checklist_counts.get("failed", 0):
             warnings.append(
-                "home checklist contains failed or warning items; "
-                "see final/reports/checklist.json"
+                "home checklist contains failed or warning items; see final/reports/checklist.json"
             )
+        issues.extend(self._checklist_issues(checklist_data))
 
-        metrics = self._read_json(
-            workspace_dir / "drc_ecc" / "analysis" / "drc_metrics.json"
-        )
+        metrics = self._read_json(workspace_dir / "drc_ecc" / "analysis" / "drc_metrics.json")
         ok = len(missing_required) == 0
-        flow_success = all(
-            state == StateEnum.Success.value
-            for state in required_steps.values()
-        )
+        flow_success = all(state == StateEnum.Success.value for state in required_steps.values())
         summary = {
             "schema_version": 1,
             "status": "ok" if ok else "incomplete",
@@ -338,10 +421,10 @@ class SignoffPackageCollector:
             "metrics": metrics,
             "sta_matrix": sta_matrix,
             "missing_required": missing_required,
+            "missing_optional": missing_optional,
             "warnings": warnings,
         }
         summary_path = package_dir / "summary.json"
-        summary_path.write_text(json.dumps(summary, indent=2))
 
         manifest = {
             "schema_version": 1,
@@ -356,28 +439,32 @@ class SignoffPackageCollector:
             },
             "files": copied,
             "missing_required": missing_required,
+            "missing_optional": missing_optional,
             "warnings": warnings,
         }
         manifest_path = package_dir / "manifest.json"
-        manifest_path.write_text(json.dumps(manifest, indent=2))
-
-        readme_path = package_dir / "README.md"
-        readme_path.write_text(
-            f"# {design} Signoff Package\n\n"
-            f"- Workspace: {workspace_dir.resolve()}\n"
-            f"- Status: {summary['status']}\n"
-            "- Harden outputs are under `harden/`.\n"
-            "- Final physical resources are under `final/`.\n"
-        )
 
         archive_path = None
-        if options.archive and (ok or options.allow_incomplete):
-            archive_path = str(package_dir.with_suffix(".tar.gz"))
-            archive_file = Path(archive_path)
-            if archive_file.exists():
-                archive_file.unlink()
-            with tarfile.open(archive_file, "w:gz") as archive:
-                archive.add(package_dir, arcname=package_dir.name)
+        if options.materialize:
+            summary_path.write_text(json.dumps(summary, indent=2))
+            manifest_path.write_text(json.dumps(manifest, indent=2))
+
+            readme_path = package_dir / "README.md"
+            readme_path.write_text(
+                f"# {design} Signoff Package\n\n"
+                f"- Workspace: {workspace_dir.resolve()}\n"
+                f"- Status: {summary['status']}\n"
+                "- Harden outputs are under `harden/`.\n"
+                "- Final physical resources are under `final/`.\n"
+            )
+
+            if options.archive and (ok or options.allow_incomplete):
+                archive_path = str(package_dir.with_suffix(".tar.gz"))
+                archive_file = Path(archive_path)
+                if archive_file.exists():
+                    archive_file.unlink()
+                with tarfile.open(archive_file, "w:gz") as archive:
+                    archive.add(package_dir, arcname=package_dir.name)
 
         return SignoffPackageResult(
             ok=ok,
@@ -387,42 +474,78 @@ class SignoffPackageCollector:
             summary_path=str(summary_path),
             copied=copied,
             missing_required=missing_required,
+            missing_optional=missing_optional,
             warnings=warnings,
+            issues=issues,
         )
 
-    def _add_file(self,
-                  workspace_dir: Path,
-                  package_dir: Path,
-                  role: str,
-                  source: Path | None,
-                  destination: str,
-                  required: bool,
-                  copied: list[dict],
-                  missing_required: list[str]) -> None:
+    def _add_file(
+        self,
+        workspace_dir: Path,
+        package_dir: Path,
+        role: str,
+        source: Path | None,
+        destination: str,
+        required: bool,
+        copied: list[dict],
+        missing_required: list[str],
+        missing_optional: list[str],
+        issues: list[SignoffPackageIssue],
+        materialize: bool,
+    ) -> None:
         if source is None or not source.is_file() or source.stat().st_size <= 0:
             if required:
                 missing_required.append(destination)
+            else:
+                missing_optional.append(destination)
+            issues.append(
+                SignoffPackageIssue(
+                    kind="resource",
+                    label=role,
+                    location=self._review_source_path(workspace_dir, source, destination),
+                    reason=(
+                        "Required file is missing or empty"
+                        if required
+                        else "Optional file is missing or empty"
+                    ),
+                    required=required,
+                    destination=destination,
+                )
+            )
             return
 
-        target = package_dir / destination
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source, target)
-        copied.append({
-            "role": role,
-            "required": required,
-            "source": self._source_path(workspace_dir, source),
-            "destination": destination,
-            "size_bytes": target.stat().st_size,
-            "sha256": self._sha256(target),
-        })
+        if materialize:
+            target = package_dir / destination
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+            size_bytes = target.stat().st_size
+            sha256 = self._sha256(target)
+        else:
+            size_bytes = source.stat().st_size
+            sha256 = None
+        copied.append(
+            {
+                "role": role,
+                "required": required,
+                "source": self._source_path(workspace_dir, source),
+                "destination": destination,
+                "size_bytes": size_bytes,
+                "sha256": sha256,
+            }
+        )
 
-    def _copy_tree_files(self,
-                         workspace_dir: Path,
-                         package_dir: Path,
-                         source_dir: Path,
-                         destination_dir: str,
-                         role: str,
-                         copied: list[dict]) -> None:
+    def _copy_tree_files(
+        self,
+        workspace_dir: Path,
+        package_dir: Path,
+        source_dir: Path,
+        destination_dir: str,
+        role: str,
+        copied: list[dict],
+        missing_optional: list[str],
+        issues: list[SignoffPackageIssue],
+        materialize: bool,
+    ) -> None:
         if not source_dir.is_dir():
             return
         for source in sorted(path for path in source_dir.rglob("*") if path.is_file()):
@@ -436,12 +559,20 @@ class SignoffPackageCollector:
                 required=False,
                 copied=copied,
                 missing_required=[],
+                missing_optional=missing_optional,
+                issues=issues,
+                materialize=materialize,
             )
 
-    def _collect_debug_files(self,
-                             workspace_dir: Path,
-                             package_dir: Path,
-                             copied: list[dict]) -> None:
+    def _collect_debug_files(
+        self,
+        workspace_dir: Path,
+        package_dir: Path,
+        copied: list[dict],
+        missing_optional: list[str],
+        issues: list[SignoffPackageIssue],
+        materialize: bool,
+    ) -> None:
         patterns = [
             "*_ecc/feature/*",
             "*_ecc/subflow.json",
@@ -462,6 +593,9 @@ class SignoffPackageCollector:
                     required=False,
                     copied=copied,
                     missing_required=[],
+                    missing_optional=missing_optional,
+                    issues=issues,
+                    materialize=materialize,
                 )
         output_db_dirs = sorted(workspace_dir.glob("*_ecc/output/*_db"))
         output_view_dirs = sorted(workspace_dir.glob("*_ecc/output/*_view"))
@@ -475,6 +609,9 @@ class SignoffPackageCollector:
                 destination_dir=f"debug/{source.relative_to(workspace_dir).as_posix()}",
                 role="debug",
                 copied=copied,
+                missing_optional=missing_optional,
+                issues=issues,
+                materialize=materialize,
             )
 
     def _read_json(self, path: Path) -> dict:
@@ -492,9 +629,7 @@ class SignoffPackageCollector:
                 digest.update(chunk)
         return digest.hexdigest()
 
-    def _path_from_config(self,
-                          workspace_dir: Path,
-                          path_text: str) -> Path | None:
+    def _path_from_config(self, workspace_dir: Path, path_text: str) -> Path | None:
         if not path_text:
             return None
         path = Path(path_text)
@@ -508,23 +643,34 @@ class SignoffPackageCollector:
         except ValueError:
             return str(source)
 
-    def _find_one(self,
-                  directory: Path,
-                  preferred_name: str,
-                  pattern: str,
-                  missing_label: str,
-                  missing_required: list[str]) -> Path | None:
+    def _review_source_path(
+        self,
+        workspace_dir: Path,
+        source: Path | None,
+        fallback: str,
+    ) -> str:
+        if source is None:
+            return fallback
+        try:
+            return source.relative_to(workspace_dir).as_posix()
+        except ValueError:
+            return source.name
+
+    def _find_one(
+        self,
+        directory: Path,
+        preferred_name: str,
+        pattern: str,
+    ) -> tuple[Path | None, str]:
         preferred = directory / preferred_name
         if preferred.is_file():
-            return preferred
+            return preferred, ""
         matches = sorted(directory.glob(pattern)) if directory.is_dir() else []
         if len(matches) == 1:
-            return matches[0]
+            return matches[0], ""
         if len(matches) > 1:
-            missing_required.append(f"{missing_label}: multiple matches")
-            return None
-        missing_required.append(missing_label)
-        return None
+            return None, "Multiple matching files found"
+        return None, "Required file is missing or empty"
 
     def _design_from_outputs(self, workspace_dir: Path) -> str:
         for pattern, suffix in (
@@ -557,6 +703,8 @@ class SignoffPackageCollector:
     def _checklist_counts(self, checklist_data: dict) -> dict:
         counts = {"passed": 0, "warning": 0, "failed": 0}
         for item in checklist_data.get("checklist", []):
+            if not isinstance(item, dict):
+                continue
             state = str(item.get("state", "")).lower()
             if state == "passed":
                 counts["passed"] += 1
@@ -565,6 +713,33 @@ class SignoffPackageCollector:
             elif state == "failed":
                 counts["failed"] += 1
         return counts
+
+    def _checklist_issues(self, checklist_data: dict) -> list[SignoffPackageIssue]:
+        issues = []
+        for item in checklist_data.get("checklist", []):
+            if not isinstance(item, dict):
+                continue
+            state = str(item.get("state", "")).strip()
+            normalized_state = state.lower()
+            if normalized_state not in {"warning", "failed"}:
+                continue
+            scope = " / ".join(
+                str(item.get(key, "")).strip()
+                for key in ("step", "type", "item")
+                if str(item.get(key, "")).strip()
+            )
+            info = str(item.get("info", "")).strip()
+            issues.append(
+                SignoffPackageIssue(
+                    kind="checklist",
+                    label=str(item.get("item", "Checklist item")).strip() or "Checklist item",
+                    location=scope or "home/checklist.json",
+                    reason=f"{state or normalized_state.title()}{f': {info}' if info else ''}",
+                    required=False,
+                    destination="final/reports/checklist.json",
+                )
+            )
+        return issues
 
     def _sta_matrix(self, sta_config: dict) -> list[dict]:
         liberty_by_corner = {
@@ -581,11 +756,13 @@ class SignoffPackageCollector:
                 if isinstance(rcx_corners, str):
                     rcx_corners = [rcx_corners]
                 for rcx_corner in rcx_corners:
-                    matrix.append({
-                        "lib_corner": lib_corner,
-                        "temperature": liberty.get("temperature", ""),
-                        "rcx_corner": rcx_corner,
-                    })
+                    matrix.append(
+                        {
+                            "lib_corner": lib_corner,
+                            "temperature": liberty.get("temperature", ""),
+                            "rcx_corner": rcx_corner,
+                        }
+                    )
         return matrix
 
     def _temperature_token(self, temperature) -> str:

--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -207,7 +207,7 @@ class SignoffPackageCollector:
         expected_spefs = set()
         for item in sta_matrix:
             expected_spefs.add(
-                f"{design}_{item['rcx_corner']}_{self._temperature_token(item['temperature'])}C.spef"
+                f"{top_module}_{item['rcx_corner']}_{self._temperature_token(item['temperature'])}C.spef"
             )
             report_dir = (
                 workspace_dir
@@ -221,22 +221,22 @@ class SignoffPackageCollector:
                 f"{self._temperature_token(item['temperature'])}/"
                 f"{item['rcx_corner']}"
             )
-            for suffix in (
-                ".rpt.json",
-                ".rpt",
-                ".cap",
-                ".fanout",
-                ".trans",
-                "_hold.skew",
-                "_setup.skew",
-            ):
+            qor_summary = report_dir / "qor_summary.rpt"
+            add_file(
+                role="final.sta_report",
+                source=qor_summary,
+                destination=f"{report_dest}/{qor_summary.name}",
+                required=True,
+            )
+            for report_path in sorted(report_dir.glob("*.rpt")):
+                if report_path == qor_summary:
+                    continue
                 add_file(
                     role="final.sta_report",
-                    source=report_dir / f"{top_module}{suffix}",
-                    destination=f"{report_dest}/{top_module}{suffix}",
-                    required=suffix in (".rpt.json", ".rpt"),
+                    source=report_path,
+                    destination=f"{report_dest}/{report_path.name}",
                 )
-            item["report"] = f"{report_dest}/{top_module}.rpt.json"
+            item["report"] = f"{report_dest}/{qor_summary.name}"
 
         rcx_output_dir = workspace_dir / "RCX_ecc" / "output"
         spef_paths = sorted(rcx_output_dir.glob("*.spef")) if rcx_output_dir.is_dir() else []

--- a/chipcompiler/pyinstaller_utils.py
+++ b/chipcompiler/pyinstaller_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 EXCLUDED_PAYLOAD_PREFIXES = (
     "chipcompiler/thirdparty/ecc-tools",
     "chipcompiler/thirdparty/ecc-sizer",
@@ -22,6 +24,24 @@ EXCLUDED_HIDDENIMPORT_PREFIXES = (
     "torch.test",
 )
 
+REQUIRED_RUNTIME_BINARY_PREFIXES = (
+    "ecc_tools_bin/ecc_py",
+)
+
+
+def collect_package_extension_binaries(search_locations, pattern, destination):
+    binaries = []
+    collected_names = set()
+    for location in search_locations:
+        package_dir = Path(location)
+        for candidate_dir in (package_dir, package_dir.parent / "bin"):
+            for extension in candidate_dir.glob(pattern):
+                if extension.name in collected_names:
+                    continue
+                binaries.append((str(extension), destination))
+                collected_names.add(extension.name)
+    return binaries
+
 
 def payload_path_matches(path, prefix):
     normalized = str(path).replace("\\", "/")
@@ -33,6 +53,14 @@ def payload_path_matches(path, prefix):
 
 
 def payload_is_excluded(item):
+    destination = item[0] if isinstance(item, (tuple, list)) else item
+    normalized_destination = str(destination).replace("\\", "/")
+    if any(
+        normalized_destination.startswith(prefix)
+        for prefix in REQUIRED_RUNTIME_BINARY_PREFIXES
+    ):
+        return False
+
     paths = item[:2] if isinstance(item, (tuple, list)) else (item,)
     return any(
         payload_path_matches(path, prefix)

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -10,6 +10,7 @@ from chipcompiler.runtime.requests import (
     FlowRunStepRequest,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
+    WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
@@ -66,6 +67,11 @@ RUNTIME_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="workspace.reset_flow",
         request_model=WorkspaceIdRequest,
         handler_name="reset_flow",
+    ),
+    RuntimeMethodSpec(
+        method_name="workspace.export_signoff",
+        request_model=WorkspaceExportSignoffRequest,
+        handler_name="export_signoff",
     ),
     RuntimeMethodSpec(
         method_name="flow.run",

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -12,6 +12,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
+    WorkspaceInspectSignoffRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
     WorkspaceSyncConfigRequest,
@@ -72,6 +73,11 @@ RUNTIME_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="workspace.export_signoff",
         request_model=WorkspaceExportSignoffRequest,
         handler_name="export_signoff",
+    ),
+    RuntimeMethodSpec(
+        method_name="workspace.inspect_signoff",
+        request_model=WorkspaceInspectSignoffRequest,
+        handler_name="inspect_signoff",
     ),
     RuntimeMethodSpec(
         method_name="flow.run",

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -46,6 +46,11 @@ class WorkspaceExportSignoffRequest:
 
 
 @dataclass(frozen=True)
+class WorkspaceInspectSignoffRequest:
+    workspace_id: str
+
+
+@dataclass(frozen=True)
 class WorkspaceInfoRequest:
     workspace_id: str
     step: str

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -15,6 +15,7 @@ class WorkspaceCreateRequest:
     origin_verilog: str = ""
     filelist: str = ""
     rtl_list: list[str] | None = None
+    sdc: str = ""
     flow_config: dict[str, Any] | None = None
 
 

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -15,6 +15,7 @@ class WorkspaceCreateRequest:
     origin_verilog: str = ""
     filelist: str = ""
     rtl_list: list[str] | None = None
+    flow_config: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -82,6 +83,7 @@ class RequestValidationError(ValueError):
 
 
 FIELD_ALIASES = {
+    "flowConfig": "flow_config",
     "pdkRoot": "pdk_root",
     "pdkJson": "pdk_json",
     "originDef": "origin_def",

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -39,6 +39,12 @@ class WorkspaceSyncConfigRequest:
 
 
 @dataclass(frozen=True)
+class WorkspaceExportSignoffRequest:
+    workspace_id: str
+    output_path: str
+
+
+@dataclass(frozen=True)
 class WorkspaceInfoRequest:
     workspace_id: str
     step: str
@@ -84,6 +90,7 @@ FIELD_ALIASES = {
     "rtlList": "rtl_list",
     "workspaceId": "workspace_id",
     "configPath": "config_path",
+    "outputPath": "output_path",
     "infoId": "info_id",
     "id": "info_id",
 }

--- a/chipcompiler/runtime/signoff_export.py
+++ b/chipcompiler/runtime/signoff_export.py
@@ -9,6 +9,179 @@ from chipcompiler.engine import EngineFlow, SignoffPackageOptions
 from chipcompiler.runtime.workspace_api import RuntimeApiError
 
 
+_REVIEW_GROUPS = (
+    ("initial", "Initial"),
+    ("config", "Config"),
+    ("harden", "Harden"),
+    ("final_design", "Final Design"),
+    ("sta", "STA"),
+    ("spef", "SPEF"),
+    ("reports", "Reports"),
+)
+
+
+def inspect_signoff_package(workspace) -> dict:
+    result = EngineFlow(workspace).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+    groups = {
+        group_id: {
+            "id": group_id,
+            "label": label,
+            "available": 0,
+            "missing_required": 0,
+            "missing_optional": 0,
+            "warning": False,
+            "blocked_details": [],
+            "warning_details": [],
+        }
+        for group_id, label in _REVIEW_GROUPS
+    }
+    flow_details = []
+    checklist_details = []
+
+    for copied in result.copied:
+        destination = copied.get("destination", "")
+        groups[_review_group_id(destination)]["available"] += 1
+    for missing in result.missing_required:
+        if missing.startswith("flow step "):
+            continue
+        groups[_review_group_id(missing)]["missing_required"] += 1
+    for missing in result.missing_optional:
+        groups[_review_group_id(missing)]["missing_optional"] += 1
+    for issue in getattr(result, "issues", []):
+        detail = _review_detail(issue)
+        if issue.kind == "flow":
+            flow_details.append(detail)
+        elif issue.kind == "checklist":
+            checklist_details.append(detail)
+        elif issue.kind == "resource":
+            detail_key = "blocked_details" if issue.required else "warning_details"
+            groups[_review_group_id(issue.destination)][detail_key].append(detail)
+    if result.warnings:
+        groups["reports"]["warning"] = True
+
+    review_groups = []
+    risks = []
+    if flow_details:
+        risks.append(
+            {
+                "severity": "blocked",
+                "title": "Flow requirements not complete",
+                "summary": _flow_summary(len(flow_details)),
+                "details": flow_details,
+            }
+        )
+    for group_id, _label in _REVIEW_GROUPS:
+        group = groups[group_id]
+        required_missing = group.pop("missing_required")
+        optional_missing = group.pop("missing_optional")
+        checklist_warning = group.pop("warning")
+        blocked_details = group.pop("blocked_details")
+        warning_details = group.pop("warning_details")
+        available = group["available"]
+        expected = available + required_missing + optional_missing
+
+        if required_missing:
+            status = "blocked"
+            summary = _missing_summary(required_missing, "required")
+            risks.append(
+                {
+                    "severity": "blocked",
+                    "title": f"{group['label']} resources missing",
+                    "summary": summary,
+                    "details": blocked_details,
+                }
+            )
+        elif optional_missing or checklist_warning:
+            status = "attention"
+            summary = (
+                _missing_summary(optional_missing, "optional")
+                if optional_missing
+                else "Checklist requires attention"
+            )
+            if optional_missing:
+                risks.append(
+                    {
+                        "severity": "warning",
+                        "title": f"{group['label']} optional resources missing",
+                        "summary": summary,
+                        "details": warning_details,
+                    }
+                )
+        else:
+            status = "ready"
+            summary = (
+                f"{available} of {expected} resources ready"
+                if expected
+                else "No resources expected"
+            )
+
+        review_groups.append(
+            {
+                "id": group_id,
+                "label": group["label"],
+                "status": status,
+                "available": available,
+                "expected": expected,
+                "summary": summary,
+            }
+        )
+
+    if result.warnings:
+        risks.append(
+            {
+                "severity": "warning",
+                "title": "Checklist attention",
+                "summary": "The workspace checklist contains failed or warning items",
+                "details": checklist_details,
+            }
+        )
+
+    risks.sort(key=lambda risk: risk["severity"] != "blocked")
+
+    return {
+        "status": "blocked" if result.missing_required else "attention" if risks else "ready",
+        "groups": review_groups,
+        "risks": risks,
+    }
+
+
+def _review_detail(issue) -> dict:
+    return {
+        "kind": issue.kind,
+        "label": issue.label,
+        "location": issue.location,
+        "reason": issue.reason,
+    }
+
+
+def _review_group_id(resource: str) -> str:
+    if resource.startswith("initial/") or resource.startswith("origin "):
+        return "initial"
+    if resource.startswith("config/") or resource == "config directory":
+        return "config"
+    if resource.startswith("harden/"):
+        return "harden"
+    if resource.startswith("final/design/"):
+        return "final_design"
+    if resource.startswith("final/timing/sta/"):
+        return "sta"
+    if resource.startswith("final/timing/spef/") or resource == "RCX SPEF files":
+        return "spef"
+    return "reports"
+
+
+def _missing_summary(count: int, kind: str) -> str:
+    suffix = "resource" if count == 1 else "resources"
+    return f"{count} {kind} {suffix} missing"
+
+
+def _flow_summary(count: int) -> str:
+    suffix = "step is" if count == 1 else "steps are"
+    return f"{count} required flow {suffix} not successful"
+
+
 def export_signoff_package_archive(workspace, output_path: str) -> str:
     raw_destination = Path(output_path).expanduser()
     destination = raw_destination.parent.resolve() / raw_destination.name

--- a/chipcompiler/runtime/signoff_export.py
+++ b/chipcompiler/runtime/signoff_export.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from chipcompiler.engine import EngineFlow, SignoffPackageOptions
+from chipcompiler.runtime.workspace_api import RuntimeApiError
+
+
+def export_signoff_package_archive(workspace, output_path: str) -> str:
+    raw_destination = Path(output_path).expanduser()
+    destination = raw_destination.parent.resolve() / raw_destination.name
+
+    with tempfile.TemporaryDirectory(prefix="ecc-signoff-") as temporary_root:
+        result = EngineFlow(workspace).collect_signoff_package(
+            SignoffPackageOptions(output_dir=temporary_root, archive=True)
+        )
+        if not result.ok:
+            missing = ", ".join(result.missing_required) or "unknown required resources"
+            raise RuntimeApiError(
+                "command_failed",
+                f"signoff package is incomplete: {missing}",
+            )
+        if not result.archive_path:
+            raise RuntimeApiError(
+                "command_failed",
+                "signoff package archive was not created",
+            )
+
+        archive = Path(result.archive_path)
+        if not archive.is_file():
+            raise RuntimeApiError(
+                "command_failed",
+                f"signoff package archive does not exist: {archive}",
+            )
+
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, staged_name = tempfile.mkstemp(
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+        )
+        os.close(descriptor)
+        staged_path = Path(staged_name)
+        try:
+            shutil.copy2(archive, staged_path)
+            os.replace(staged_path, destination)
+        finally:
+            staged_path.unlink(missing_ok=True)
+
+    return str(destination)

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -74,6 +74,7 @@ class WorkspaceRuntimeApi:
                 input_filelist=input_filelist,
                 pdk_root=request.pdk_root,
                 pdk_json=pdk_json,
+                flow_config=request.flow_config,
             )
         finally:
             if pdk_json_temp_path is not None:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -15,6 +15,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
+    WorkspaceInspectSignoffRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
     WorkspaceSyncConfigRequest,
@@ -56,9 +57,7 @@ class WorkspaceRuntimeApi:
         if not input_filelist:
             rtl_paths = _normalize_rtl_list(request.rtl_list or [])
             if rtl_paths:
-                temp_filelist_dir = tempfile.TemporaryDirectory(
-                    prefix="ecc-workspace-filelist-"
-                )
+                temp_filelist_dir = tempfile.TemporaryDirectory(prefix="ecc-workspace-filelist-")
                 input_filelist = _write_filelist(temp_filelist_dir.name, rtl_paths)
 
         import chipcompiler.data as data_api
@@ -183,6 +182,14 @@ class WorkspaceRuntimeApi:
             return {"outputPath": output_path}
 
         return self._with_session_mutation_lock(request.workspace_id, export)
+
+    def inspect_signoff(self, request: WorkspaceInspectSignoffRequest) -> dict:
+        def inspect(session: WorkspaceSession) -> dict:
+            from chipcompiler.runtime.signoff_export import inspect_signoff_package
+
+            return inspect_signoff_package(session.workspace)
+
+        return self._with_session_mutation_lock(request.workspace_id, inspect)
 
     def close_workspace(self, request: WorkspaceIdRequest) -> dict:
         def close(session: WorkspaceSession) -> dict:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -73,6 +73,7 @@ class WorkspaceRuntimeApi:
                 input_filelist=input_filelist,
                 pdk_root=request.pdk_root,
                 pdk_json=pdk_json,
+                sdc=request.sdc,
                 flow_config=request.flow_config,
             )
         finally:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -13,6 +13,7 @@ from chipcompiler.runtime.requests import (
     FlowRunRequest,
     FlowRunStepRequest,
     WorkspaceCreateRequest,
+    WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
@@ -167,6 +168,20 @@ class WorkspaceRuntimeApi:
             return {"directory": str(session.directory)}
 
         return self._with_session_mutation_lock(request.workspace_id, reset)
+
+    def export_signoff(self, request: WorkspaceExportSignoffRequest) -> dict:
+        def export(session: WorkspaceSession) -> dict:
+            from chipcompiler.runtime.signoff_export import (
+                export_signoff_package_archive,
+            )
+
+            output_path = export_signoff_package_archive(
+                session.workspace,
+                request.output_path,
+            )
+            return {"outputPath": output_path}
+
+        return self._with_session_mutation_lock(request.workspace_id, export)
 
     def close_workspace(self, request: WorkspaceIdRequest) -> dict:
         def close(session: WorkspaceSession) -> dict:

--- a/chipcompiler/tools/ecc/checklist.py
+++ b/chipcompiler/tools/ecc/checklist.py
@@ -1134,15 +1134,16 @@ class EccStaChecklist(EccChecklist):
         except OSError:
             return None
 
+        path_group_summaries = []
         for line in lines:
             fields = line.split()
-            if len(fields) < 8 or fields[0] in {"Path", "Summary"}:
+            if len(fields) < 8 or fields[0] == "Path":
                 continue
             try:
                 frequency_mhz = self.frequency_mhz(fields[-4])
                 if frequency_mhz is None:
                     continue
-                return {
+                summary = {
                     "frequency_mhz": frequency_mhz,
                     "hold_tns": float(fields[-2]),
                     "hold_wns": float(fields[-3]),
@@ -1151,6 +1152,20 @@ class EccStaChecklist(EccChecklist):
                 }
             except ValueError:
                 continue
+            if fields[0] == "Summary":
+                return summary
+            path_group_summaries.append(summary)
+
+        if path_group_summaries:
+            return {
+                "frequency_mhz": min(
+                    summary["frequency_mhz"] for summary in path_group_summaries
+                ),
+                "hold_tns": min(summary["hold_tns"] for summary in path_group_summaries),
+                "hold_wns": min(summary["hold_wns"] for summary in path_group_summaries),
+                "max_tns": min(summary["max_tns"] for summary in path_group_summaries),
+                "max_wns": min(summary["max_wns"] for summary in path_group_summaries),
+            }
         return None
 
     def frequency_mhz(self, value: str) -> float | None:

--- a/chipcompiler/tools/ecc/checklist.py
+++ b/chipcompiler/tools/ecc/checklist.py
@@ -2,6 +2,7 @@
 # -*- encoding: utf-8 -*-
 import glob
 import os
+import re
 
 from chipcompiler.data import (
     Workspace, 
@@ -11,6 +12,18 @@ from chipcompiler.data import (
     CheckState
 )
 from chipcompiler.utility import json_read
+
+STA_REPORT_FILENAMES = (
+    "qor_summary.rpt",
+    "timing_max_in2out.rpt",
+    "timing_max_in2reg.rpt",
+    "timing_max_reg2out.rpt",
+    "timing_max_reg2reg.rpt",
+    "timing_min_in2out.rpt",
+    "timing_min_in2reg.rpt",
+    "timing_min_reg2out.rpt",
+    "timing_min_reg2reg.rpt",
+)
 
 class EccChecklist:
     CHECKLIST_ITEMS = {
@@ -1059,16 +1072,6 @@ class EccStaChecklist(EccChecklist):
             pass
         return str(temperature).replace("-", "m").replace(".", "p")
 
-    def collect_sta_report_paths(self) -> list:
-        output_dir = self.workspace_step.output.get("dir", "")
-        if not output_dir or not os.path.isdir(output_dir):
-            return []
-
-        return sorted(glob.glob(
-            os.path.join(output_dir, "**", "*.rpt.json"),
-            recursive=True,
-        ))
-
     def expected_sta_report_paths(self) -> list:
         sta_config = self.workspace.config.get(StepEnum.STA.value, "")
         sta_data = json_read(sta_config)
@@ -1076,8 +1079,6 @@ class EccStaChecklist(EccChecklist):
             return []
 
         output_dir = self.workspace_step.output.get("dir", "")
-        top_module = self.workspace.design.top_module \
-            or self.workspace.design.name
         liberty_by_corner = {
             liberty.get("corner"): liberty
             for liberty in sta_data.get("liberty", [])
@@ -1094,70 +1095,86 @@ class EccStaChecklist(EccChecklist):
                     corner_name,
                     self.temperature_token(liberty.get("temperature")),
                 )
+                if isinstance(rcx_corner_names, str):
+                    rcx_corner_names = [rcx_corner_names]
                 for rcx_corner_name in rcx_corner_names:
-                    expected_paths.append(os.path.join(
+                    corner_dir = os.path.join(
                         output_dir,
                         report_corner_dir,
                         rcx_corner_name,
-                        f"{top_module}.rpt.json",
-                    ))
+                    )
+                    expected_paths.extend(
+                        os.path.join(corner_dir, report_name)
+                        for report_name in STA_REPORT_FILENAMES
+                    )
 
         return expected_paths
 
-    def load_sta_reports(self) -> list:
-        reports = []
-        for path in self.collect_sta_report_paths():
-            data = json_read(path)
-            if len(data) > 0:
-                reports.append((path, data))
+    def collect_sta_qor_paths(self, expected_paths: list[str]) -> list[str]:
+        qor_paths = [
+            path
+            for path in expected_paths
+            if os.path.basename(path) == "qor_summary.rpt"
+        ]
+        if qor_paths:
+            return qor_paths
 
-        return reports
+        output_dir = self.workspace_step.output.get("dir", "")
+        if not output_dir or not os.path.isdir(output_dir):
+            return []
+        return sorted(glob.glob(
+            os.path.join(output_dir, "**", "qor_summary.rpt"),
+            recursive=True,
+        ))
 
-    def sta_report_has_violation(self,
-                                 data : dict,
-                                 delay_type : str) -> bool:
-        for slack_item in data.get("slack", []):
-            if slack_item.get("delay_type", "") != delay_type:
+    def parse_qor_summary(self, path: str) -> dict | None:
+        try:
+            with open(path, encoding="utf-8", errors="ignore") as file:
+                lines = file.read().splitlines()
+        except OSError:
+            return None
+
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 8 or fields[0] in {"Path", "Summary"}:
                 continue
+            try:
+                frequency_mhz = self.frequency_mhz(fields[-4])
+                if frequency_mhz is None:
+                    continue
+                return {
+                    "frequency_mhz": frequency_mhz,
+                    "hold_tns": float(fields[-2]),
+                    "hold_wns": float(fields[-3]),
+                    "max_tns": float(fields[-6]),
+                    "max_wns": float(fields[-7]),
+                }
+            except ValueError:
+                continue
+        return None
 
-            tns = self.to_float(slack_item.get("TNS"), 0.0)
-            wns = self.to_float(slack_item.get("WNS"), 0.0)
-            if tns is None or wns is None or tns < 0 or wns < 0:
-                return True
-
-        return False
-
-    def sta_report_has_delay_type(self,
-                                  data : dict,
-                                  delay_type : str) -> bool:
-        return any(
-            slack_item.get("delay_type", "") == delay_type
-            for slack_item in data.get("slack", [])
+    def frequency_mhz(self, value: str) -> float | None:
+        match = re.fullmatch(
+            r"([+-]?(?:\d+(?:\.\d*)?|\.\d+))(GHz|MHz|kHz|Hz)", value
         )
-
-    def sta_report_frequency(self,
-                             data : dict,
-                             target_frequency : float) -> float | None:
-        max_wns = None
-        for slack_item in data.get("slack", []):
-            if slack_item.get("delay_type", "") == "max":
-                max_wns = self.to_float(slack_item.get("WNS"))
-                break
-
-        if target_frequency <= 0 or max_wns is None:
+        if match is None:
             return None
+        frequency = float(match.group(1))
+        scale = {"GHz": 1000.0, "MHz": 1.0, "kHz": 0.001, "Hz": 0.000001}
+        return frequency * scale[match.group(2)]
 
-        clk_period = 1000.0 / target_frequency
-        if clk_period - max_wns <= 0:
-            return None
-
-        return 1000.0 / (clk_period - max_wns)
+    def load_sta_qor_summaries(self, qor_paths: list[str]) -> list[dict]:
+        return [
+            summary
+            for path in qor_paths
+            if (summary := self.parse_qor_summary(path)) is not None
+        ]
 
     def check(self) -> bool:
         step = StepEnum.STA.value
-        reports = self.load_sta_reports()
-        report_paths = [path for path, _ in reports]
         expected_paths = self.expected_sta_report_paths()
+        qor_paths = self.collect_sta_qor_paths(expected_paths)
+        summaries = self.load_sta_qor_summaries(qor_paths)
         target_frequency = self.to_float(
             self.workspace.parameters.data.get("Frequency max [MHz]", 0),
             0.0,
@@ -1169,31 +1186,27 @@ class EccStaChecklist(EccChecklist):
                 for path in expected_paths
             )
         else:
-            signoff_success = len(reports) > 0
+            signoff_success = len(qor_paths) > 0 and all(
+                os.path.isfile(path) and os.path.getsize(path) > 0
+                for path in qor_paths
+            )
 
-        setup_success = len(reports) > 0 and all(
-            self.sta_report_has_delay_type(data, "max")
-            and not self.sta_report_has_violation(data, "max")
-            for _, data in reports
+        summaries_complete = len(summaries) == len(qor_paths) and len(qor_paths) > 0
+        setup_success = summaries_complete and all(
+            summary["max_tns"] >= 0 and summary["max_wns"] >= 0
+            for summary in summaries
         )
-        hold_success = len(reports) > 0 and all(
-            self.sta_report_has_delay_type(data, "min")
-            and not self.sta_report_has_violation(data, "min")
-            for _, data in reports
+        hold_success = summaries_complete and all(
+            summary["hold_tns"] >= 0 and summary["hold_wns"] >= 0
+            for summary in summaries
         )
-
-        frequencies = [
-            self.sta_report_frequency(data, target_frequency)
-            for _, data in reports
-        ]
         frequency_success = (
-            len(reports) > 0
+            summaries_complete
             and target_frequency > 0
-            and all(freq is not None and freq >= target_frequency
-                    for freq in frequencies)
+            and all(summary["frequency_mhz"] >= target_frequency for summary in summaries)
         )
 
-        reports_parse_success = len(report_paths) == len(reports) and len(reports) > 0
+        reports_parse_success = summaries_complete
         checks = [
             ("STA", "check STA signoff matrix", signoff_success),
             ("Timing", "check setup timing", setup_success),

--- a/chipcompiler/tools/ecc/checklist.py
+++ b/chipcompiler/tools/ecc/checklist.py
@@ -956,8 +956,8 @@ class EccRcxChecklist(EccChecklist):
 
     def spef_corner_name(self,
                          spef_path : str) -> str:
-        design_name = self.workspace.design.name \
-            or self.workspace.design.top_module
+        design_name = self.workspace.design.top_module \
+            or self.workspace.design.name
         name = os.path.basename(spef_path)
         if name.endswith(".spef"):
             name = name[:-5]

--- a/chipcompiler/tools/ecc/checklist.py
+++ b/chipcompiler/tools/ecc/checklist.py
@@ -997,8 +997,8 @@ class EccRcxChecklist(EccChecklist):
 
     def check_spef_file(self,
                         spef_path : str) -> bool:
-        design_name = self.workspace.design.name \
-            or self.workspace.design.top_module
+        design_name = self.workspace.design.top_module \
+            or self.workspace.design.name
         tokens = ["*SPEF", "*DESIGN", "*NAME_MAP"]
         if design_name:
             tokens.append(f"*DESIGN \"{design_name}\"")

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -46,6 +46,7 @@ def collect_sta_signoff_items(workspace: Workspace) -> list[dict]:
         liberty.get("corner"): liberty
         for liberty in sta_data.get("liberty", [])
     }
+    spef_design_name = workspace.design.top_module or workspace.design.name
     items = []
 
     for signoff_group in sta_data.get("signoff", []):
@@ -68,7 +69,7 @@ def collect_sta_signoff_items(workspace: Workspace) -> list[dict]:
                     "liberty_files": liberty_files,
                     "spef_file": os.path.join(
                         rcx_output_dir,
-                        f"{workspace.design.name}_{rcx_corner_name}_"
+                        f"{spef_design_name}_{rcx_corner_name}_"
                         f"{temperature_token(temperature)}C.spef",
                     ),
                 })
@@ -1006,7 +1007,7 @@ def run_sta(workspace: Workspace,
         ecc_module.run_timing(
             config=workspace.config.get(StepEnum.STA.value, ""),
             output_dir=report_dir,
-            work_dir=step.directory,
+            work_dir=step.data.get(StepEnum.STA.value, ""),
             lib_paths=liberty_files,
             sdc_path=workspace.pdk.sdc,
             spef_path=spef_file,

--- a/ecc.spec
+++ b/ecc.spec
@@ -14,7 +14,11 @@ from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_all, collect_data_files, copy_metadata
 
-from chipcompiler.pyinstaller_utils import filter_collected_payloads, filter_hiddenimports
+from chipcompiler.pyinstaller_utils import (
+    collect_package_extension_binaries,
+    filter_collected_payloads,
+    filter_hiddenimports,
+)
 
 ECC_DIR = Path(SPECPATH)
 HOOKS_DIR = ECC_DIR / "hooks"
@@ -192,8 +196,11 @@ def collect_ecc_tools_extension_binaries():
     if module_spec is None or module_spec.submodule_search_locations is None:
         return []
 
-    package_dir = Path(next(iter(module_spec.submodule_search_locations)))
-    return [(str(extension), "ecc_tools_bin") for extension in package_dir.glob("ecc_py*.so")]
+    return collect_package_extension_binaries(
+        module_spec.submodule_search_locations,
+        "ecc_py*.so",
+        "ecc_tools_bin",
+    )
 
 
 ecc_datas, ecc_binaries, ecc_hiddenimports = collect_all("chipcompiler")

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -4,7 +4,13 @@ from pathlib import Path
 
 import chipcompiler.data as data_api
 import chipcompiler.data.workspace as workspace_data
-from chipcompiler.data import StepEnum, create_workspace, load_workspace
+from chipcompiler.data import (
+    OriginDesign,
+    StepEnum,
+    WorkspaceStep,
+    create_workspace,
+    load_workspace,
+)
 from chipcompiler.data.workspace import (
     Workspace,
     build_workspace_config_paths,
@@ -12,9 +18,9 @@ from chipcompiler.data.workspace import (
     prepare_workspace_for_rerun,
     refresh_workspace_config,
     sync_workspace_config_to_parameters,
+    update_step_config,
 )
 from chipcompiler.utility import json_read, json_write
-
 
 EXPECTED_WORKSPACE_CONFIG_FILENAMES = {
     "flow": "flow_config.json",
@@ -42,6 +48,34 @@ ROUTABILITY_FLAG_STRING_CASES = (
     ("2", 2),
     ("maybe", 1),
 )
+
+
+def test_rcx_step_config_uses_top_module_for_spef_paths(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    db_config = config_dir / "db.json"
+    rcx_config = config_dir / "rcx.json"
+    json_write(db_config, {"INPUT": {}, "OUTPUT": {}})
+    json_write(
+        rcx_config,
+        {"corners": [{"name": "Cworst", "temperature": [125]}]},
+    )
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="project_gcd_ws_0002", top_module="gcd"),
+        config={"db": db_config, StepEnum.RCX.value: rcx_config},
+    )
+    step = WorkspaceStep(
+        name=StepEnum.RCX.value,
+        input={"def": None, "verilog": None},
+        output={"dir": tmp_path / "RCX_ecc" / "output"},
+    )
+
+    update_step_config(workspace, step)
+
+    assert json_read(rcx_config)["corners"][0]["spef_file"] == [
+        {"125": str(tmp_path / "RCX_ecc" / "output" / "gcd_Cworst_125C.spef")}
+    ]
 
 
 def _create_loaded_ics55_workspace(

--- a/test/packaging/test_pyinstaller_packaging.py
+++ b/test/packaging/test_pyinstaller_packaging.py
@@ -1,7 +1,20 @@
 from chipcompiler.pyinstaller_utils import (
+    collect_package_extension_binaries,
     filter_collected_payloads,
     filter_hiddenimports,
 )
+
+
+def test_collect_package_extension_binaries_checks_sibling_bin(tmp_path):
+    package_dir = tmp_path / "ecc_tools_bin"
+    package_dir.mkdir()
+    extension = tmp_path / "bin" / "ecc_py.cpython-311-x86_64-linux-gnu.so"
+    extension.parent.mkdir()
+    extension.touch()
+
+    assert collect_package_extension_binaries(
+        [package_dir], "ecc_py*.so", "ecc_tools_bin"
+    ) == [(str(extension), "ecc_tools_bin")]
 
 
 def test_pyinstaller_payload_filter_excludes_oversized_paths():
@@ -41,6 +54,17 @@ def test_pyinstaller_payload_filter_keeps_torch_runtime_binaries():
     ]
 
     assert filter_collected_payloads(payloads) == payloads
+
+
+def test_pyinstaller_payload_filter_keeps_ecc_tools_python_extension():
+    payload = (
+        "ecc_tools_bin/ecc_py.cpython-311-x86_64-linux-gnu.so",
+        "/repo/chipcompiler/thirdparty/ecc-tools/ecc_tools_bin/"
+        "ecc_py.cpython-311-x86_64-linux-gnu.so",
+        "EXTENSION",
+    )
+
+    assert filter_collected_payloads([payload]) == [payload]
 
 
 def test_pyinstaller_hiddenimport_filter_keeps_public_torch_imports():

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -17,6 +17,7 @@ def test_runtime_method_registry_contains_current_methods_once():
         "workspace.refresh_config",
         "workspace.sync_config",
         "workspace.reset_flow",
+        "workspace.export_signoff",
         "flow.run",
         "flow.run_step",
     )
@@ -59,7 +60,10 @@ def test_runtime_method_lookup_returns_spec():
     assert spec is not None
     assert spec.request_model is WorkspaceOpenRequest
     assert spec.handler_name == "open_workspace"
-    assert runtime_method_by_name("workspace.signoff") is None
+    export_spec = runtime_method_by_name("workspace.export_signoff")
+    assert export_spec is not None
+    assert export_spec.request_model is requests.WorkspaceExportSignoffRequest
+    assert export_spec.handler_name == "export_signoff"
     assert runtime_method_by_name("db.ensure") is None
 
 

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -18,6 +18,7 @@ def test_runtime_method_registry_contains_current_methods_once():
         "workspace.sync_config",
         "workspace.reset_flow",
         "workspace.export_signoff",
+        "workspace.inspect_signoff",
         "flow.run",
         "flow.run_step",
     )
@@ -64,6 +65,10 @@ def test_runtime_method_lookup_returns_spec():
     assert export_spec is not None
     assert export_spec.request_model is requests.WorkspaceExportSignoffRequest
     assert export_spec.handler_name == "export_signoff"
+    inspect_spec = runtime_method_by_name("workspace.inspect_signoff")
+    assert inspect_spec is not None
+    assert inspect_spec.request_model is requests.WorkspaceInspectSignoffRequest
+    assert inspect_spec.handler_name == "inspect_signoff"
     assert runtime_method_by_name("db.ensure") is None
 
 

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -28,6 +28,11 @@ def _parse_runtime_request(method: str, params: object, *, persistent_db_enabled
 
 def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
     pdk_json = {"name": "ics55", "lef": ["tech.lef"]}
+    flow_config = {
+        "start_step": "Synthesis",
+        "end_step": "Harden",
+        "steps": ["Synthesis", "RCX", "sta", "Harden"],
+    }
 
     request = _parse_runtime_request(
         "workspace.create",
@@ -40,6 +45,7 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
             "originVerilog": "/in.v",
             "paramJson": {"Design": "gcd"},
             "rtlList": ["a.v"],
+            "flowConfig": flow_config,
         },
     )
 
@@ -52,6 +58,7 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
     assert request.origin_verilog == "/in.v"
     assert request.parameters == {"Design": "gcd"}
     assert request.rtl_list == ["a.v"]
+    assert request.flow_config == flow_config
 
 
 @pytest.mark.parametrize(

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -13,6 +13,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
+    WorkspaceInspectSignoffRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
     WorkspaceSyncConfigRequest,
@@ -73,6 +74,11 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
             "workspace.export_signoff",
             {"workspaceId": "ws-1", "outputPath": "/exports/custom.tar.gz"},
             WorkspaceExportSignoffRequest,
+        ),
+        (
+            "workspace.inspect_signoff",
+            {"workspaceId": "ws-1"},
+            WorkspaceInspectSignoffRequest,
         ),
         (
             "workspace.sync_config",

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -46,6 +46,7 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
             "originVerilog": "/in.v",
             "paramJson": {"Design": "gcd"},
             "rtlList": ["a.v"],
+            "sdc": "/constraints/top.sdc",
             "flowConfig": flow_config,
         },
     )
@@ -59,6 +60,7 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
     assert request.origin_verilog == "/in.v"
     assert request.parameters == {"Design": "gcd"}
     assert request.rtl_list == ["a.v"]
+    assert request.sdc == "/constraints/top.sdc"
     assert request.flow_config == flow_config
 
 

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -11,6 +11,7 @@ from chipcompiler.runtime.requests import (
     RequestValidationError,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
+    WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
@@ -61,6 +62,11 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
         ("workspace.home", {"workspaceId": "ws-1"}, WorkspaceIdRequest),
         ("workspace.refresh_config", {"workspaceId": "ws-1"}, WorkspaceIdRequest),
         ("workspace.reset_flow", {"workspaceId": "ws-1"}, WorkspaceIdRequest),
+        (
+            "workspace.export_signoff",
+            {"workspaceId": "ws-1", "outputPath": "/exports/custom.tar.gz"},
+            WorkspaceExportSignoffRequest,
+        ),
         (
             "workspace.sync_config",
             {"workspaceId": "ws-1", "configPath": "/work/ws/config/route.json"},
@@ -166,6 +172,19 @@ def test_workspace_info_accepts_info_id_alias():
 
     assert isinstance(request, WorkspaceInfoRequest)
     assert request.info_id == "timing"
+
+
+def test_workspace_export_signoff_preserves_exact_output_path():
+    request = _parse_runtime_request(
+        "workspace.export_signoff",
+        {
+            "workspaceId": "ws-1",
+            "outputPath": "/exports/custom.tar.gz ",
+        },
+    )
+
+    assert isinstance(request, WorkspaceExportSignoffRequest)
+    assert request.output_path == "/exports/custom.tar.gz "
 
 
 @pytest.mark.parametrize(

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -7,6 +7,7 @@ from chipcompiler.runtime.requests import (
     DbEnsureRequest,
     DbReleaseRequest,
     WorkspaceExportSignoffRequest,
+    WorkspaceInspectSignoffRequest,
     WorkspaceOpenRequest,
 )
 from chipcompiler.runtime.server import RuntimeServer
@@ -44,6 +45,9 @@ class CompleteFakeApi:
 
     def export_signoff(self, _request):
         raise AssertionError("unexpected export_signoff call")
+
+    def inspect_signoff(self, _request):
+        raise AssertionError("unexpected inspect_signoff call")
 
     def flow_run(self, _request):
         raise AssertionError("unexpected flow_run call")
@@ -190,6 +194,29 @@ def test_workspace_export_signoff_dispatches_exact_output_path():
     }
 
 
+def test_workspace_inspect_signoff_dispatches_typed_request():
+    class FakeApi(CompleteFakeApi):
+        def inspect_signoff(self, request):
+            assert isinstance(request, WorkspaceInspectSignoffRequest)
+            return {"status": "ready", "groups": [], "risks": []}
+
+    server = RuntimeServer(api=FakeApi())
+
+    response = _dispatch(
+        server,
+        (
+            '{"jsonrpc":"2.0","method":"workspace.inspect_signoff",'
+            '"params":{"workspaceId":"workspace-1"},"id":6}'
+        ),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "result": {"status": "ready", "groups": [], "risks": []},
+        "id": 6,
+    }
+
+
 def test_persistent_db_methods_dispatch_typed_requests_to_runtime_api():
     seen = []
 
@@ -221,10 +248,7 @@ def test_persistent_db_methods_dispatch_typed_requests_to_runtime_api():
     )
     release_response = _dispatch(
         server,
-        (
-            '{"jsonrpc":"2.0","method":"db.release",'
-            '"params":{"workspaceId":"workspace-1"},"id":9}'
-        ),
+        ('{"jsonrpc":"2.0","method":"db.release","params":{"workspaceId":"workspace-1"},"id":9}'),
     )
 
     assert ensure_response["result"] == {
@@ -246,10 +270,7 @@ def test_persistent_db_methods_are_not_registered_by_default():
 
     response = _dispatch(
         server,
-        (
-            '{"jsonrpc":"2.0","method":"db.ensure",'
-            '"params":{"workspaceId":"workspace-1"},"id":10}'
-        ),
+        ('{"jsonrpc":"2.0","method":"db.ensure","params":{"workspaceId":"workspace-1"},"id":10}'),
     )
 
     assert response["id"] == 10

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -3,7 +3,12 @@ import json
 import pytest
 
 from chipcompiler.runtime.methods import RUNTIME_METHODS, runtime_methods
-from chipcompiler.runtime.requests import DbEnsureRequest, DbReleaseRequest, WorkspaceOpenRequest
+from chipcompiler.runtime.requests import (
+    DbEnsureRequest,
+    DbReleaseRequest,
+    WorkspaceExportSignoffRequest,
+    WorkspaceOpenRequest,
+)
 from chipcompiler.runtime.server import RuntimeServer
 from chipcompiler.runtime.workspace_api import RuntimeApiError
 
@@ -36,6 +41,9 @@ class CompleteFakeApi:
 
     def reset_flow(self, _request):
         raise AssertionError("unexpected reset_flow call")
+
+    def export_signoff(self, _request):
+        raise AssertionError("unexpected export_signoff call")
 
     def flow_run(self, _request):
         raise AssertionError("unexpected flow_run call")
@@ -155,6 +163,30 @@ def test_workspace_method_dispatches_typed_request_to_runtime_api():
         "jsonrpc": "2.0",
         "result": {"workspaceId": "workspace-1", "directory": "/ws"},
         "id": 4,
+    }
+
+
+def test_workspace_export_signoff_dispatches_exact_output_path():
+    class FakeApi(CompleteFakeApi):
+        def export_signoff(self, request):
+            assert isinstance(request, WorkspaceExportSignoffRequest)
+            return {"outputPath": request.output_path}
+
+    server = RuntimeServer(api=FakeApi())
+
+    response = _dispatch(
+        server,
+        (
+            '{"jsonrpc":"2.0","method":"workspace.export_signoff",'
+            '"params":{"workspaceId":"workspace-1",'
+            '"outputPath":"/exports/custom.tar.gz "},"id":5}'
+        ),
+    )
+
+    assert response == {
+        "jsonrpc": "2.0",
+        "result": {"outputPath": "/exports/custom.tar.gz "},
+        "id": 5,
     }
 
 

--- a/test/runtime/test_signoff_export.py
+++ b/test/runtime/test_signoff_export.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from chipcompiler.runtime import signoff_export
 from chipcompiler.runtime.requests import WorkspaceExportSignoffRequest
 from chipcompiler.runtime.sessions import WorkspaceSessionRegistry
 from chipcompiler.runtime.workspace_api import RuntimeApiError, WorkspaceRuntimeApi
@@ -82,6 +83,178 @@ def test_workspace_export_signoff_waits_for_session_mutation_lock(monkeypatch, t
         raise result
     assert result == {"outputPath": str(output_path)}
     assert entered.is_set()
+
+
+def test_inspect_signoff_package_returns_grouped_review_with_actionable_details(
+    monkeypatch,
+):
+    class FakeFlow:
+        def __init__(self, workspace):
+            assert workspace == "workspace"
+
+        def collect_signoff_package(self, options):
+            assert options.archive is False
+            assert options.materialize is False
+            return SimpleNamespace(
+                copied=[
+                    {
+                        "destination": "initial/gcd.v",
+                        "size_bytes": 10,
+                    },
+                    {
+                        "destination": "config/sta.json",
+                        "size_bytes": 20,
+                    },
+                    {
+                        "destination": "final/timing/sta/MAX_125/RCworst/qor_summary.rpt",
+                        "size_bytes": 30,
+                    },
+                ],
+                missing_required=["harden/gcd.gds", "flow step RCX is Failed"],
+                missing_optional=["final/design/gcd.png"],
+                warnings=["home checklist contains failed or warning items"],
+                issues=[
+                    SimpleNamespace(
+                        kind="resource",
+                        label="harden.gds",
+                        location="Harden_ecc/output/gcd_Harden.gds",
+                        reason="Required file is missing or empty",
+                        required=True,
+                        destination="harden/gcd.gds",
+                    ),
+                    SimpleNamespace(
+                        kind="flow",
+                        label="RCX flow step",
+                        location="RCX",
+                        reason="State is Failed",
+                        required=True,
+                        destination="flow step RCX",
+                    ),
+                    SimpleNamespace(
+                        kind="resource",
+                        label="final.design.image",
+                        location="filler_ecc/output/gcd_filler.png",
+                        reason="Optional file is missing or empty",
+                        required=False,
+                        destination="final/design/gcd.png",
+                    ),
+                    SimpleNamespace(
+                        kind="checklist",
+                        label="check setup slack",
+                        location="STA / Timing / check setup slack",
+                        reason="Failed: WNS is negative",
+                        required=False,
+                        destination="final/reports/checklist.json",
+                    ),
+                ],
+            )
+
+    monkeypatch.setattr(signoff_export, "EngineFlow", FakeFlow)
+
+    review = signoff_export.inspect_signoff_package("workspace")
+
+    assert review["status"] == "blocked"
+    assert [group["id"] for group in review["groups"]] == [
+        "initial",
+        "config",
+        "harden",
+        "final_design",
+        "sta",
+        "spef",
+        "reports",
+    ]
+    assert review["groups"][2] == {
+        "id": "harden",
+        "label": "Harden",
+        "status": "blocked",
+        "available": 0,
+        "expected": 1,
+        "summary": "1 required resource missing",
+    }
+    assert review["groups"][3]["status"] == "attention"
+    assert [risk["severity"] for risk in review["risks"]] == [
+        "blocked",
+        "blocked",
+        "warning",
+        "warning",
+    ]
+    harden_risk = next(
+        risk for risk in review["risks"] if risk["title"] == "Harden resources missing"
+    )
+    assert harden_risk["details"] == [
+        {
+            "kind": "resource",
+            "label": "harden.gds",
+            "location": "Harden_ecc/output/gcd_Harden.gds",
+            "reason": "Required file is missing or empty",
+        }
+    ]
+    flow_risk = next(
+        risk for risk in review["risks"] if risk["title"] == "Flow requirements not complete"
+    )
+    assert flow_risk["details"] == [
+        {
+            "kind": "flow",
+            "label": "RCX flow step",
+            "location": "RCX",
+            "reason": "State is Failed",
+        }
+    ]
+    checklist_risk = next(
+        risk for risk in review["risks"] if risk["title"] == "Checklist attention"
+    )
+    assert checklist_risk["details"] == [
+        {
+            "kind": "checklist",
+            "label": "check setup slack",
+            "location": "STA / Timing / check setup slack",
+            "reason": "Failed: WNS is negative",
+        }
+    ]
+    assert all(
+        not detail["location"].startswith("/")
+        for risk in review["risks"]
+        for detail in risk["details"]
+    )
+
+
+def test_workspace_inspect_signoff_waits_for_session_mutation_lock(monkeypatch, tmp_path):
+    workspace = SimpleNamespace(directory=tmp_path / "workspace")
+    sessions = WorkspaceSessionRegistry()
+    session = sessions.open_session(workspace.directory, workspace=workspace)
+    entered = threading.Event()
+    results = queue.Queue()
+
+    def fake_inspect(active_workspace):
+        assert active_workspace is workspace
+        entered.set()
+        return {"status": "ready", "groups": [], "risks": []}
+
+    monkeypatch.setattr(signoff_export, "inspect_signoff_package", fake_inspect)
+    api = WorkspaceRuntimeApi(sessions=sessions)
+    request_class = getattr(
+        __import__("chipcompiler.runtime.requests", fromlist=["WorkspaceInspectSignoffRequest"]),
+        "WorkspaceInspectSignoffRequest",
+    )
+
+    def run_inspection():
+        try:
+            results.put(api.inspect_signoff(request_class(workspace_id=session.workspace_id)))
+        except BaseException as error:  # pragma: no cover - re-raised below
+            results.put(error)
+
+    with session.mutation_lock:
+        worker = threading.Thread(target=run_inspection)
+        worker.start()
+        assert not entered.wait(0.1)
+        assert worker.is_alive()
+
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    result = results.get_nowait()
+    if isinstance(result, BaseException):
+        raise result
+    assert result == {"status": "ready", "groups": [], "risks": []}
 
 
 def test_export_signoff_package_archive_collects_temporarily_and_replaces_atomically(

--- a/test/runtime/test_signoff_export.py
+++ b/test/runtime/test_signoff_export.py
@@ -1,3 +1,5 @@
+import queue
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -34,6 +36,52 @@ def test_workspace_export_signoff_returns_exact_output_path(monkeypatch, tmp_pat
 
     assert result == {"outputPath": str(output_path)}
     assert calls == [(workspace, str(output_path))]
+
+
+def test_workspace_export_signoff_waits_for_session_mutation_lock(monkeypatch, tmp_path):
+    workspace = SimpleNamespace(directory=tmp_path / "workspace")
+    sessions = WorkspaceSessionRegistry()
+    session = sessions.open_session(workspace.directory, workspace=workspace)
+    output_path = tmp_path / "export.tar.gz"
+    entered = threading.Event()
+    results = queue.Queue()
+
+    def fake_export(_workspace, requested_output):
+        entered.set()
+        return requested_output
+
+    monkeypatch.setattr(
+        "chipcompiler.runtime.signoff_export.export_signoff_package_archive",
+        fake_export,
+    )
+    api = WorkspaceRuntimeApi(sessions=sessions)
+
+    def run_export():
+        try:
+            results.put(
+                api.export_signoff(
+                    WorkspaceExportSignoffRequest(
+                        workspace_id=session.workspace_id,
+                        output_path=str(output_path),
+                    )
+                )
+            )
+        except BaseException as error:  # pragma: no cover - re-raised below
+            results.put(error)
+
+    with session.mutation_lock:
+        worker = threading.Thread(target=run_export)
+        worker.start()
+        assert not entered.wait(0.1)
+        assert worker.is_alive()
+
+    worker.join(timeout=2)
+    assert not worker.is_alive()
+    result = results.get_nowait()
+    if isinstance(result, BaseException):
+        raise result
+    assert result == {"outputPath": str(output_path)}
+    assert entered.is_set()
 
 
 def test_export_signoff_package_archive_collects_temporarily_and_replaces_atomically(

--- a/test/runtime/test_signoff_export.py
+++ b/test/runtime/test_signoff_export.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from chipcompiler.runtime.requests import WorkspaceExportSignoffRequest
+from chipcompiler.runtime.sessions import WorkspaceSessionRegistry
+from chipcompiler.runtime.workspace_api import RuntimeApiError, WorkspaceRuntimeApi
+
+
+def test_workspace_export_signoff_returns_exact_output_path(monkeypatch, tmp_path):
+    workspace = SimpleNamespace(directory=tmp_path / "workspace")
+    sessions = WorkspaceSessionRegistry()
+    session = sessions.open_session(workspace.directory, workspace=workspace)
+    output_path = tmp_path / "exports" / "custom name.tar.gz"
+    calls = []
+
+    def fake_export(active_workspace, requested_output):
+        calls.append((active_workspace, requested_output))
+        return str(output_path)
+
+    monkeypatch.setattr(
+        "chipcompiler.runtime.signoff_export.export_signoff_package_archive",
+        fake_export,
+    )
+    api = WorkspaceRuntimeApi(sessions=sessions)
+
+    result = api.export_signoff(
+        WorkspaceExportSignoffRequest(
+            workspace_id=session.workspace_id,
+            output_path=str(output_path),
+        )
+    )
+
+    assert result == {"outputPath": str(output_path)}
+    assert calls == [(workspace, str(output_path))]
+
+
+def test_export_signoff_package_archive_collects_temporarily_and_replaces_atomically(
+    monkeypatch,
+    tmp_path,
+):
+    from chipcompiler.runtime.signoff_export import export_signoff_package_archive
+
+    output_path = tmp_path / "nested" / "chosen.tar.gz"
+    captured_output_dirs = []
+
+    class FakeFlow:
+        def __init__(self, workspace):
+            assert workspace == "workspace"
+
+        def collect_signoff_package(self, options):
+            captured_output_dirs.append(options.output_dir)
+            archive = Path(options.output_dir) / "design_signoff_package.tar.gz"
+            archive.write_bytes(b"archive")
+            return SimpleNamespace(
+                ok=True,
+                archive_path=str(archive),
+                missing_required=[],
+            )
+
+    monkeypatch.setattr(
+        "chipcompiler.runtime.signoff_export.EngineFlow",
+        FakeFlow,
+    )
+
+    result = export_signoff_package_archive("workspace", str(output_path))
+
+    assert result == str(output_path.resolve())
+    assert output_path.read_bytes() == b"archive"
+    assert captured_output_dirs
+    assert not Path(captured_output_dirs[0]).exists()
+    assert not list(output_path.parent.glob(f".{output_path.name}.*"))
+
+
+def test_export_signoff_package_archive_preserves_existing_target_on_incomplete_result(
+    monkeypatch,
+    tmp_path,
+):
+    from chipcompiler.runtime.signoff_export import export_signoff_package_archive
+
+    output_path = tmp_path / "existing.tar.gz"
+    output_path.write_bytes(b"old")
+
+    class FakeFlow:
+        def __init__(self, workspace):
+            pass
+
+        def collect_signoff_package(self, options):
+            return SimpleNamespace(
+                ok=False,
+                archive_path=None,
+                missing_required=["harden/design.gds", "harden/design.lef"],
+            )
+
+    monkeypatch.setattr(
+        "chipcompiler.runtime.signoff_export.EngineFlow",
+        FakeFlow,
+    )
+
+    with pytest.raises(RuntimeApiError) as exc_info:
+        export_signoff_package_archive("workspace", str(output_path))
+
+    assert exc_info.value.code == "command_failed"
+    assert "harden/design.gds" in exc_info.value.message
+    assert "harden/design.lef" in exc_info.value.message
+    assert output_path.read_bytes() == b"old"
+
+
+def test_export_signoff_package_archive_replaces_symlink_entry_not_target(
+    monkeypatch,
+    tmp_path,
+):
+    from chipcompiler.runtime.signoff_export import export_signoff_package_archive
+
+    target = tmp_path / "target.tar.gz"
+    target.write_bytes(b"target")
+    output_path = tmp_path / "chosen.tar.gz"
+    try:
+        output_path.symlink_to(target.name)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable")
+
+    class FakeFlow:
+        def __init__(self, workspace):
+            pass
+
+        def collect_signoff_package(self, options):
+            archive = Path(options.output_dir) / "archive.tar.gz"
+            archive.write_bytes(b"new")
+            return SimpleNamespace(ok=True, archive_path=str(archive), missing_required=[])
+
+    monkeypatch.setattr(
+        "chipcompiler.runtime.signoff_export.EngineFlow",
+        FakeFlow,
+    )
+
+    export_signoff_package_archive("workspace", str(output_path))
+
+    assert not output_path.is_symlink()
+    assert output_path.read_bytes() == b"new"
+    assert target.read_bytes() == b"target"

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -247,6 +247,7 @@ def test_create_workspace_returns_plain_runtime_result_and_session(monkeypatch, 
             pdk_json={"name": "ics55"},
             parameters={"Design": "gcd"},
             rtl_list=["a.v"],
+            sdc="/constraints/top.sdc",
         )
     )
 
@@ -254,6 +255,7 @@ def test_create_workspace_returns_plain_runtime_result_and_session(monkeypatch, 
     assert result["directory"] == str(ws.resolve())
     assert result["workspaceId"].startswith("workspace-")
     assert isinstance(capture["create_kwargs"]["pdk_json"], str)
+    assert capture["create_kwargs"]["sdc"] == "/constraints/top.sdc"
     assert DummyFlow.instances[0].created
     assert api.sessions.get_session(result["workspaceId"]).directory == ws.resolve()
 

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -258,6 +258,21 @@ def test_create_workspace_returns_plain_runtime_result_and_session(monkeypatch, 
     assert api.sessions.get_session(result["workspaceId"]).directory == ws.resolve()
 
 
+def test_create_workspace_forwards_dynamic_flow_config(monkeypatch, tmp_path):
+    capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    flow_config = {
+        "start_step": "Synthesis",
+        "end_step": "Harden",
+        "steps": ["Synthesis", "RCX", "sta", "Harden"],
+    }
+
+    WorkspaceRuntimeApi().create_workspace(
+        WorkspaceCreateRequest(directory=str(ws), flow_config=flow_config)
+    )
+
+    assert capture["create_kwargs"]["flow_config"] == flow_config
+
+
 def test_create_workspace_writes_rtl_list_filelist_outside_workspace(
     monkeypatch,
     tmp_path,

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -15,15 +15,21 @@ def _write_json(path: Path, data: dict) -> None:
     _write(path, json.dumps(data, indent=2))
 
 
-def _make_signoff_workspace(tmp_path: Path) -> Path:
+def _make_signoff_workspace(
+    tmp_path: Path,
+    design: str = "gcd",
+    top_module: str = "gcd",
+) -> Path:
     workspace_dir = tmp_path / "gcd_workspace"
-    design = "gcd"
 
-    _write(workspace_dir / "origin" / f"{design}.v", "module gcd; endmodule\n")
-    _write(workspace_dir / "origin" / f"{design}.sdc", "create_clock -period 10 clk\n")
+    _write(workspace_dir / "origin" / f"{top_module}.v", "module gcd; endmodule\n")
+    _write(
+        workspace_dir / "origin" / f"{top_module}.sdc",
+        "create_clock -period 10 clk\n",
+    )
     _write_json(
         workspace_dir / "home" / "parameters.json",
-        {"Design": design, "Top module": design, "PDK": "ics55"},
+        {"Design": design, "Top module": top_module, "PDK": "ics55"},
     )
     _write_json(
         workspace_dir / "home" / "flow.json",
@@ -57,25 +63,32 @@ def _make_signoff_workspace(tmp_path: Path) -> Path:
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.def.gz")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.gds")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.png")
-    _write(workspace_dir / "RCX_ecc" / "output" / f"{design}_RCworst_125C.spef")
+    _write(
+        workspace_dir / "RCX_ecc" / "output" / f"{top_module}_RCworst_125C.spef"
+    )
 
     sta_dir = workspace_dir / "sta_ecc" / "output" / "MAX_125" / "RCworst"
-    _write_json(sta_dir / f"{design}.rpt.json", {"slack": []})
-    _write(sta_dir / f"{design}.rpt")
+    _write(sta_dir / "qor_summary.rpt", "qor summary\n")
+    _write(sta_dir / "timing_max_reg2reg.rpt", "max paths\n")
+    _write(sta_dir / "timing_min_reg2reg.rpt", "min paths\n")
 
     _write_json(workspace_dir / "route_ecc" / "analysis" / "route_metrics.json", {})
     _write(workspace_dir / "route_ecc" / "report" / "route.db.rpt")
     return workspace_dir
 
 
-def _make_engine_flow(workspace_dir: Path) -> EngineFlow:
+def _make_engine_flow(
+    workspace_dir: Path,
+    design: str = "gcd",
+    top_module: str = "gcd",
+) -> EngineFlow:
     workspace = Workspace()
     workspace.directory = str(workspace_dir)
-    workspace.design = OriginDesign(name="gcd", top_module="gcd")
+    workspace.design = OriginDesign(name=design, top_module=top_module)
     workspace.flow.path = str(workspace_dir / "home" / "flow.json")
     workspace.parameters = Parameters(
         path=str(workspace_dir / "home" / "parameters.json"),
-        data={"Design": "gcd", "Top module": "gcd", "PDK": "ics55"},
+        data={"Design": design, "Top module": top_module, "PDK": "ics55"},
     )
     return EngineFlow(workspace=workspace)
 
@@ -100,10 +113,49 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
     summary = json.loads((package_dir / "summary.json").read_text())
     assert summary["final"]["verilog"] == "final/design/gcd.v.gz"
     assert summary["sta_matrix"][0]["report"] == (
-        "final/timing/sta/MAX_125/RCworst/gcd.rpt.json"
+        "final/timing/sta/MAX_125/RCworst/qor_summary.rpt"
     )
 
     manifest = json.loads((package_dir / "manifest.json").read_text())
     destinations = {item["destination"] for item in manifest["files"]}
     assert "final/design/gcd.def.gz" in destinations
     assert "final/reports/route/analysis/route_metrics.json" in destinations
+    assert "final/timing/sta/MAX_125/RCworst/qor_summary.rpt" in destinations
+    assert "final/timing/sta/MAX_125/RCworst/timing_max_reg2reg.rpt" in destinations
+    assert "final/timing/sta/MAX_125/RCworst/timing_min_reg2reg.rpt" in destinations
+
+
+def test_collect_signoff_package_uses_top_module_for_rcx_spef(tmp_path):
+    design = "project_gcd_ws_0002"
+    top_module = "gcd"
+    workspace_dir = _make_signoff_workspace(tmp_path, design, top_module)
+    engine_flow = _make_engine_flow(workspace_dir, design, top_module)
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=False))
+
+    package_dir = Path(result.package_dir)
+    assert result.ok is True
+    assert (
+        package_dir / "final" / "timing" / "spef" / "gcd_RCworst_125C.spef"
+    ).is_file()
+
+
+def test_collect_signoff_package_requires_qor_summary_for_each_sta_corner(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (
+        workspace_dir
+        / "sta_ecc"
+        / "output"
+        / "MAX_125"
+        / "RCworst"
+        / "qor_summary.rpt"
+    ).unlink()
+    engine_flow = _make_engine_flow(workspace_dir)
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=False))
+
+    assert result.ok is False
+    assert (
+        "final/timing/sta/MAX_125/RCworst/qor_summary.rpt"
+        in result.missing_required
+    )

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -5,6 +5,18 @@ from chipcompiler.data import OriginDesign, Parameters, StateEnum, Workspace
 from chipcompiler.engine import EngineFlow
 from chipcompiler.engine.signoff import SignoffPackageOptions
 
+STA_REPORT_NAMES = (
+    "qor_summary.rpt",
+    "timing_max_in2out.rpt",
+    "timing_max_in2reg.rpt",
+    "timing_max_reg2out.rpt",
+    "timing_max_reg2reg.rpt",
+    "timing_min_in2out.rpt",
+    "timing_min_in2reg.rpt",
+    "timing_min_reg2out.rpt",
+    "timing_min_reg2reg.rpt",
+)
+
 
 def _write(path: Path, text: str = "data") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -63,14 +75,11 @@ def _make_signoff_workspace(
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.def.gz")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.gds")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.png")
-    _write(
-        workspace_dir / "RCX_ecc" / "output" / f"{top_module}_RCworst_125C.spef"
-    )
+    _write(workspace_dir / "RCX_ecc" / "output" / f"{top_module}_RCworst_125C.spef")
 
     sta_dir = workspace_dir / "sta_ecc" / "output" / "MAX_125" / "RCworst"
-    _write(sta_dir / "qor_summary.rpt", "qor summary\n")
-    _write(sta_dir / "timing_max_reg2reg.rpt", "max paths\n")
-    _write(sta_dir / "timing_min_reg2reg.rpt", "min paths\n")
+    for report_name in STA_REPORT_NAMES:
+        _write(sta_dir / report_name, f"{report_name}\n")
 
     _write_json(workspace_dir / "route_ecc" / "analysis" / "route_metrics.json", {})
     _write(workspace_dir / "route_ecc" / "report" / "route.db.rpt")
@@ -120,9 +129,10 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
     destinations = {item["destination"] for item in manifest["files"]}
     assert "final/design/gcd.def.gz" in destinations
     assert "final/reports/route/analysis/route_metrics.json" in destinations
-    assert "final/timing/sta/MAX_125/RCworst/qor_summary.rpt" in destinations
-    assert "final/timing/sta/MAX_125/RCworst/timing_max_reg2reg.rpt" in destinations
-    assert "final/timing/sta/MAX_125/RCworst/timing_min_reg2reg.rpt" in destinations
+    assert {
+        f"final/timing/sta/MAX_125/RCworst/{report_name}" for report_name in STA_REPORT_NAMES
+    }.issubset(destinations)
+    assert all(".tsv" not in destination for destination in destinations)
 
 
 def test_collect_signoff_package_uses_top_module_for_rcx_spef(tmp_path):
@@ -135,27 +145,118 @@ def test_collect_signoff_package_uses_top_module_for_rcx_spef(tmp_path):
 
     package_dir = Path(result.package_dir)
     assert result.ok is True
-    assert (
-        package_dir / "final" / "timing" / "spef" / "gcd_RCworst_125C.spef"
-    ).is_file()
+    assert (package_dir / "final" / "timing" / "spef" / "gcd_RCworst_125C.spef").is_file()
 
 
 def test_collect_signoff_package_requires_qor_summary_for_each_sta_corner(tmp_path):
     workspace_dir = _make_signoff_workspace(tmp_path)
-    (
-        workspace_dir
-        / "sta_ecc"
-        / "output"
-        / "MAX_125"
-        / "RCworst"
-        / "qor_summary.rpt"
-    ).unlink()
+    (workspace_dir / "sta_ecc" / "output" / "MAX_125" / "RCworst" / "qor_summary.rpt").unlink()
     engine_flow = _make_engine_flow(workspace_dir)
 
     result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=False))
 
     assert result.ok is False
-    assert (
-        "final/timing/sta/MAX_125/RCworst/qor_summary.rpt"
-        in result.missing_required
+    assert "final/timing/sta/MAX_125/RCworst/qor_summary.rpt" in result.missing_required
+
+
+def test_collect_signoff_package_requires_each_sta_path_report(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    report_name = "timing_min_in2out.rpt"
+    (workspace_dir / "sta_ecc" / "output" / "MAX_125" / "RCworst" / report_name).unlink()
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
     )
+
+    assert result.ok is False
+    assert f"final/timing/sta/MAX_125/RCworst/{report_name}" in result.missing_required
+    assert any(
+        issue.location == f"sta_ecc/output/MAX_125/RCworst/{report_name}" and issue.required
+        for issue in result.issues
+    )
+
+
+def test_collect_signoff_package_ignores_harden_tsv_resource(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is True
+    assert all(".tsv" not in destination for destination in result.missing_optional)
+    assert all(".tsv" not in issue.destination for issue in result.issues)
+
+
+def test_collect_signoff_package_inspection_does_not_materialize_resources(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is True
+    assert result.copied[0]["size_bytes"] > 0
+    assert result.copied[0]["sha256"] is None
+    assert not Path(result.package_dir).exists()
+
+
+def test_collect_signoff_package_inspection_records_missing_optional_resource(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "filler_ecc" / "output" / "gcd_filler.png").unlink()
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is True
+    assert "final/design/gcd.png" in result.missing_optional
+
+
+def test_collect_signoff_package_reports_actionable_inspection_issues(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "Harden_ecc" / "output" / "gcd_Harden.gds").unlink()
+    _write_json(
+        workspace_dir / "home" / "flow.json",
+        {"steps": [{"name": "RCX", "state": "Failed"}]},
+    )
+    _write_json(
+        workspace_dir / "home" / "checklist.json",
+        {
+            "checklist": [
+                {
+                    "step": "STA",
+                    "type": "Timing",
+                    "item": "check setup slack",
+                    "state": "Failed",
+                    "info": "WNS is negative",
+                }
+            ]
+        },
+    )
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert {issue.kind for issue in result.issues} == {
+        "resource",
+        "flow",
+        "checklist",
+    }
+    assert any(
+        issue.location == "Harden_ecc/output/gcd_Harden.gds"
+        and issue.reason == "Required file is missing or empty"
+        and issue.required
+        for issue in result.issues
+    )
+    assert any(
+        issue.location == "RCX" and issue.reason == "State is Failed" for issue in result.issues
+    )
+    assert any(
+        issue.location == "STA / Timing / check setup slack"
+        and issue.reason == "Failed: WNS is negative"
+        and not issue.required
+        for issue in result.issues
+    )
+    assert all(str(workspace_dir) not in issue.location for issue in result.issues)

--- a/test/tools/ecc/test_checklist.py
+++ b/test/tools/ecc/test_checklist.py
@@ -26,17 +26,30 @@ clk                       2.500      0.000       0    100MHz       1.250      0.
 Summary                   2.500      0.000       0    100MHz       1.250      0.000       0
 """
 
+QOR_SUMMARY_WITH_FAILING_SUMMARY = """\
+Path Group                  WNS        TNS     NVP      FREQ      WNS(H)     TNS(H)  NVP(H)
+-------------------------------------------------------------------------------------------
+clk                       2.500      0.000       0    100MHz       1.250      0.000       0
+data                     -0.500     -1.000       1     90MHz      -0.250     -0.500       1
+-------------------------------------------------------------------------------------------
+Summary                  -0.500     -1.000       1     90MHz      -0.250     -0.500       1
+"""
+
 
 def _write(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text)
 
 
-def _sta_checker(tmp_path: Path, report_names=STA_REPORT_NAMES) -> EccStaChecklist:
+def _sta_checker(
+    tmp_path: Path,
+    report_names=STA_REPORT_NAMES,
+    qor_summary: str = QOR_SUMMARY,
+) -> EccStaChecklist:
     output_dir = tmp_path / "sta_ecc" / "output"
     report_dir = output_dir / "MAX_125" / "RCworst"
     for report_name in report_names:
-        text = QOR_SUMMARY if report_name == "qor_summary.rpt" else "timing paths\n"
+        text = qor_summary if report_name == "qor_summary.rpt" else "timing paths\n"
         _write(report_dir / report_name, text)
 
     sta_config = tmp_path / "config" / "sta.json"
@@ -84,3 +97,12 @@ def test_sta_checklist_fails_matrix_when_a_path_report_is_missing(tmp_path):
 
     assert checker.check() is False
     assert _item_state(checker, "check STA signoff matrix") == "Failed"
+
+
+def test_sta_checklist_uses_qor_summary_row_for_timing_status(tmp_path):
+    checker = _sta_checker(tmp_path, qor_summary=QOR_SUMMARY_WITH_FAILING_SUMMARY)
+
+    assert checker.check() is False
+    assert _item_state(checker, "check setup timing") == "Failed"
+    assert _item_state(checker, "check hold timing") == "Failed"
+    assert _item_state(checker, "check frequency requirement") == "Failed"

--- a/test/tools/ecc/test_checklist.py
+++ b/test/tools/ecc/test_checklist.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from chipcompiler.data import StepEnum
+from chipcompiler.tools.ecc.checklist import EccStaChecklist
+
+
+STA_REPORT_NAMES = (
+    "qor_summary.rpt",
+    "timing_max_in2out.rpt",
+    "timing_max_in2reg.rpt",
+    "timing_max_reg2out.rpt",
+    "timing_max_reg2reg.rpt",
+    "timing_min_in2out.rpt",
+    "timing_min_in2reg.rpt",
+    "timing_min_reg2out.rpt",
+    "timing_min_reg2reg.rpt",
+)
+
+QOR_SUMMARY = """\
+Path Group                  WNS        TNS     NVP      FREQ      WNS(H)     TNS(H)  NVP(H)
+-------------------------------------------------------------------------------------------
+clk                       2.500      0.000       0    100MHz       1.250      0.000       0
+-------------------------------------------------------------------------------------------
+Summary                   2.500      0.000       0    100MHz       1.250      0.000       0
+"""
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _sta_checker(tmp_path: Path, report_names=STA_REPORT_NAMES) -> EccStaChecklist:
+    output_dir = tmp_path / "sta_ecc" / "output"
+    report_dir = output_dir / "MAX_125" / "RCworst"
+    for report_name in report_names:
+        text = QOR_SUMMARY if report_name == "qor_summary.rpt" else "timing paths\n"
+        _write(report_dir / report_name, text)
+
+    sta_config = tmp_path / "config" / "sta.json"
+    _write(
+        sta_config,
+        json.dumps(
+            {
+                "liberty": [{"corner": "MAX", "temperature": 125}],
+                "signoff": [{"MAX": ["RCworst"]}],
+            }
+        ),
+    )
+    checklist_path = tmp_path / "sta_ecc" / "checklist.json"
+    workspace = SimpleNamespace(
+        config={StepEnum.STA.value: str(sta_config)},
+        design=SimpleNamespace(name="gcd", top_module="gcd"),
+        home=SimpleNamespace(update_checklist=lambda **kwargs: None),
+        parameters=SimpleNamespace(data={"Frequency max [MHz]": 100}),
+    )
+    workspace_step = SimpleNamespace(
+        checklist={"path": str(checklist_path)},
+        name=StepEnum.STA.value,
+        output={"dir": str(output_dir)},
+    )
+    return EccStaChecklist(workspace, workspace_step)
+
+
+def _item_state(checker: EccStaChecklist, item: str) -> str:
+    data = json.loads(Path(checker.workspace_step.checklist["path"]).read_text())
+    return next(row["state"] for row in data["checklist"] if row["item"] == item)
+
+
+def test_sta_checklist_validates_current_text_reports(tmp_path):
+    checker = _sta_checker(tmp_path)
+
+    assert checker.check() is True
+    assert _item_state(checker, "check STA signoff matrix") == "Passed"
+    assert _item_state(checker, "check setup timing") == "Passed"
+    assert _item_state(checker, "check hold timing") == "Passed"
+    assert _item_state(checker, "check frequency requirement") == "Passed"
+
+
+def test_sta_checklist_fails_matrix_when_a_path_report_is_missing(tmp_path):
+    checker = _sta_checker(tmp_path, STA_REPORT_NAMES[:-1])
+
+    assert checker.check() is False
+    assert _item_state(checker, "check STA signoff matrix") == "Failed"

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -94,3 +94,15 @@ def test_rcx_checklist_strips_top_module_from_spef_corner(tmp_path):
     )
 
     assert checklist.spef_corner_name("/rcx/gcd_Cworst_125C.spef") == "Cworst"
+
+
+def test_rcx_checklist_uses_top_module_for_spef_design_token(tmp_path):
+    spef = tmp_path / "gcd_Cworst_125C.spef"
+    spef.write_text('*SPEF "IEEE 1481-1998"\n*DESIGN "gcd"\n*NAME_MAP\n')
+    checklist = EccRcxChecklist.__new__(EccRcxChecklist)
+    checklist.workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="project_gcd_ws_0002", top_module="gcd"),
+    )
+
+    assert checklist.check_spef_file(str(spef)) is True

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -1,5 +1,8 @@
-from chipcompiler.data import OriginDesign, PDK, Workspace, WorkspaceStep
+import json
+
+from chipcompiler.data import PDK, OriginDesign, Workspace, WorkspaceStep
 from chipcompiler.tools.ecc import runner as ecc_runner
+from chipcompiler.tools.ecc.checklist import EccRcxChecklist
 
 
 class FakeEccModule:
@@ -58,3 +61,36 @@ def test_create_db_engine_accepts_path_inputs_for_first_ecc_step(tmp_path, monke
 
     assert module is FakeEccModule.instances[-1]
     assert ("read_def", str(design_def)) in module.calls
+
+
+def test_sta_signoff_items_use_top_module_for_rcx_spef(tmp_path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    sta_config = config_dir / "sta.json"
+    rcx_config = config_dir / "rcx.json"
+    sta_config.write_text(json.dumps({
+        "liberty": [{"corner": "MAX", "temperature": 125, "path": ["max.lib"]}],
+        "signoff": [{"MAX": ["Cworst"]}],
+    }))
+    rcx_config.write_text(json.dumps({"output": str(tmp_path / "RCX_ecc" / "output")}))
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="project_gcd_ws_0002", top_module="gcd"),
+        config={"sta": sta_config, "RCX": rcx_config},
+    )
+
+    items = ecc_runner.collect_sta_signoff_items(workspace)
+
+    assert items[0]["spef_file"] == str(
+        tmp_path / "RCX_ecc" / "output" / "gcd_Cworst_125C.spef"
+    )
+
+
+def test_rcx_checklist_strips_top_module_from_spef_corner(tmp_path):
+    checklist = EccRcxChecklist.__new__(EccRcxChecklist)
+    checklist.workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="project_gcd_ws_0002", top_module="gcd"),
+    )
+
+    assert checklist.spef_corner_name("/rcx/gcd_Cworst_125C.spef") == "Cworst"


### PR DESCRIPTION
## What Changed

- add signoff package function.
- update ecc flow for the new sta output files

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
