### PR TITLE
feat: report STA without SPEF after synthesis

### DIFF
--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -203,6 +203,81 @@ def get_eda_instance(workspace: Workspace,
     
     return ecc_module
 
+
+def run_sta_without_spef(workspace: Workspace,
+                         step: WorkspaceStep,
+                         ecc_module: ECCToolsModule | None = None) -> bool:
+    """Generate a netlist-level STA report after synthesis.
+
+    STA is supplemental to synthesis, so callers can retain a successful
+    synthesis result when this function returns ``False``.
+    """
+    try:
+        netlist_path = step.output.get("verilog", "")
+        liberty_paths = workspace.pdk.libs
+        sdc_path = workspace.pdk.sdc
+        data_dir = step.data.get("dir", "")
+        report_dir = step.report.get("dir", "")
+
+        if not netlist_path or not os.path.isfile(netlist_path):
+            raise FileNotFoundError(f"synthesis netlist does not exist: {netlist_path}")
+
+        missing_liberty_paths = [
+            liberty_path for liberty_path in liberty_paths
+            if not os.path.isfile(liberty_path)
+        ]
+        if not liberty_paths or missing_liberty_paths:
+            raise FileNotFoundError(
+                "STA liberty files are missing: "
+                f"{missing_liberty_paths or liberty_paths}"
+            )
+
+        if not sdc_path or not os.path.isfile(sdc_path):
+            raise FileNotFoundError(f"STA SDC does not exist: {sdc_path}")
+        if not data_dir or not report_dir:
+            raise ValueError("synthesis STA data or report directory is not configured")
+
+        work_dir = Path(data_dir) / "sta"
+        work_dir.mkdir(parents=True, exist_ok=True)
+        report_dir = Path(report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        if ecc_module is None:
+            ecc_module = ECCToolsModule()
+            ecc_module.init_config(
+                flow_config=workspace.config.get("flow", ""),
+                db_config=workspace.config.get("db", ""),
+                output_dir=step.data.get("dir", ""),
+                feature_dir=step.feature.get("dir", ""),
+            )
+        else:
+            ecc_module.update_step_paths(
+                output_dir=step.data.get("dir", ""),
+                feature_dir=step.feature.get("dir", ""),
+            )
+
+        ecc_module.init_techlef(workspace.pdk.tech)
+        ecc_module.init_lefs(workspace.pdk.lefs)
+        ecc_module.read_verilog(
+            verilog=netlist_path,
+            top_module=workspace.design.top_module,
+        )
+        ecc_module.run_timing(
+            config=workspace.config.get(StepEnum.STA.value, ""),
+            work_dir=work_dir,
+            output_dir=report_dir,
+            lib_paths=liberty_paths,
+            sdc_path=sdc_path,
+        )
+    except Exception as exc:
+        workspace.logger.warning(
+            "Post-synthesis STA failed; synthesis result is kept: %s", exc
+        )
+        return False
+
+    workspace.logger.info("Post-synthesis STA report saved to %s", report_dir)
+    return True
+
 def save_data(workspace: Workspace,
               step: WorkspaceStep,
               ecc_module : ECCToolsModule,

--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -52,6 +52,25 @@ def _write_fixed_netlist(src_path: str, dst_path: str) -> bool:
     return True
 
 
+def _run_ecc_synthesis_sta(workspace: Workspace,
+                           step: WorkspaceStep,
+                           ecc_module=None) -> bool:
+    """Run optional ECC STA without making ECC a Yosys import dependency."""
+    try:
+        from chipcompiler.tools.ecc.runner import run_sta_without_spef
+
+        return run_sta_without_spef(
+            workspace=workspace,
+            step=step,
+            ecc_module=ecc_module,
+        )
+    except Exception as exc:
+        workspace.logger.warning(
+            "Post-synthesis STA is unavailable; synthesis result is kept: %s", exc
+        )
+        return False
+
+
 def run_step(workspace: Workspace,
              step: WorkspaceStep,
              ecc_module=None) -> bool:
@@ -64,7 +83,7 @@ def run_step(workspace: Workspace,
     Args:
         workspace: The workspace containing design info
         step: The step workspace with paths and config
-        ecc_module: Not used for yosys (kept for API compatibility)
+        ecc_module: Optional ECC instance used for the post-synthesis STA report
 
     Returns:
         True if synthesis succeeded, False otherwise
@@ -124,6 +143,12 @@ def run_step(workspace: Workspace,
             fixed_netlist = step.output.get("fixed_verilog", "")
             if fixed_netlist:
                 _write_fixed_netlist(step.output["verilog"], fixed_netlist)
+
+            _run_ecc_synthesis_sta(
+                workspace=workspace,
+                step=step,
+                ecc_module=ecc_module,
+            )
             
             build_step_metrics(workspace=workspace, step=step)
             

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -1,6 +1,6 @@
 import json
 
-from chipcompiler.data import PDK, OriginDesign, Workspace, WorkspaceStep
+from chipcompiler.data import PDK, OriginDesign, StepEnum, Workspace, WorkspaceStep
 from chipcompiler.tools.ecc import runner as ecc_runner
 from chipcompiler.tools.ecc.checklist import EccRcxChecklist
 
@@ -27,6 +27,38 @@ class FakeEccModule:
 
     def read_def(self, path):
         self.calls.append(("read_def", path))
+
+
+class FakeSynthesisStaModule:
+    def __init__(self):
+        self.calls = []
+
+    def init_config(self, **kwargs):
+        self.calls.append(("init_config", kwargs))
+
+    def init_techlef(self, path):
+        self.calls.append(("init_techlef", path))
+
+    def init_lefs(self, paths):
+        self.calls.append(("init_lefs", paths))
+
+    def read_verilog(self, **kwargs):
+        self.calls.append(("read_verilog", kwargs))
+
+    def run_timing(self, **kwargs):
+        self.calls.append(("run_timing", kwargs))
+
+
+class FakeLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, message, *args):
+        self.infos.append((message, args))
+
+    def warning(self, message, *args):
+        self.warnings.append((message, args))
 
 
 def test_create_db_engine_accepts_path_inputs_for_first_ecc_step(tmp_path, monkeypatch):
@@ -61,6 +93,93 @@ def test_create_db_engine_accepts_path_inputs_for_first_ecc_step(tmp_path, monke
 
     assert module is FakeEccModule.instances[-1]
     assert ("read_def", str(design_def)) in module.calls
+
+
+def test_run_sta_without_spef_reads_netlist_and_writes_to_step_report(
+        tmp_path, monkeypatch):
+    netlist = tmp_path / "output" / "gcd.v"
+    techlef = tmp_path / "pdk" / "tech.lef"
+    lef = tmp_path / "pdk" / "std.lef"
+    liberty = tmp_path / "pdk" / "std.lib"
+    sdc = tmp_path / "gcd.sdc"
+    for path in (netlist, techlef, lef, liberty, sdc):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+
+    logger = FakeLogger()
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+        pdk=PDK(tech=techlef, lefs=[lef], libs=[liberty], sdc=sdc),
+        config={
+            "flow": tmp_path / "config" / "flow.json",
+            "db": tmp_path / "config" / "db.json",
+            StepEnum.STA.value: tmp_path / "config" / "sta.json",
+        },
+        logger=logger,
+    )
+    step = WorkspaceStep(
+        output={"verilog": netlist},
+        data={"dir": tmp_path / "Synthesis_yosys" / "data"},
+        feature={"dir": tmp_path / "Synthesis_yosys" / "feature"},
+        report={"dir": tmp_path / "Synthesis_yosys" / "report"},
+    )
+    module = FakeSynthesisStaModule()
+    monkeypatch.setattr(ecc_runner, "ECCToolsModule", lambda: module)
+
+    assert ecc_runner.run_sta_without_spef(workspace, step) is True
+
+    assert module.calls == [
+        (
+            "init_config",
+            {
+                "flow_config": workspace.config["flow"],
+                "db_config": workspace.config["db"],
+                "output_dir": step.data["dir"],
+                "feature_dir": step.feature["dir"],
+            },
+        ),
+        ("init_techlef", techlef),
+        ("init_lefs", [lef]),
+        ("read_verilog", {"verilog": netlist, "top_module": "gcd"}),
+        (
+            "run_timing",
+            {
+                "config": workspace.config[StepEnum.STA.value],
+                "work_dir": step.data["dir"] / "sta",
+                "output_dir": step.report["dir"],
+                "lib_paths": [liberty],
+                "sdc_path": sdc,
+            },
+        ),
+    ]
+    assert (step.data["dir"] / "sta").is_dir()
+    assert step.report["dir"].is_dir()
+    assert logger.warnings == []
+
+
+def test_run_sta_without_spef_warns_when_sdc_is_missing(tmp_path):
+    netlist = tmp_path / "output" / "gcd.v"
+    liberty = tmp_path / "pdk" / "std.lib"
+    for path in (netlist, liberty):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+
+    logger = FakeLogger()
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+        pdk=PDK(libs=[liberty], sdc=tmp_path / "missing.sdc"),
+        logger=logger,
+    )
+    step = WorkspaceStep(
+        output={"verilog": netlist},
+        data={"dir": tmp_path / "Synthesis_yosys" / "data"},
+        report={"dir": tmp_path / "Synthesis_yosys" / "report"},
+    )
+
+    assert ecc_runner.run_sta_without_spef(workspace, step) is False
+    assert logger.warnings[0][0] == "Post-synthesis STA failed; synthesis result is kept: %s"
 
 
 def test_sta_signoff_items_use_top_module_for_rcx_spef(tmp_path):

--- a/test/tools/yosys/test_runner.py
+++ b/test/tools/yosys/test_runner.py
@@ -78,6 +78,12 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], runtime_env))
     monkeypatch.setattr(runner, "check_slang_plugin", fake_check_slang_plugin)
     monkeypatch.setattr(runner.subprocess, "run", fake_run)
+    sta_calls = []
+    monkeypatch.setattr(
+        runner,
+        "_run_ecc_synthesis_sta",
+        lambda **kwargs: sta_calls.append(kwargs) or True,
+    )
 
     result = runner.run_step(workspace=workspace, step=step)
 
@@ -90,6 +96,42 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
     assert run_calls[0]["cmd"] == ["yosys", "yosys_synthesis.tcl"]
     assert run_calls[0]["cwd"] == str(step.script["dir"])
     assert run_calls[0]["env"] == runtime_env
+    assert sta_calls == [{"workspace": workspace, "step": step, "ecc_module": None}]
+    assert ("run yosys", StateEnum.Success) in updates
+    assert ("analysis", StateEnum.Success) in updates
+
+
+def test_run_step_keeps_synthesis_success_when_sta_report_fails(tmp_path, monkeypatch):
+    workspace, step, output_file, _ = _build_workspace_and_step(tmp_path)
+    updates = []
+
+    class FakeSubFlow:
+        def __init__(self, workspace, workspace_step):
+            pass
+
+        def update_step(self, step_name, state, runtime="", memory=0, info=None):
+            updates.append((step_name, state))
+
+    class FakeChecklist:
+        def __init__(self, workspace, workspace_step):
+            pass
+
+        def check(self):
+            return None
+
+    def fake_run(cmd, cwd, env, stdout, stderr):
+        output_file.write_text("module top(); endmodule\n")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(runner, "YosysSubFlow", FakeSubFlow)
+    monkeypatch.setattr(runner, "YosysChecklist", FakeChecklist)
+    monkeypatch.setattr(runner, "build_step_metrics", lambda workspace, step: None)
+    monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], {"PATH": "/tmp"}))
+    monkeypatch.setattr(runner, "check_slang_plugin", lambda *args, **kwargs: True)
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+    monkeypatch.setattr(runner, "_run_ecc_synthesis_sta", lambda **kwargs: False)
+
+    assert runner.run_step(workspace=workspace, step=step) is True
     assert ("run yosys", StateEnum.Success) in updates
     assert ("analysis", StateEnum.Success) in updates
 


### PR DESCRIPTION
## What Changed

-add ecc sta timing report after synthesis step.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
