### PR TITLE
fix: flush C stdio before retargeting fds to stop tool output leaking

### DIFF
--- a/chipcompiler/cli/rendering/progress.py
+++ b/chipcompiler/cli/rendering/progress.py
@@ -18,7 +18,7 @@ from chipcompiler.cli.inspection.log_view import (
 from chipcompiler.cli.rendering.pretty import BOLD, CYAN, DIM, GREEN, RED, RESET
 from chipcompiler.cli.rendering.pretty import style as _style
 from chipcompiler.data import StateEnum, log_flow
-from chipcompiler.utility.log import redirect_stdio_to_file
+from chipcompiler.utility.log import flush_cstdio, redirect_stdio_to_file
 
 
 def supports_color(stream, mode, env=None):
@@ -285,6 +285,9 @@ def _preserve_cli_stdio():
         for stream in (sys.stdout, sys.stderr):
             with contextlib.suppress(Exception):
                 stream.flush()
+        # Drain C/C++ buffered output while fds still point at the step log,
+        # or it leaks to the terminal on the next flush after restore.
+        flush_cstdio()
 
         try:
             os.dup2(saved_stdout_fd, 1)

--- a/chipcompiler/utility/log.py
+++ b/chipcompiler/utility/log.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import ctypes
 import logging
 import os
 import sys
@@ -56,6 +57,17 @@ def rotate_log_on_start(log_file: str, max_bytes: int, backup_count: int) -> Non
     os.replace(log_file, f"{log_file}.1")
 
 
+def flush_cstdio() -> None:
+    """Flush C stdio buffers (printf/std::cout/glog) that Python-level flushes miss.
+
+    C/C++ output sits in libc's user-space buffer and is written to fd 1/2 only
+    on flush, so it must be drained before retargeting the fds, or the pending
+    bytes land in whatever the fd points to at flush time.
+    """
+    with suppress(Exception):
+        ctypes.CDLL(None).fflush(None)
+
+
 def redirect_stdio_to_file(log_file: str) -> TextIO:
     """Redirect process stdout/stderr to log_file at file-descriptor level."""
     # The stream intentionally stays open: its fd is dup2'd onto stdout/stderr below.
@@ -64,6 +76,7 @@ def redirect_stdio_to_file(log_file: str) -> TextIO:
     for stream in (sys.stdout, sys.stderr):
         with suppress(Exception):
             stream.flush()
+    flush_cstdio()
 
     os.dup2(log_stream.fileno(), 1)
     os.dup2(log_stream.fileno(), 2)


### PR DESCRIPTION
## What Changed

- C/C++ tool output (e.g. the iSTA logo from STALOG) sits in libc's user-space buffer and is only written to fd 1 on flush. After a step, _preserve_cli_stdio restored fd 1 to the terminal while the buffer was still pending, so the residue leaked onto the terminal at process exit, after the CLI summary, and never reached the step log file.

Drain C stdio via fflush(NULL) before redirecting (redirect_stdio_to_file) and before restoring saved fds (_preserve_cli_stdio), so buffered bytes land in the destination that was active when they were produced.

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
