### PR TITLE
fix(build): unbreak nix package build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,14 @@
         hash = "sha256-hyDKWsQnfPVuxxBNxjdGR6AsGa/1NkdflBmwiK3Eqz0=";
       };
 
+      # Pinned nixpkgs ships uv-build 0.8.14, which falls outside the
+      # dependabot-managed version window in RosettaKit's pyproject.toml.
+      # rosettakit is pure Python, so any uv-build works.
+      postPatch = ''
+        substituteInPlace pyproject.toml \
+          --replace-fail 'uv-build>=0.10.0,<0.11.24' 'uv-build'
+      '';
+
       build-system = with python3Packages; [ uv-build ];
 
       pythonImportsCheck = [ "rosettakit" ];

--- a/flake.nix
+++ b/flake.nix
@@ -42,9 +42,54 @@
       pythonImportsCheck = [ "rosettakit" ];
     };
 
+    # Not in the pinned nixpkgs; required by chipcompiler's runtime server.
+    # Use the wheel: the sdist's bundled versioneer is incompatible with
+    # Python 3.13 (configparser.SafeConfigParser was removed).
+    oslash = {
+      fetchPypi,
+      python3Packages,
+    }: python3Packages.buildPythonPackage rec {
+      pname = "OSlash";
+      version = "0.6.3";
+      format = "wheel";
+
+      src = fetchPypi {
+        inherit pname version format;
+        dist = "py3";
+        python = "py3";
+        hash = "sha256-ibl4RDt9s6wmZhBr3DaArdPIhqbY/N0C/QYq+G0pSU8=";
+      };
+
+      dependencies = [ python3Packages.typing-extensions ];
+
+      pythonImportsCheck = [ "oslash" ];
+    };
+
+    jsonrpcserver = {
+      fetchPypi,
+      oslash,
+      python3Packages,
+    }: python3Packages.buildPythonPackage rec {
+      pname = "jsonrpcserver";
+      version = "5.0.9";
+      pyproject = true;
+
+      src = fetchPypi {
+        inherit pname version;
+        hash = "sha256-px+yz6GFQcgJNfYJh/knVdlNdBQSSMdDiEe5bu5cRII=";
+      };
+
+      build-system = with python3Packages; [ setuptools ];
+
+      dependencies = [ python3Packages.jsonschema oslash ];
+
+      pythonImportsCheck = [ "jsonrpcserver" ];
+    };
+
     chipcompiler = {
       ecc-dreamplace,
       ecc-tools,
+      jsonrpcserver,
       rosettakit,
       yosysWithSlang,
       lib,
@@ -70,6 +115,7 @@
         ecc-dreamplace
         ecc-tools
         fastapi
+        jsonrpcserver
         klayout
         matplotlib
         numpy
@@ -107,6 +153,7 @@
       packages.default = pkgs.callPackage chipcompiler {
         ecc-dreamplace = ecc-dreamplace.packages.${system}.default;
         ecc-tools = ecc-tools.packages.${system}.default;
+        jsonrpcserver = pkgs.callPackage jsonrpcserver { oslash = pkgs.callPackage oslash {}; };
         rosettakit = pkgs.callPackage rosettakit {};
         yosysWithSlang = infra.packages.${system}.yosysWithSlang;
       };


### PR DESCRIPTION
## What Changed

- pypaBuildPhase runs with --no-isolation, so build backends must come
from the pinned nixpkgs, whose uv-build is 0.8.14. Two failures
resulted:

    - rosettakit: its pyproject.toml (dependabot-managed) requires
  uv-build>=0.10.0,<0.11.24. Relax the requirement via postPatch;
  rosettakit is pure Python, so any uv-build works.
    - chipcompiler: pythonRuntimeDepsCheckHook failed on jsonrpcserver,
  which pyproject.toml declares but the flake never listed. It and its
  dependency oslash are absent from the pinned nixpkgs, so package
  both in the flake. oslash uses the upstream wheel because its
  sdist's bundled versioneer relies on configparser.SafeConfigParser,
  removed in Python 3.13.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [x] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [x] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
