### PR TITLE
docs: update README for have ecc in the Path

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -35,7 +35,7 @@ GUI（ECOS Studio）已迁移至 [ecos-studio](https://github.com/0xharry/ecos-s
 可以使用 `nix run . -- ...` 创建 ECC 项目，校验 `ecc.toml`，并执行完整 RTL2GDS 流程。
 
 ```bash
-nix run . -- init gcd
+nix run . -- init gcd # 如果 PATH 中已有 `ecc`，也可以使用 `ecc init gcd`
 cp ./rtl/gcd.v gcd/rtl/gcd.v
 ```
 
@@ -64,8 +64,14 @@ run = "default"
 nix run . -- check --project gcd
 nix run . -- run --project gcd
 nix run . -- status --project gcd
-nix run . -- metrics --project gcd
 nix run . -- log --project gcd
+
+# 如果 PATH 中已有 `ecc`，也可以使用 ecc 命令
+# ecc check --project gcd
+# ecc run --project gcd
+# ecc status --project gcd
+# ecc metrics --project gcd
+# ecc log --project gcd
 ```
 
 ## 功能特性

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use `nix run . -- ...` to create an ECC project, validate its `ecc.toml`,
 and run the full RTL2GDS flow.
 
 ```bash
-nix run . -- init gcd
+nix run . -- init gcd # Or use `ecc init gcd` if you have `ecc` in the Path
 cp ./rtl/gcd.v gcd/rtl/gcd.v
 ```
 
@@ -66,6 +66,12 @@ nix run . -- check --project gcd
 nix run . -- run --project gcd
 nix run . -- status --project gcd
 nix run . -- log --project gcd
+
+# Or use ecc command if you have `ecc` in the Path
+# ecc check --project gcd
+# ecc run --project gcd
+# ecc status --project gcd
+# ecc log --project gcd
 ```
 
 ## Features


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
