### PR TITLE
feat: support syn sta flow in cli

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -54,9 +54,13 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds"
+preset = "rtl2gds" # rtl2gds | rcx | harden
 run = "default"
 ```
+
+`flow.preset` 可选 `rtl2gds`、`rcx`、`harden`（`rcx` 追加 RCX 和 STA 步骤，
+`harden` 再追加 Harden 步骤）。已有项目切换 flow：修改 `flow.preset` 后加
+`--overwrite` 重跑。
 
 然后校验并运行：
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -54,13 +54,13 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds" # rtl2gds | rcx | harden
+preset = "rtl2gds" # rtl2gds | rcx | harden | syn_sta
 run = "default"
 ```
 
-`flow.preset` 可选 `rtl2gds`、`rcx`、`harden`（`rcx` 追加 RCX 和 STA 步骤，
-`harden` 再追加 Harden 步骤）。已有项目切换 flow：修改 `flow.preset` 后加
-`--overwrite` 重跑。
+`flow.preset` 可选 `rtl2gds`、`rcx`、`harden`、`syn_sta`（`rcx` 追加 RCX 和
+STA 步骤，`harden` 再追加 Harden 步骤，`syn_sta` 仅综合并附 netlist 级
+STA 报告）。已有项目切换 flow：修改 `flow.preset` 后加 `--overwrite` 重跑。
 
 然后校验并运行：
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -59,8 +59,8 @@ run = "default"
 ```
 
 `flow.preset` 可选 `rtl2gds`、`rcx`、`harden`、`syn_sta`（`rcx` 追加 RCX 和
-STA 步骤，`harden` 再追加 Harden 步骤，`syn_sta` 仅综合并附 netlist 级
-STA 报告）。已有项目切换 flow：修改 `flow.preset` 后加 `--overwrite` 重跑。
+STA 步骤，`harden` 再追加 Harden 步骤，`syn_sta` 仅综合，并尝试生成
+netlist 级 STA 报告（STA 失败不影响综合结果）。已有项目切换 flow：修改 `flow.preset` 后加 `--overwrite` 重跑。
 
 然后校验并运行：
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds"
+preset = "rtl2gds" # rtl2gds | rcx | harden
 run = "default"
 ```
+
+`flow.preset` accepts `rtl2gds`, `rcx`, or `harden` (`rcx` appends the RCX and
+STA steps, `harden` additionally appends the Harden step). To switch flows on
+an existing project, update `flow.preset` and re-run with `--overwrite`.
 
 Then validate and run:
 

--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds" # rtl2gds | rcx | harden
+preset = "rtl2gds" # rtl2gds | rcx | harden | syn_sta
 run = "default"
 ```
 
-`flow.preset` accepts `rtl2gds`, `rcx`, or `harden` (`rcx` appends the RCX and
-STA steps, `harden` additionally appends the Harden step). To switch flows on
-an existing project, update `flow.preset` and re-run with `--overwrite`.
+`flow.preset` accepts `rtl2gds`, `rcx`, `harden`, or `syn_sta` (`rcx` appends
+the RCX and STA steps, `harden` additionally appends the Harden step, and
+`syn_sta` runs synthesis only, with a netlist-level STA report). To switch
+flows on an existing project, update `flow.preset` and re-run with `--overwrite`.
 
 Then validate and run:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ run = "default"
 
 `flow.preset` accepts `rtl2gds`, `rcx`, `harden`, or `syn_sta` (`rcx` appends
 the RCX and STA steps, `harden` additionally appends the Harden step, and
-`syn_sta` runs synthesis only, with a netlist-level STA report). To switch
+`syn_sta` runs synthesis only, with a best-effort
+netlist-level STA report (an STA failure does not fail the step). To switch
 flows on an existing project, update `flow.preset` and re-run with `--overwrite`.
 
 Then validate and run:

--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -56,6 +56,7 @@ name = "ics55"
 root = ""
 
 [flow]
+# preset: rtl2gds | rcx | harden
 preset = "rtl2gds"
 run = "default"
 """
@@ -140,6 +141,7 @@ def check(command_input: CheckInput, ctx: CommandContext) -> CommandResult:
 
 
 def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
+    from chipcompiler import rtl2gds as rtl2gds_api
     from chipcompiler.cli.project.config import (
         find_config_path,
         load_project_config,
@@ -150,7 +152,6 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
     )
     from chipcompiler.data import create_workspace
     from chipcompiler.engine import EngineFlow
-    from chipcompiler.rtl2gds import build_rtl2gds_flow
 
     project = ctx.project
     project_dir = ctx.project_dir
@@ -296,8 +297,13 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
 
     try:
         engine_flow = EngineFlow(workspace=workspace)
+        flow_builders = {
+            "rtl2gds": rtl2gds_api.build_rtl2gds_flow,
+            "rcx": rtl2gds_api.build_rcx_flow,
+            "harden": rtl2gds_api.build_harden_flow,
+        }
         if not engine_flow.has_init():
-            for step, tool, state in build_rtl2gds_flow():
+            for step, tool, state in flow_builders[cfg.flow_preset]():
                 engine_flow.add_step(step=step, tool=tool, state=state)
 
         engine_flow.create_step_workspaces()

--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -56,7 +56,7 @@ name = "ics55"
 root = ""
 
 [flow]
-# preset: rtl2gds | rcx | harden
+# preset: rtl2gds | rcx | harden | syn_sta
 preset = "rtl2gds"
 run = "default"
 """
@@ -297,11 +297,7 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
 
     try:
         engine_flow = EngineFlow(workspace=workspace)
-        flow_builders = {
-            "rtl2gds": rtl2gds_api.build_rtl2gds_flow,
-            "rcx": rtl2gds_api.build_rcx_flow,
-            "harden": rtl2gds_api.build_harden_flow,
-        }
+        flow_builders = rtl2gds_api.get_flow_builders()
         if not engine_flow.has_init():
             for step, tool, state in flow_builders[cfg.flow_preset]():
                 engine_flow.add_step(step=step, tool=tool, state=state)

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -3,7 +3,7 @@ import tomllib
 from dataclasses import dataclass, field
 
 SUPPORTED_PDK_NAMES = {"ics55"}
-SUPPORTED_FLOW_PRESETS = {"rtl2gds"}
+SUPPORTED_FLOW_PRESETS = {"rtl2gds", "rcx", "harden"}
 SUPPORTED_FLOW_RUNS = {"default"}
 FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
 RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -3,7 +3,6 @@ import tomllib
 from dataclasses import dataclass, field
 
 SUPPORTED_PDK_NAMES = {"ics55"}
-SUPPORTED_FLOW_PRESETS = {"rtl2gds", "rcx", "harden"}
 SUPPORTED_FLOW_RUNS = {"default"}
 FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
 RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}
@@ -106,6 +105,12 @@ def find_config_path(project_dir: str) -> str | None:
     return path if os.path.isfile(path) else None
 
 
+def _supported_flow_presets() -> set[str]:
+    from chipcompiler import rtl2gds as rtl2gds_api
+
+    return set(rtl2gds_api.get_flow_builders())
+
+
 def validate_project_config(cfg: ProjectConfig) -> list[str]:
     toml_error = getattr(cfg, "_toml_error", None)
     if toml_error:
@@ -149,7 +154,7 @@ def validate_project_config(cfg: ProjectConfig) -> list[str]:
 
     if not cfg.flow_preset:
         errors.append("flow.preset is required")
-    elif cfg.flow_preset not in SUPPORTED_FLOW_PRESETS:
+    elif cfg.flow_preset not in _supported_flow_presets():
         errors.append(f"unsupported flow.preset: {cfg.flow_preset}")
 
     if cfg.flow_run and cfg.flow_run not in SUPPORTED_FLOW_RUNS:

--- a/chipcompiler/rtl2gds/__init__.py
+++ b/chipcompiler/rtl2gds/__init__.py
@@ -1,11 +1,15 @@
 from .builder import (
-    build_rtl2gds_flow, 
     build_harden_flow,
-    build_rcx_flow
+    build_rcx_flow,
+    build_rtl2gds_flow,
+    build_syn_sta_flow,
+    get_flow_builders,
 )
 
 __all__ = [
-    'build_rtl2gds_flow',
-    'build_harden_flow',
-    'build_rcx_flow'
+    "build_rtl2gds_flow",
+    "build_harden_flow",
+    "build_rcx_flow",
+    "build_syn_sta_flow",
+    "get_flow_builders",
 ]

--- a/chipcompiler/rtl2gds/builder.py
+++ b/chipcompiler/rtl2gds/builder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
+from collections.abc import Callable
 
 from chipcompiler.data import (
     StepEnum,
@@ -21,6 +21,15 @@ def build_rtl2gds_flow() -> list:
     
     return steps
 
+
+def build_syn_sta_flow() -> list:
+    steps = []
+
+    steps.append((StepEnum.SYNTHESIS, "yosys", StateEnum.Unstart))
+
+    return steps
+
+
 def build_harden_flow() -> list:
     steps = build_rcx_flow()
 
@@ -35,3 +44,15 @@ def build_rcx_flow() -> list:
     steps.append((StepEnum.STA, "ecc", StateEnum.Unstart))
     
     return steps
+
+
+def get_flow_builders() -> dict[str, Callable[[], list]]:
+    """Discover flow presets from the build_*_flow defs in this module."""
+    builders = {}
+    for name, fn in globals().items():
+        if not (callable(fn) and name.startswith("build_") and name.endswith("_flow")):
+            continue
+        preset = name[len("build_") : -len("_flow")]
+        if preset:
+            builders[preset] = fn
+    return builders

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -40,6 +40,7 @@ class ECCToolsModule:
     """
     python api package of ECC.
     """
+
     def __init__(self):
         try:
             from ecc_tools_bin import ecc_py as ecc
@@ -60,7 +61,7 @@ class ECCToolsModule:
 
     def get_ecc(self):
         return self.ecc
-    
+
     def exit(self):
         """exit ECC tools"""
         self.ecc.flow_exit()
@@ -71,7 +72,7 @@ class ECCToolsModule:
 
     def get_dmInst_ptr(self):
         return self.ecc.get_dmInst()
-        
+
     def pydb(
         self,
         dm_inst_ptr,
@@ -100,15 +101,9 @@ class ECCToolsModule:
     ########################################################################
     # config api
     ########################################################################
-    def init_config(self,
-                    flow_config : str,
-                    db_config : str,
-                    output_dir : str,
-                    feature_dir : str):
+    def init_config(self, flow_config: str, db_config: str, output_dir: str, feature_dir: str):
         """init_config"""
-        self.ecc.flow_init(
-            flow_config=path_text(flow_config)
-        )
+        self.ecc.flow_init(flow_config=path_text(flow_config))
 
         self.ecc.db_init(
             config_path=path_text(db_config),
@@ -122,32 +117,28 @@ class ECCToolsModule:
             feature_path=path_text(feature_dir),
         )
 
-    def update_sta_data_config(self,
-                               db_config: str,
-                               output_dir: str,
-                               lib_paths: list[str],
-                               sdc_path: str):
+    def update_sta_data_config(
+        self, db_config: str, output_dir: str, lib_paths: list[str], sdc_path: str
+    ):
         self.ecc.db_init(
             config_path=path_text(db_config),
             output_path=path_text(output_dir),
             lib_paths=path_texts(lib_paths),
             sdc_path=path_text(sdc_path),
         )
-        
+
     ########################################################################
     # data api
     ########################################################################
     def idb_init(self, config_path: str):
         return self.ecc.idb_init(path_text(config_path))
 
-    def set_net(self, 
-                net_name: str, 
-                net_type: str):
+    def set_net(self, net_name: str, net_type: str):
         """
         set net type
         """
         return self.ecc.set_net(net_name=net_name, net_type=net_type)
-    
+
     def remove_except_pg_net(self):
         return self.ecc.remove_except_pg_net()
 
@@ -197,19 +188,14 @@ class ECCToolsModule:
 
     def set_exclude_cell_names(self, cell_names: set):
         self.cell_names = cell_names
-        
-    def write_placement_back(self, 
-                             dm_inst_ptr, 
-                             node_x, 
-                             node_y):
-        self.ecc.write_placement_back(dm_inst_ptr, 
-                                       node_x, 
-                                       node_y)
-    
+
+    def write_placement_back(self, dm_inst_ptr, node_x, node_y):
+        self.ecc.write_placement_back(dm_inst_ptr, node_x, node_y)
+
     ########################################################################
     # data io api
     ########################################################################
-    def init_techlef(self, tech_lef_path : str):
+    def init_techlef(self, tech_lef_path: str):
         """init tech lef"""
         self.ecc.tech_lef_init(path_text(tech_lef_path))
 
@@ -221,12 +207,9 @@ class ECCToolsModule:
         """init def"""
         self.ecc.def_init(def_path=path_text(path))
 
-    def read_verilog(self, 
-                     verilog : str, 
-                     top_module: str):
+    def read_verilog(self, verilog: str, top_module: str):
         """init verilog"""
-        self.ecc.verilog_init(path_text(verilog),
-                               top_module)
+        self.ecc.verilog_init(path_text(verilog), top_module)
 
     def def_save(self, def_path: str):
         """save def file"""
@@ -240,25 +223,19 @@ class ECCToolsModule:
         """save tcl file"""
         self.ecc.tcl_save(path_text(output_path))
 
-    def verilog_save(self, 
-                     output_verilog, 
-                     cell_names: set | None = None):
+    def verilog_save(self, output_verilog, cell_names: set | None = None):
         """verilog save"""
         if cell_names is None:
             cell_names = set()
-        self.ecc.netlist_save(
-            netlist_path=path_text(output_verilog),
-            exclude_cell_names=cell_names
-        )
-        
-    def json_save(self,
-                  path : str):
+        self.ecc.netlist_save(netlist_path=path_text(output_verilog), exclude_cell_names=cell_names)
+
+    def json_save(self, path: str):
         self.ecc.json_save(path=path_text(path))
 
     def view_json_save(
         self,
         output_dir: str,
-        json_format: str = "pretty", 
+        json_format: str = "pretty",
         compress: bool = False,
     ):
         """
@@ -296,11 +273,11 @@ class ECCToolsModule:
     def load_data(self, path: str):
         """load ECC data"""
         return self.ecc.load_data(path=path_text(path))
-    
+
     def is_db_data_exists(self, db_path: str) -> bool:
         if not db_path or not os.path.isdir(db_path):
             return False
-    
+
         DB_DATA_FILES = (
             "layout/metadata.idb",
             "layout/units.idb",
@@ -325,18 +302,15 @@ class ECCToolsModule:
             "design/groups.idb",
             "design/fills.idb",
         )
-        
-        return all(
-            os.path.isfile(os.path.join(db_path, file_path))
-            for file_path in DB_DATA_FILES
-        )
+
+        return all(os.path.isfile(os.path.join(db_path, file_path)) for file_path in DB_DATA_FILES)
 
     def write_soc_json(self, path: str, harden_cores: list[str] | None = None):
         """write SoC json"""
         if harden_cores is None:
             harden_cores = []
         return self.ecc.write_soc_json(path=path_text(path), harden_cores=harden_cores)
-    
+
     ########################################################################
     # feature api
     ########################################################################
@@ -346,9 +320,7 @@ class ECCToolsModule:
         """
         self.ecc.feature_summary(path_text(json_path))
 
-    def feature_step(self, 
-                     step: str, 
-                     json_path: str):
+    def feature_step(self, step: str, json_path: str):
         """
         generate step feature
         """
@@ -372,15 +344,14 @@ class ECCToolsModule:
 
     def feature_cong_map(self, step: str, dir: str):
         return self.ecc.feature_cong_map(step=step, dir=path_text(dir))
-        
+
     ########################################################################
     # reports api
     ########################################################################
     def report_wirelength(self, path: str = ""):
         return self.ecc.report_wirelength(path=path_text(path))
 
-    def report_summary(self, 
-                       path: str):
+    def report_summary(self, path: str):
         """
         generate step report
         """
@@ -440,16 +411,14 @@ class ECCToolsModule:
 
     def get_wire_timing_power_data(self, n_worst_path_per_clock: int):
         return self.ecc.get_wire_timing_power_data(n_worst_path_per_clock)
-        
+
     ########################################################################
     # CTS api
     ########################################################################
-    def run_cts(self, 
-                config: str, 
-                output : str) -> bool:
+    def run_cts(self, config: str, output: str) -> bool:
         return self.ecc.run_cts(path_text(config), path_text(output))
-    
-    def report_cts(self, output : str):
+
+    def report_cts(self, output: str):
         self.ecc.cts_report(path_text(output))
 
     def feature_cts_timing(self) -> dict:
@@ -463,48 +432,44 @@ class ECCToolsModule:
         generate cts map feature
         """
         self.ecc.feature_cts_eval(path_text(json_path), map_grid_size)
-    
-    ########################################################################    
+
+    ########################################################################
     # DRC api
     ########################################################################
-    def init_drc(self, 
-                 output_dir : str,
-                 therad_number : int = 128):
+    def init_drc(self, output_dir: str, therad_number: int = 128):
         """
         init drc config
         """
-        self.ecc.init_drc(
-            temp_directory_path=path_text(output_dir),
-            thread_number=therad_number)
-        
-    def run_drc(self, 
-                config: str, 
-                report_path : str="") -> bool:
+        self.ecc.init_drc(temp_directory_path=path_text(output_dir), thread_number=therad_number)
+
+    def run_drc(self, config: str, report_path: str = "") -> bool:
         """
         run drc check
         """
         self.ecc.run_drc(config=path_text(config), report=path_text(report_path))
-        
+
     def save_drc(self, feature_path: str):
         """
         generate drc result
         """
         self.ecc.save_drc(path=path_text(feature_path))
-    
-    ########################################################################    
+
+    ########################################################################
     # floorplan api
     ########################################################################
-    def init_floorplan(self,
-                       die_area: str,
-                       core_area: str,
-                       core_site: str,
-                       io_site: str,
-                       corner_site: str,
-                       core_util: double,
-                       x_margin: double,
-                       y_margin: double,
-                       aspect_ratio: double,
-                       cell_area: double):
+    def init_floorplan(
+        self,
+        die_area: str,
+        core_area: str,
+        core_site: str,
+        io_site: str,
+        corner_site: str,
+        core_util: double,
+        x_margin: double,
+        y_margin: double,
+        aspect_ratio: double,
+        cell_area: double,
+    ):
         """
         init floorplan
         Example:
@@ -521,15 +486,12 @@ class ECCToolsModule:
             x_margin=x_margin,
             y_margin=y_margin,
             xy_ratio=aspect_ratio,
-            cell_area=cell_area)
+            cell_area=cell_area,
+        )
 
     def init_floorplan_by_area(
-        self,
-        die_area: str,
-        core_area: str,
-        core_site: str,
-        io_site: str,
-        corner_site: str):
+        self, die_area: str, core_area: str, core_site: str, io_site: str, corner_site: str
+    ):
         """
         init floorplan by die area and core area
         """
@@ -543,7 +505,8 @@ class ECCToolsModule:
             x_margin=0,
             y_margin=0,
             aspect_ratio=0,
-            cell_area=0)
+            cell_area=0,
+        )
 
     def init_floorplan_by_core_utilization(
         self,
@@ -554,7 +517,8 @@ class ECCToolsModule:
         x_margin: double,
         y_margin: double,
         aspect_ratio: double,
-        cell_area: double = 0):
+        cell_area: double = 0,
+    ):
         """
         init floorplan by core utilization
         """
@@ -568,23 +532,16 @@ class ECCToolsModule:
             x_margin=x_margin,
             y_margin=y_margin,
             aspect_ratio=aspect_ratio,
-            cell_area=cell_area)
+            cell_area=cell_area,
+        )
 
-    def gern_track(self, 
-                   layer: str, 
-                   x_start: int, 
-                   x_step: int, 
-                   y_start: int, 
-                   y_step: int):
+    def gern_track(self, layer: str, x_start: int, x_step: int, y_start: int, y_step: int):
         """
         generate track
         """
         return self.ecc.gern_track(
-            layer=layer, 
-            x_start=x_start, 
-            x_step=x_step, 
-            y_start=y_start, 
-            y_step=y_step)
+            layer=layer, x_start=x_start, x_step=x_step, y_start=y_start, y_step=y_step
+        )
 
     def place_port(
         self,
@@ -666,25 +623,17 @@ class ECCToolsModule:
     ########################################################################
     # pdn api
     ########################################################################
-    def add_pdn_io(self, 
-                   net_name: str, 
-                   direction: str, 
-                   is_power: bool, 
-                   pin_name: str = None):
+    def add_pdn_io(self, net_name: str, direction: str, is_power: bool, pin_name: str = None):
         if pin_name is None:
             pin_name = net_name
-        return self.ecc.add_pdn_io(pin_name=pin_name, 
-                                    net_name=net_name, 
-                                    direction=direction, 
-                                    is_power=is_power)
+        return self.ecc.add_pdn_io(
+            pin_name=pin_name, net_name=net_name, direction=direction, is_power=is_power
+        )
 
-    def global_net_connect(self, 
-                           net_name: str, 
-                           instance_pin_name: str, 
-                           is_power: bool):
-        return self.ecc.global_net_connect(net_name=net_name, 
-                                            instance_pin_name=instance_pin_name, 
-                                            is_power=is_power)
+    def global_net_connect(self, net_name: str, instance_pin_name: str, is_power: bool):
+        return self.ecc.global_net_connect(
+            net_name=net_name, instance_pin_name=instance_pin_name, is_power=is_power
+        )
 
     def place_pdn_port(
         self,
@@ -706,34 +655,36 @@ class ECCToolsModule:
             layer=layer,
         )
 
-    def create_pdn_grid(self,
-                        layer : str,
-                        net_power : str,
-                        net_ground : str,
-                        width : double,
-                        offset : double):
-        return self.ecc.create_grid(layer_name=layer,
-                                     net_name_power=net_power,
-                                     net_name_ground=net_ground,
-                                     width=width,
-                                     offset=offset)
+    def create_pdn_grid(
+        self, layer: str, net_power: str, net_ground: str, width: double, offset: double
+    ):
+        return self.ecc.create_grid(
+            layer_name=layer,
+            net_name_power=net_power,
+            net_name_ground=net_ground,
+            width=width,
+            offset=offset,
+        )
 
-    def create_pdn_stripe(self,
-                          layer : str,
-                          net_power : str,
-                          net_ground : str,
-                          width : double,
-                          pitch : double,
-                          offset : double):
-        return self.ecc.create_stripe(layer_name=layer,
-                                       net_name_power=net_power,
-                                       net_name_ground=net_ground,
-                                       width=width,
-                                       pitch=pitch,
-                                       offset=offset)
+    def create_pdn_stripe(
+        self,
+        layer: str,
+        net_power: str,
+        net_ground: str,
+        width: double,
+        pitch: double,
+        offset: double,
+    ):
+        return self.ecc.create_stripe(
+            layer_name=layer,
+            net_name_power=net_power,
+            net_name_ground=net_ground,
+            width=width,
+            pitch=pitch,
+            offset=offset,
+        )
 
-    def connect_pdn_layers(self,
-                           layers : list[str]):
+    def connect_pdn_layers(self, layers: list[str]):
         return self.ecc.connect_two_layer(layers=layers)
 
     def connectMacroPdn(
@@ -827,11 +778,7 @@ class ECCToolsModule:
             height=height,
         )
 
-    def auto_place_pins(self, 
-                        layer: str, 
-                        width: int, 
-                        height: int, 
-                        sides: list[str] | None = None):
+    def auto_place_pins(self, layer: str, width: int, height: int, sides: list[str] | None = None):
         """
         layer : layer place io pins
         witdh : io pin width, in dbu
@@ -840,27 +787,17 @@ class ECCToolsModule:
         """
         if sides is None:
             sides = []
-        return self.ecc.auto_place_pins(
-            layer=layer, 
-            width=width, 
-            height=height, 
-            sides=sides
-        )
+        return self.ecc.auto_place_pins(layer=layer, width=width, height=height, sides=sides)
 
-    def tapcell(self, 
-                tapcell: str, 
-                distance: double, 
-                endcap: str):
-        return self.ecc.tapcell(tapcell=tapcell, 
-                                 distance=distance, 
-                                 endcap=endcap)
-        
+    def tapcell(self, tapcell: str, distance: double, endcap: str):
+        return self.ecc.tapcell(tapcell=tapcell, distance=distance, endcap=endcap)
+
     ########################################################################
     # pnp api
     ########################################################################
     def pnp(self, config: str):
         self.ecc.run_pnp(path_text(config))
-    
+
     ########################################################################
     # placement api
     ########################################################################
@@ -872,7 +809,7 @@ class ECCToolsModule:
 
     def destroy_pl(self):
         return self.ecc.destroy_pl()
-        
+
     def feature_placement_map(self, json_path: str, map_grid_size=1):
         """
         generate placement map feature
@@ -884,23 +821,20 @@ class ECCToolsModule:
 
     def run_legalize(self, config: str):
         self.ecc.run_incremental_lg()
-        
+
     def run_filler(self, config: str):
         self.ecc.insert_filler(path_text(config))
-        
+
     def run_macro_placement(self, config: str, tcl_path=""):
         """
         run macro placement
         """
         self.ecc.runMP(path_text(config), path_text(tcl_path))
-        
+
     def run_refinement(self, tcl_path=""):
         self.ecc.runRef(path_text(tcl_path))
-        
-    def run_ai_placement(self,
-                        config: str, 
-                        onnx_path: str, 
-                        normalization_path: str):
+
+    def run_ai_placement(self, config: str, onnx_path: str, normalization_path: str):
         """
         Run AI-guided placement using ONNX model
 
@@ -908,9 +842,9 @@ class ECCToolsModule:
             onnx_path: Path to the ONNX model file
             normalization_path: Path to the normalization parameters JSON file
         """
-        self.ecc.run_ai_placement(path_text(config),
-                                   path_text(onnx_path),
-                                   path_text(normalization_path))
+        self.ecc.run_ai_placement(
+            path_text(config), path_text(onnx_path), path_text(normalization_path)
+        )
 
     def placer_run_mp(self):
         return self.ecc.placer_run_mp()
@@ -923,16 +857,13 @@ class ECCToolsModule:
 
     def placer_run_dp(self):
         return self.ecc.placer_run_dp()
-        
-    def feature_macro_drc_distribution(self, 
-                                       path: str, 
-                                       drc_path: str):
+
+    def feature_macro_drc_distribution(self, path: str, drc_path: str):
         """
         build macro drc distribution
         """
-        self.ecc.feature_macro_drc(path=path, 
-                                    drc_path=drc_path)
-    
+        self.ecc.feature_macro_drc(path=path, drc_path=drc_path)
+
     ########################################################################
     # routing api
     ########################################################################
@@ -945,10 +876,10 @@ class ECCToolsModule:
         self.ecc.init_rt(config=path_text(config))
         self.ecc.run_rt()
         self.ecc.destroy_rt()
-        
+
     def close_routing(self):
         self.ecc.destroy_rt()
-        
+
     # read route json file to ecc route data
     def feature_route_read(self, json_path: str):
         self.ecc.feature_route_read(path=path_text(json_path))
@@ -956,8 +887,8 @@ class ECCToolsModule:
     # read route def and save route data to json
     def feature_route(self, json_path: str):
         self.ecc.feature_route(path=path_text(json_path))
-        
-    def is_rt_timing_enable(self, config : str):
+
+    def is_rt_timing_enable(self, config: str):
         if os.path.exists(config):
             with open(config, encoding="utf-8") as f_reader:
                 json_data = json.load(f_reader)
@@ -976,7 +907,7 @@ class ECCToolsModule:
         if pdk:
             return self.ecc.init_rcx(config=path_text(config), pdk=pdk)
         return self.ecc.init_rcx(config=path_text(config))
-    
+
     def run_rcx(self):
         return self.ecc.run_rcx()
 
@@ -985,8 +916,7 @@ class ECCToolsModule:
         if destroy_rcx is None:
             return None
         return destroy_rcx()
-    
-    
+
     ########################################################################
     # STA api
     ########################################################################
@@ -1068,11 +998,7 @@ class ECCToolsModule:
     def run_sta(self, output_dir: str):
         return None
 
-    def init_sta(self,
-                 output_dir : str,
-                 top_module : str,
-                 lib_paths : list[str],
-                 sdc_path: str):
+    def init_sta(self, output_dir: str, top_module: str, lib_paths: list[str], sdc_path: str):
         return None
 
     def release_sta(self):
@@ -1083,7 +1009,6 @@ class ECCToolsModule:
 
     def init_log(self, log_dir: str):
         return None
-       
 
     def set_design_workspace(self, design_workspace: str):
         return None
@@ -1093,17 +1018,17 @@ class ECCToolsModule:
 
     def read_netlist(self, file_name: str):
         return None
-        
-    def read_liberty(self, lib_paths : list[str]):
+
+    def read_liberty(self, lib_paths: list[str]):
         return None
-        
-    def link_design(self, design : str):
+
+    def link_design(self, design: str):
         return None
 
     def read_spef(self, file_name: str):
         return None
 
-    def read_sdc(self, sdc_path : str):
+    def read_sdc(self, sdc_path: str):
         return None
 
     def get_net_name(self, pin_port_name: str):
@@ -1152,7 +1077,8 @@ class ECCToolsModule:
         lib_paths: list[str] | None = None,
         sdc_path: str = "",
         spef_path: str = "",
-        design_name: str = ""):
+        design_name: str = "",
+    ):
         output_lib_path = Path(output_lib_path)
         output_lib_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -1163,7 +1089,7 @@ class ECCToolsModule:
         if not design_name:
             design_name = output_lib_path.stem
             if design_name.endswith("_Harden"):
-                design_name = design_name[:-len("_Harden")]
+                design_name = design_name[: -len("_Harden")]
 
         sta_output_dir = Path(output_dir) if output_dir else output_lib_path.parent
         self.ecc.lib_init(lib_paths=path_texts(lib_paths))
@@ -1177,15 +1103,11 @@ class ECCToolsModule:
             self.ecc.destroy_sta()
 
         source_lib_path = (
-            sta_output_dir
-            / "timing_characterizer"
-            / f"{design_name}_{analysis_mode}.lib"
+            sta_output_dir / "timing_characterizer" / f"{design_name}_{analysis_mode}.lib"
         )
         if not source_lib_path.exists():
             candidates = sorted(
-                (sta_output_dir / "timing_characterizer").glob(
-                    f"*_{analysis_mode}.lib"
-                )
+                (sta_output_dir / "timing_characterizer").glob(f"*_{analysis_mode}.lib")
             )
             if len(candidates) == 1:
                 source_lib_path = candidates[0]
@@ -1203,7 +1125,7 @@ class ECCToolsModule:
                 "}\n",
                 encoding="utf-8",
             )
-        
+
     def create_data_flow(self):
         return None
 
@@ -1212,20 +1134,22 @@ class ECCToolsModule:
         get lib files that use in the disign
         """
         return None
-    
-    def report_timing(self,
-                      digits: int = 3,
-                      delay_type: str = "max_min",
-                      exclude_cell_names: list[str] | None = None,
-                      derate: bool = False,
-                      is_clock_cap: bool = False,
-                      is_not_bak_rpt: bool = True,
-                      max_path: int = 3,
-                      nworst: int = 1,
-                      from_list: list[str] | None = None,
-                      through: list[list[str]] | None = None,
-                      to_list: list[str] | None = None,
-                      is_json: bool = True):
+
+    def report_timing(
+        self,
+        digits: int = 3,
+        delay_type: str = "max_min",
+        exclude_cell_names: list[str] | None = None,
+        derate: bool = False,
+        is_clock_cap: bool = False,
+        is_not_bak_rpt: bool = True,
+        max_path: int = 3,
+        nworst: int = 1,
+        from_list: list[str] | None = None,
+        through: list[list[str]] | None = None,
+        to_list: list[str] | None = None,
+        is_json: bool = True,
+    ):
         """
         report timing
         """
@@ -1242,7 +1166,7 @@ class ECCToolsModule:
 
     def get_wire_timing_data(self, n_worst_path_per_clock: int):
         return None
-        
+
     ########################################################################
     # timing opt api
     ########################################################################
@@ -1257,7 +1181,7 @@ class ECCToolsModule:
 
     def run_timing_opt_setup(self, config: str):
         self.ecc.run_to_setup(path_text(config))
-    
+
     ########################################################################
     # data vectorization
     ########################################################################
@@ -1267,13 +1191,15 @@ class ECCToolsModule:
     def layout_graph(self, path: str):
         return self.ecc.layout_graph(path=path_text(path))
 
-    def generate_vectors(self, 
-                         vectors_dir : str,
-                         patch_row_step: int = 9, 
-                         patch_col_step: int = 9, 
-                         batch_mode: bool = True, 
-                         is_placement_mode: bool = False, 
-                         sta_mode: int = 0):
+    def generate_vectors(
+        self,
+        vectors_dir: str,
+        patch_row_step: int = 9,
+        patch_col_step: int = 9,
+        batch_mode: bool = True,
+        is_placement_mode: bool = False,
+        sta_mode: int = 0,
+    ):
         """
         generate vectorized data from design
         """
@@ -1286,7 +1212,7 @@ class ECCToolsModule:
             sta_mode=sta_mode,
         )
 
-    def vectors_nets_to_def(self, vectors_dir : str):
+    def vectors_nets_to_def(self, vectors_dir: str):
         """
         save vectorized data to def
         """
@@ -1300,7 +1226,7 @@ class ECCToolsModule:
 
     def get_timing_instance_graph(self, instance_graph_path: str):
         return self.ecc.get_timing_instance_graph(path_text(instance_graph_path))
-    
+
     ########################################################################
     # evaluation api
     ########################################################################
@@ -1425,13 +1351,13 @@ class ECCToolsModule:
 
     def eval_overflow(self):
         return self.ecc.eval_overflow()
-    
+
     ########################################################################
     # net optimization
     ########################################################################
-    def run_net_opt(self, config : str):
+    def run_net_opt(self, config: str):
         return self.ecc.fix_fanout(path_text(config))
-    
+
     def build_rc_tree_from_flat_data(
         self,
         netName: str,

--- a/docs/development.md
+++ b/docs/development.md
@@ -262,7 +262,7 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds"
+preset = "rtl2gds" # rtl2gds | rcx | harden
 run = "default"
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -262,7 +262,7 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds" # rtl2gds | rcx | harden
+preset = "rtl2gds" # rtl2gds | rcx | harden | syn_sta
 run = "default"
 ```
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -443,18 +443,21 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds" # rtl2gds | rcx | harden
+preset = "rtl2gds" # rtl2gds | rcx | harden | syn_sta
 run = "default"
 
 [params.place]
 target_density = 0.65
 ```
 
-Current validation supports the `ics55` PDK, the `rtl2gds`, `rcx`, and
-`harden` flow presets, and `flow.run = "default"`. The preset selects the flow
-builder: `rcx` appends the RCX and STA steps to the rtl2gds flow, and `harden`
-additionally appends the Harden step. Switching presets on an existing run
-requires `ecc run --overwrite` to rebuild the workspace.
+Current validation supports the `ics55` PDK and `flow.run = "default"`. Valid
+flow presets are discovered from the `build_*_flow` defs in
+`chipcompiler/rtl2gds/builder.py` (currently `rtl2gds`, `rcx`, `harden`, and
+`syn_sta`). The preset selects the flow builder: `rcx` appends the RCX and STA
+steps to the rtl2gds flow, `harden` additionally appends the Harden step, and
+`syn_sta` runs synthesis only, with a netlist-level STA report. Switching
+presets on an existing run requires `ecc run --overwrite` to rebuild the
+workspace.
 `design.rtl` must contain exactly one entry; use a
 filelist (`.f`, `.fl`, or `.filelist`) for multi-source RTL designs. If
 `pdk.root` is empty, the CLI falls back to `CHIPCOMPILER_ICS55_PDK_ROOT` or

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -455,7 +455,8 @@ flow presets are discovered from the `build_*_flow` defs in
 `chipcompiler/rtl2gds/builder.py` (currently `rtl2gds`, `rcx`, `harden`, and
 `syn_sta`). The preset selects the flow builder: `rcx` appends the RCX and STA
 steps to the rtl2gds flow, `harden` additionally appends the Harden step, and
-`syn_sta` runs synthesis only, with a netlist-level STA report. Switching
+`syn_sta` runs synthesis only, with a best-effort netlist-level STA report
+(an STA failure does not fail the step). Switching
 presets on an existing run requires `ecc run --overwrite` to rebuild the
 workspace.
 `design.rtl` must contain exactly one entry; use a

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -443,15 +443,19 @@ name = "ics55"
 root = "/path/to/ics55"
 
 [flow]
-preset = "rtl2gds"
+preset = "rtl2gds" # rtl2gds | rcx | harden
 run = "default"
 
 [params.place]
 target_density = 0.65
 ```
 
-Current validation supports the `ics55` PDK, the `rtl2gds` flow preset, and
-`flow.run = "default"`. `design.rtl` must contain exactly one entry; use a
+Current validation supports the `ics55` PDK, the `rtl2gds`, `rcx`, and
+`harden` flow presets, and `flow.run = "default"`. The preset selects the flow
+builder: `rcx` appends the RCX and STA steps to the rtl2gds flow, and `harden`
+additionally appends the Harden step. Switching presets on an existing run
+requires `ecc run --overwrite` to rebuild the workspace.
+`design.rtl` must contain exactly one entry; use a
 filelist (`.f`, `.fl`, or `.filelist`) for multi-source RTL designs. If
 `pdk.root` is empty, the CLI falls back to `CHIPCOMPILER_ICS55_PDK_ROOT` or
 `ICS55_PDK_ROOT`.

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -2,6 +2,8 @@ import json
 import os
 from types import SimpleNamespace
 
+import pytest
+
 from chipcompiler.cli import main as cli_main
 
 
@@ -62,6 +64,24 @@ def _install_flow_mocks(monkeypatch):
     )
 
     return capture
+
+
+def _set_flow_preset(project_dir, preset):
+    toml_path = os.path.join(project_dir, "ecc.toml")
+    with open(toml_path) as f:
+        content = f.read()
+    content = content.replace('preset = "rtl2gds"', f'preset = "{preset}"')
+    with open(toml_path, "w") as f:
+        f.write(content)
+
+
+def _patch_all_flow_builders(monkeypatch):
+    markers = {}
+    for attr in ("build_rtl2gds_flow", "build_rcx_flow", "build_harden_flow"):
+        steps = [("Synthesis", "yosys", "Unstart"), (attr, "ecc", "Unstart")]
+        markers[attr] = steps
+        monkeypatch.setattr(f"chipcompiler.rtl2gds.{attr}", lambda steps=steps: steps)
+    return markers
 
 
 class TestRun:
@@ -189,3 +209,41 @@ class TestRun:
         assert "inspect_cmd" in record
         assert "metrics_cmd" not in record
         assert "log_cmd" in record
+
+
+class TestRunFlowPreset:
+    @pytest.mark.parametrize(
+        "preset,builder_attr",
+        [
+            ("rtl2gds", "build_rtl2gds_flow"),
+            ("rcx", "build_rcx_flow"),
+            ("harden", "build_harden_flow"),
+        ],
+    )
+    def test_run_dispatches_builder_for_preset(
+        self, tmp_path, monkeypatch, create_cli_project, preset, builder_attr
+    ):
+        project_dir = create_cli_project()
+        _set_flow_preset(project_dir, preset)
+        _install_flow_mocks(monkeypatch)
+        markers = _patch_all_flow_builders(monkeypatch)
+
+        rc = cli_main.run(["run", "--project", project_dir])
+
+        assert rc == 0
+        assert DummyFlow.instances[0].added_steps == markers[builder_attr]
+
+    def test_run_overwrite_rebuilds_flow_with_new_preset(
+        self, tmp_path, monkeypatch, create_cli_project, create_flow_json
+    ):
+        project_dir = create_cli_project()
+        run_dir = os.path.join(project_dir, "runs", "default")
+        create_flow_json(run_dir, profile="main")
+        _set_flow_preset(project_dir, "harden")
+        _install_flow_mocks(monkeypatch)
+        markers = _patch_all_flow_builders(monkeypatch)
+
+        rc = cli_main.run(["run", "--project", project_dir, "--overwrite"])
+
+        assert rc == 0
+        assert DummyFlow.instances[0].added_steps == markers["build_harden_flow"]

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -55,7 +55,7 @@ def _install_flow_mocks(monkeypatch):
     monkeypatch.setattr("chipcompiler.data.create_workspace", fake_create_workspace)
     monkeypatch.setattr("chipcompiler.engine.EngineFlow", DummyFlow)
     monkeypatch.setattr(
-        "chipcompiler.rtl2gds.build_rtl2gds_flow",
+        "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
         lambda: [("Synthesis", "yosys", "Unstart")],
     )
     monkeypatch.setattr(
@@ -77,10 +77,10 @@ def _set_flow_preset(project_dir, preset):
 
 def _patch_all_flow_builders(monkeypatch):
     markers = {}
-    for attr in ("build_rtl2gds_flow", "build_rcx_flow", "build_harden_flow"):
+    for attr in ("build_rtl2gds_flow", "build_rcx_flow", "build_harden_flow", "build_syn_sta_flow"):
         steps = [("Synthesis", "yosys", "Unstart"), (attr, "ecc", "Unstart")]
         markers[attr] = steps
-        monkeypatch.setattr(f"chipcompiler.rtl2gds.{attr}", lambda steps=steps: steps)
+        monkeypatch.setattr(f"chipcompiler.rtl2gds.builder.{attr}", lambda steps=steps: steps)
     return markers
 
 
@@ -218,6 +218,7 @@ class TestRunFlowPreset:
             ("rtl2gds", "build_rtl2gds_flow"),
             ("rcx", "build_rcx_flow"),
             ("harden", "build_harden_flow"),
+            ("syn_sta", "build_syn_sta_flow"),
         ],
     )
     def test_run_dispatches_builder_for_preset(

--- a/test/cli/params/test_commands.py
+++ b/test/cli/params/test_commands.py
@@ -190,7 +190,7 @@ class TestRunSet:
             ),
         )
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(
@@ -271,7 +271,7 @@ class TestRunSet:
             ),
         )
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(

--- a/test/cli/params/test_provenance.py
+++ b/test/cli/params/test_provenance.py
@@ -34,7 +34,7 @@ class TestCliProvenance:
             ),
         )
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(
@@ -96,7 +96,7 @@ class TestCliProvenance:
             ),
         )
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(
@@ -163,7 +163,7 @@ class TestCliProvenance:
             ),
         )
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(

--- a/test/cli/rendering/test_pretty.py
+++ b/test/cli/rendering/test_pretty.py
@@ -259,7 +259,7 @@ class TestPrettyDefaultOutput:
         )
         monkeypatch.setattr("chipcompiler.engine.EngineFlow", DummyFlow)
         monkeypatch.setattr(
-            "chipcompiler.rtl2gds.build_rtl2gds_flow",
+            "chipcompiler.rtl2gds.builder.build_rtl2gds_flow",
             lambda: [("Synthesis", "yosys", "Unstart")],
         )
         monkeypatch.setattr(

--- a/test/rtl2gds/test_builder.py
+++ b/test/rtl2gds/test_builder.py
@@ -1,0 +1,44 @@
+import chipcompiler.rtl2gds.builder as builder_module
+from chipcompiler.rtl2gds import get_flow_builders
+
+
+def test_discovery_includes_current_presets():
+    assert {"rtl2gds", "rcx", "harden", "syn_sta"} <= set(get_flow_builders())
+
+
+def test_discovery_picks_up_new_flow_def(monkeypatch):
+    def build_future_flow():
+        return [("Synthesis", "yosys", "Unstart")]
+
+    monkeypatch.setattr(builder_module, "build_future_flow", build_future_flow, raising=False)
+    assert get_flow_builders()["future"] is build_future_flow
+
+    monkeypatch.undo()
+    assert "future" not in get_flow_builders()
+
+
+def test_discovery_resolves_callables_at_call_time(monkeypatch):
+    def replacement():
+        return []
+
+    monkeypatch.setattr(builder_module, "build_rtl2gds_flow", replacement)
+    assert get_flow_builders()["rtl2gds"] is replacement
+
+
+def test_discovery_ignores_non_matching_names(monkeypatch):
+    def build_flow():  # empty preset name
+        return []
+
+    def build_helper():  # missing _flow suffix
+        return []
+
+    def helper_build_x_flow():  # missing build_ prefix
+        return []
+
+    for fn in (build_flow, build_helper, helper_build_x_flow):
+        monkeypatch.setattr(builder_module, fn.__name__, fn, raising=False)
+
+    builders = get_flow_builders()
+    assert "" not in builders
+    for fn in (build_flow, build_helper, helper_build_x_flow):
+        assert fn not in builders.values()


### PR DESCRIPTION
## What Changed

- support to choose syn_sta flow and more flow in ecc.toml

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
