### PR TITLE
feat: add CLI PDK partial overrides via [pdk.overrides] in ecc.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           git clone --depth 10 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
           cd chipcompiler/thirdparty/icsprout55-pdk
-          git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53
+          git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53 # Pin for ecc-dreamplace error on latest pdk, remove this after upstream fix.
           curl -fsSL https://github.com/Emin017/icsprout55-pdk/commit/9a4df8c336158a78947cbcbe6b18d19cae5bab3c.patch | git apply --verbose
           grep -q 'RELEASE_TAG ?= latest' Makefile || { echo "Patch failed to apply"; exit 1; }
           make unzip RELEASE_TAG=v1.10.100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Setup PDK
         run: |
-          git clone --depth 1 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
-          cd chipcompiler/thirdparty/icsprout55-pdk && make unzip
+          git clone --depth 10 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
+          cd chipcompiler/thirdparty/icsprout55-pdk && git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53 && make unzip
 
       - name: Setup OSS CAD Suite
         uses: YosysHQ/setup-oss-cad-suite@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,11 @@ jobs:
       - name: Setup PDK
         run: |
           git clone --depth 10 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
-          cd chipcompiler/thirdparty/icsprout55-pdk && git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53 && make unzip
+          cd chipcompiler/thirdparty/icsprout55-pdk
+          git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53
+          curl -fsSL https://github.com/Emin017/icsprout55-pdk/commit/9a4df8c336158a78947cbcbe6b18d19cae5bab3c.patch | git apply --verbose
+          grep -q 'RELEASE_TAG ?= latest' Makefile || { echo "Patch failed to apply"; exit 1; }
+          make unzip RELEASE_TAG=v1.10.100
 
       - name: Setup OSS CAD Suite
         uses: YosysHQ/setup-oss-cad-suite@v4

--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -261,6 +261,7 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
             parameters=parameters,
             input_filelist=input_filelist,
             pdk_root=pdk_root,
+            pdk_overrides=cfg.pdk_overrides,
         )
     except Exception as exc:
         return CommandResult.err(

--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -145,6 +145,7 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
     from chipcompiler.cli.project.config import (
         find_config_path,
         load_project_config,
+        resolve_pdk_overrides,
         resolve_pdk_root,
         resolve_rtl,
         to_parameters,
@@ -261,7 +262,7 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
             parameters=parameters,
             input_filelist=input_filelist,
             pdk_root=pdk_root,
-            pdk_overrides=cfg.pdk_overrides,
+            pdk_overrides=resolve_pdk_overrides(cfg),
         )
     except Exception as exc:
         return CommandResult.err(

--- a/chipcompiler/cli/inspection/config_view.py
+++ b/chipcompiler/cli/inspection/config_view.py
@@ -83,6 +83,20 @@ def build_project_config_items(
         }
     )
 
+    # PDK overrides
+    if cfg.pdk_overrides:
+        items.append(
+            {
+                "kind": "config",
+                "scope": "project",
+                "key": "pdk.overrides",
+                "value": cfg.pdk_overrides,
+                "resolved": cfg.pdk_overrides,
+                "source": "ecc.toml",
+                "inspect_cmd": inspect,
+            }
+        )
+
     # Run directory
     try:
         run_dir_rel = os.path.relpath(run_dir, project_dir)

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -91,7 +91,7 @@ def _parse_config(data: dict, config_path: str) -> ProjectConfig:
         project_dir=project_dir,
     )
 
-    if "overrides" in pdk and not isinstance(pdk_overrides_raw, dict):
+    if not isinstance(pdk_overrides_raw, dict):
         cfg._pdk_config_errors = [
             "[pdk.overrides] must be a table (mapping), not " + type(pdk_overrides_raw).__name__
         ]
@@ -126,21 +126,16 @@ def _supported_flow_presets() -> set[str]:
 
 
 def validate_project_config(cfg: ProjectConfig) -> list[str]:
-    toml_error = getattr(cfg, "_toml_error", None)
-    if toml_error:
-        return [f"malformed ecc.toml: {toml_error}"]
+    if cfg._toml_error:
+        return [f"malformed ecc.toml: {cfg._toml_error}"]
 
     errors = []
 
-    pdk_config_errors = getattr(cfg, "_pdk_config_errors", None)
-    if pdk_config_errors:
-        for pe in pdk_config_errors:
-            errors.append(f"invalid PDK configuration: {pe}")
+    for pe in cfg._pdk_config_errors:
+        errors.append(f"invalid PDK configuration: {pe}")
 
-    param_errors = getattr(cfg, "_param_errors", None)
-    if param_errors:
-        for pe in param_errors:
-            errors.append(f"invalid params: {pe}")
+    for pe in cfg._param_errors:
+        errors.append(f"invalid params: {pe}")
 
     if not cfg.design_name:
         errors.append("design.name is required")

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -165,7 +165,7 @@ def validate_project_config(cfg: ProjectConfig) -> list[str]:
         if not os.path.isdir(pdk_root):
             errors.append(f"pdk.root is not a directory: {cfg.pdk_root or '$(env)'}")
         else:
-            pdk_err = _validate_pdk_contents(cfg.pdk_name, pdk_root, cfg.pdk_overrides)
+            pdk_err = _validate_pdk_contents(cfg.pdk_name, pdk_root, resolve_pdk_overrides(cfg))
             if pdk_err:
                 errors.append(pdk_err)
     else:
@@ -251,6 +251,26 @@ def _resolve_pdk_root(cfg: ProjectConfig) -> str:
     if not cfg.pdk_root:
         return _pdk_root_from_env()
     return _resolve_path(cfg.project_dir, cfg.pdk_root)
+
+
+def resolve_pdk_overrides(cfg: ProjectConfig) -> dict[str, object]:
+    """Return pdk_overrides with path-field values resolved against the project dir.
+
+    Only fields the PDK dataclass declares as paths are rewritten; non-path
+    values such as dont_use glob patterns pass through untouched.
+    """
+    from chipcompiler.data.pdk import PATH_LIST_FIELDS, PATH_SCALAR_FIELDS
+
+    resolved = dict(cfg.pdk_overrides)
+    for key, value in resolved.items():
+        if key in PATH_SCALAR_FIELDS and isinstance(value, str):
+            resolved[key] = _resolve_path(cfg.project_dir, value)
+        elif key in PATH_LIST_FIELDS and isinstance(value, list):
+            resolved[key] = [
+                _resolve_path(cfg.project_dir, element) if isinstance(element, str) else element
+                for element in value
+            ]
+    return resolved
 
 
 def _validate_pdk_contents(

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -30,6 +30,10 @@ class ProjectConfig:
 
     params_overrides: dict[str, object] = field(default_factory=dict)
 
+    _toml_error: str | None = field(default=None, init=False, repr=False)
+    _param_errors: list[str] = field(default_factory=list, init=False, repr=False)
+    _pdk_config_errors: list[str] = field(default_factory=list, init=False, repr=False)
+
 
 def load_project_config(config_path: str) -> ProjectConfig:
     try:

--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -20,6 +20,7 @@ class ProjectConfig:
 
     pdk_name: str = ""
     pdk_root: str = ""
+    pdk_overrides: dict[str, object] = field(default_factory=dict)
 
     flow_preset: str = ""
     flow_run: str = ""
@@ -68,6 +69,9 @@ def _parse_config(data: dict, config_path: str) -> ProjectConfig:
     def _str(val, default=""):
         return val if isinstance(val, str) else default
 
+    pdk_overrides_raw = pdk.get("overrides", {})
+    pdk_overrides = {} if not isinstance(pdk_overrides_raw, dict) else pdk_overrides_raw
+
     cfg = ProjectConfig(
         design_name=_str(design.get("name", "")),
         design_top=_str(design.get("top", "")),
@@ -76,11 +80,17 @@ def _parse_config(data: dict, config_path: str) -> ProjectConfig:
         design_frequency_mhz=freq,
         pdk_name=_str(pdk.get("name", "")),
         pdk_root=_str(pdk.get("root", "")),
+        pdk_overrides=pdk_overrides,
         flow_preset=_str(flow.get("preset", "")),
         flow_run=_str(flow.get("run", "default"), "default"),
         config_path=config_path,
         project_dir=project_dir,
     )
+
+    if "overrides" in pdk and not isinstance(pdk_overrides_raw, dict):
+        cfg._pdk_config_errors = [
+            "[pdk.overrides] must be a table (mapping), not " + type(pdk_overrides_raw).__name__
+        ]
 
     params_raw = data.get("params")
     if isinstance(params_raw, dict):
@@ -118,6 +128,11 @@ def validate_project_config(cfg: ProjectConfig) -> list[str]:
 
     errors = []
 
+    pdk_config_errors = getattr(cfg, "_pdk_config_errors", None)
+    if pdk_config_errors:
+        for pe in pdk_config_errors:
+            errors.append(f"invalid PDK configuration: {pe}")
+
     param_errors = getattr(cfg, "_param_errors", None)
     if param_errors:
         for pe in param_errors:
@@ -146,7 +161,7 @@ def validate_project_config(cfg: ProjectConfig) -> list[str]:
         if not os.path.isdir(pdk_root):
             errors.append(f"pdk.root is not a directory: {cfg.pdk_root or '$(env)'}")
         else:
-            pdk_err = _validate_pdk_contents(cfg.pdk_name, pdk_root)
+            pdk_err = _validate_pdk_contents(cfg.pdk_name, pdk_root, cfg.pdk_overrides)
             if pdk_err:
                 errors.append(pdk_err)
     else:
@@ -234,13 +249,15 @@ def _resolve_pdk_root(cfg: ProjectConfig) -> str:
     return _resolve_path(cfg.project_dir, cfg.pdk_root)
 
 
-def _validate_pdk_contents(pdk_name: str, pdk_root: str) -> str | None:
+def _validate_pdk_contents(
+    pdk_name: str, pdk_root: str, pdk_overrides: dict | None = None
+) -> str | None:
     if not pdk_root:
         return None
     try:
         from chipcompiler.data.pdk import get_pdk
 
-        get_pdk(pdk_name, pdk_root)
+        get_pdk(pdk_name, pdk_root, overrides=pdk_overrides)
         return None
     except ValueError as exc:
         return str(exc)

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -87,7 +87,7 @@ _PROTECTED_FIELDS = {"name", "version"}
 
 # Optional path fields not covered by PDK.validate() (which only checks the
 # always-required root/tech/lefs/libs). When one of these is set through an
-# override, its existence is checked here so a bad configured path fails before
+# override, get_pdk checks its existence so a bad configured path fails before
 # a run; base and external PDKs are unaffected because the check is scoped to
 # override-supplied keys only.
 _OPTIONAL_PATH_LABELS = {
@@ -109,8 +109,7 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
         New PDK instance with overrides applied
 
     Raises:
-        ValueError: If unknown fields or type-invalid values are provided, or an
-            override-supplied optional path (mapping_file/sdc/spef) does not exist
+        ValueError: If unknown fields or type-invalid values are provided
     """
     if not overrides:
         return pdk
@@ -143,18 +142,7 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
         if not ok:
             raise ValueError(f"PDK override '{key}' must be {kind}, got {type(value).__name__}")
 
-    updated = replace(pdk, **overrides)
-
-    errors = []
-    for key, label in _OPTIONAL_PATH_LABELS.items():
-        if key not in overrides:
-            continue
-        path = getattr(updated, key)
-        if path and not path.is_file():
-            errors.append(f"{label}: {path}")
-    _raise_pdk_validation_error(errors)
-
-    return updated
+    return replace(pdk, **overrides)
 
 
 def PDK_EXTERNAL(pdk_config: str | Path, pdk_name: str = "") -> PDK:
@@ -219,8 +207,17 @@ def get_pdk(
         pdk = PDK_SG13G2(pdk_root=pdk_root)
     else:
         pdk = PDK(name=pdk_name_normalized)
-    pdk = apply_pdk_overrides(pdk, overrides or {})
+    overrides = overrides or {}
+    pdk = apply_pdk_overrides(pdk, overrides)
     pdk.validate()
+    errors = []
+    for key, label in _OPTIONAL_PATH_LABELS.items():
+        if key not in overrides:
+            continue
+        path = getattr(pdk, key)
+        if path and not path.is_file():
+            errors.append(f"{label}: {path}")
+    _raise_pdk_validation_error(errors)
     return pdk
 
 

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -72,20 +72,29 @@ class PDK:
             for liberty in self.libs:
                 if not liberty.is_file():
                     errors.append(f"PDK liberty file not found: {liberty}")
-        if self.mapping_file and not self.mapping_file.is_file():
-            errors.append(f"PDK mapping file not found: {self.mapping_file}")
-        if self.sdc and not self.sdc.is_file():
-            errors.append(f"PDK SDC file not found: {self.sdc}")
-        if self.spef and not self.spef.is_file():
-            errors.append(f"PDK SPEF file not found: {self.spef}")
-        if errors:
-            msg = "PDK validation failed:\n  " + "\n  ".join(errors)
-            logger.error(msg)
-            raise ValueError(msg)
+        _raise_pdk_validation_error(errors)
+
+
+def _raise_pdk_validation_error(errors: list) -> None:
+    if errors:
+        msg = "PDK validation failed:\n  " + "\n  ".join(errors)
+        logger.error(msg)
+        raise ValueError(msg)
 
 
 _DEFAULT_PDK = PDK()
 _PROTECTED_FIELDS = {"name", "version"}
+
+# Optional path fields not covered by PDK.validate() (which only checks the
+# always-required root/tech/lefs/libs). When one of these is set through an
+# override, its existence is checked here so a bad configured path fails before
+# a run; base and external PDKs are unaffected because the check is scoped to
+# override-supplied keys only.
+_OPTIONAL_PATH_LABELS = {
+    "mapping_file": "PDK mapping file not found",
+    "sdc": "PDK SDC file not found",
+    "spef": "PDK SPEF file not found",
+}
 
 
 def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
@@ -100,7 +109,8 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
         New PDK instance with overrides applied
 
     Raises:
-        ValueError: If unknown fields or type-invalid values are provided
+        ValueError: If unknown fields or type-invalid values are provided, or an
+            override-supplied optional path (mapping_file/sdc/spef) does not exist
     """
     if not overrides:
         return pdk
@@ -133,7 +143,18 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
         if not ok:
             raise ValueError(f"PDK override '{key}' must be {kind}, got {type(value).__name__}")
 
-    return replace(pdk, **overrides)
+    updated = replace(pdk, **overrides)
+
+    errors = []
+    for key, label in _OPTIONAL_PATH_LABELS.items():
+        if key not in overrides:
+            continue
+        path = getattr(updated, key)
+        if path and not path.is_file():
+            errors.append(f"{label}: {path}")
+    _raise_pdk_validation_error(errors)
+
+    return updated
 
 
 def PDK_EXTERNAL(pdk_config: str | Path, pdk_name: str = "") -> PDK:

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -21,8 +21,8 @@ class PDK:
     version: str = ""  # pdk version
     root: Path | None = None  # resolved pdk root path
     tech: Path | None = None  # pdk tech lef file
-    lefs: list = field(default_factory=list)  # pdk lef files
-    libs: list = field(default_factory=list)  # pdk liberty files
+    lefs: list[Path] = field(default_factory=list[Path])  # pdk lef files
+    libs: list[Path] = field(default_factory=list[Path])  # pdk liberty files
     mapping_file: Path | None = None  # pdk mapping file
     corners: list = field(default_factory=list)
     sdc: Path | None = None  # pdk sdc file
@@ -85,6 +85,12 @@ def _raise_pdk_validation_error(errors: list) -> None:
 _DEFAULT_PDK = PDK()
 _PROTECTED_FIELDS = {"name", "version"}
 
+# Fields whose values are filesystem paths, derived from the dataclass
+# annotations so CLI path resolution and override validation stay in sync
+# with the field definitions.
+PATH_SCALAR_FIELDS = {f.name for f in fields(PDK) if f.type == Path | None}
+PATH_LIST_FIELDS = {f.name for f in fields(PDK) if f.type == list[Path]}
+
 # Optional path fields not covered by PDK.validate() (which only checks the
 # always-required root/tech/lefs/libs). When one of these is set through an
 # override, get_pdk checks its existence so a bad configured path fails before
@@ -141,6 +147,15 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
             ok, kind = isinstance(value, str), "a string"
         if not ok:
             raise ValueError(f"PDK override '{key}' must be {kind}, got {type(value).__name__}")
+        # Path-list elements hit Path() in __post_init__; reject non-strings
+        # here with ValueError instead of escaping replace() as TypeError.
+        if key in PATH_LIST_FIELDS and isinstance(value, list):
+            for index, element in enumerate(value):
+                if not isinstance(element, str):
+                    raise ValueError(
+                        f"PDK override '{key}' elements must be strings, "
+                        f"got {type(element).__name__} at index {index}"
+                    )
 
     return replace(pdk, **overrides)
 

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -79,6 +79,7 @@ class PDK:
 
 
 _DEFAULT_PDK = PDK()
+_PROTECTED_FIELDS = {"name", "version"}
 
 
 def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
@@ -98,14 +99,19 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
     if not overrides:
         return pdk
 
-    valid = {f.name for f in fields(PDK)}
-    unknown = sorted(set(overrides) - valid)
-    if unknown:
-        raise ValueError(f"unknown PDK override fields: {unknown}; valid fields: {sorted(valid)}")
+    all_fields = {f.name for f in fields(PDK)}
+    overridable = sorted(all_fields - _PROTECTED_FIELDS)
+    unknown = sorted(set(overrides) - all_fields)
 
-    if "name" in overrides or "version" in overrides:
+    if unknown:
         raise ValueError(
-            "PDK override fields 'name' and 'version' cannot be overridden; "
+            f"unknown PDK override fields: {unknown}; valid overridable fields: {overridable}"
+        )
+
+    protected = sorted(set(overrides) & _PROTECTED_FIELDS)
+    if protected:
+        raise ValueError(
+            f"PDK override fields {protected} cannot be overridden; "
             "use the appropriate built-in PDK name instead"
         )
 

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -72,6 +72,12 @@ class PDK:
             for liberty in self.libs:
                 if not liberty.is_file():
                     errors.append(f"PDK liberty file not found: {liberty}")
+        if self.mapping_file and not self.mapping_file.is_file():
+            errors.append(f"PDK mapping file not found: {self.mapping_file}")
+        if self.sdc and not self.sdc.is_file():
+            errors.append(f"PDK SDC file not found: {self.sdc}")
+        if self.spef and not self.spef.is_file():
+            errors.append(f"PDK SPEF file not found: {self.spef}")
         if errors:
             msg = "PDK validation failed:\n  " + "\n  ".join(errors)
             logger.error(msg)

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -32,13 +32,13 @@ class PDK:
     site_corner: str = ""  # corner site
     tap_cell: str = ""  # tap cell
     end_cap: str = ""  # end cap
-    buffers: list = field(default_factory=list)  # buffers
-    fillers: list = field(default_factory=list)  # fillers
+    buffers: list[str] = field(default_factory=list[str])  # buffers
+    fillers: list[str] = field(default_factory=list[str])  # fillers
     tie_high_cell: str = ""
     tie_high_port: str = ""
     tie_low_cell: str = ""
     tie_low_port: str = ""
-    dont_use: list = field(default_factory=list)  # don't use cell list
+    dont_use: list[str] = field(default_factory=list[str])  # don't use cell list
     abc_driver_cell: str = ""  # ABC driving cell
     abc_load: float = 0.015  # ABC output load
 
@@ -90,6 +90,7 @@ _PROTECTED_FIELDS = {"name", "version"}
 # with the field definitions.
 PATH_SCALAR_FIELDS = {f.name for f in fields(PDK) if f.type == Path | None}
 PATH_LIST_FIELDS = {f.name for f in fields(PDK) if f.type == list[Path]}
+STRING_LIST_FIELDS = {f.name for f in fields(PDK) if f.type == list[str]}
 
 # Optional path fields not covered by PDK.validate() (which only checks the
 # always-required root/tech/lefs/libs). When one of these is set through an
@@ -147,9 +148,11 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
             ok, kind = isinstance(value, str), "a string"
         if not ok:
             raise ValueError(f"PDK override '{key}' must be {kind}, got {type(value).__name__}")
-        # Path-list elements hit Path() in __post_init__; reject non-strings
-        # here with ValueError instead of escaping replace() as TypeError.
-        if key in PATH_LIST_FIELDS and isinstance(value, list):
+        # Path-list elements hit Path() in __post_init__; cell-name list
+        # elements are written verbatim into generated tool configs. Reject
+        # non-strings here with ValueError instead of escaping replace() as
+        # TypeError or reaching tool input.
+        if key in PATH_LIST_FIELDS | STRING_LIST_FIELDS and isinstance(value, list):
             for index, element in enumerate(value):
                 if not isinstance(element, str):
                     raise ValueError(

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
 
 from chipcompiler.utility.path import optional_path, path_list
@@ -78,6 +78,52 @@ class PDK:
             raise ValueError(msg)
 
 
+_DEFAULT_PDK = PDK()
+
+
+def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
+    """
+    Apply field overrides to a PDK instance via whole-field replacement.
+
+    Args:
+        pdk: Base PDK instance
+        overrides: Mapping of field names to new values
+
+    Returns:
+        New PDK instance with overrides applied
+
+    Raises:
+        ValueError: If unknown fields or type-invalid values are provided
+    """
+    if not overrides:
+        return pdk
+
+    valid = {f.name for f in fields(PDK)}
+    unknown = sorted(set(overrides) - valid)
+    if unknown:
+        raise ValueError(f"unknown PDK override fields: {unknown}; valid fields: {sorted(valid)}")
+
+    if "name" in overrides or "version" in overrides:
+        raise ValueError(
+            "PDK override fields 'name' and 'version' cannot be overridden; "
+            "use the appropriate built-in PDK name instead"
+        )
+
+    for key, value in overrides.items():
+        default = getattr(_DEFAULT_PDK, key)
+        if isinstance(default, list):
+            ok, kind = isinstance(value, list), "a list"
+        elif isinstance(default, float):
+            ok = isinstance(value, (int, float)) and not isinstance(value, bool)
+            kind = "a number"
+        else:
+            ok, kind = isinstance(value, str), "a string"
+        if not ok:
+            raise ValueError(f"PDK override '{key}' must be {kind}, got {type(value).__name__}")
+
+    return replace(pdk, **overrides)
+
+
 def PDK_EXTERNAL(pdk_config: str | Path, pdk_name: str = "") -> PDK:
     with open(pdk_config, encoding="utf-8") as file:
         data = json.load(file)
@@ -123,6 +169,7 @@ def get_pdk(
     pdk_name: str,
     pdk_root: str | Path = "",
     pdk_config: str | Path = "",
+    overrides: dict | None = None,
 ) -> PDK:
     """
     Return the PDK instance based on the given pdk name.
@@ -139,6 +186,7 @@ def get_pdk(
         pdk = PDK_SG13G2(pdk_root=pdk_root)
     else:
         pdk = PDK(name=pdk_name_normalized)
+    pdk = apply_pdk_overrides(pdk, overrides or {})
     pdk.validate()
     return pdk
 

--- a/chipcompiler/data/workspace/__init__.py
+++ b/chipcompiler/data/workspace/__init__.py
@@ -958,6 +958,7 @@ def create_workspace(
     pdk_json: str | Path = "",
     flow_config: dict | None = None,
     sdc: str | Path = "",
+    pdk_overrides: dict | None = None,
 ) -> Workspace:
     """
     Create a workspace for chip design flow.
@@ -1003,7 +1004,9 @@ def create_workspace(
         workspace.pdk = pdk
 
     if isinstance(pdk, str):
-        workspace.pdk = get_pdk(pdk_name=pdk, pdk_root=pdk_root, pdk_config=pdk_json)
+        workspace.pdk = get_pdk(
+            pdk_name=pdk, pdk_root=pdk_root, pdk_config=pdk_json, overrides=pdk_overrides
+        )
 
     explicit_sdc_path = Path(sdc).expanduser().resolve() if sdc else None
     if explicit_sdc_path is not None:

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -933,7 +933,7 @@ class ECCToolsModule:
         work_dir: PathArg = "",
         report_dir: PathArg = "",
         feature_dir: PathArg = "",
-        lib_paths: list[str] | None = None,
+        lib_paths: list[Path] | list[str] | None = None,
         sdc_path: str = "",
         spef_path: str = "",
         output_modes: tuple[str, ...] = ("report", "structured"),
@@ -1004,7 +1004,9 @@ class ECCToolsModule:
     def run_sta(self, output_dir: str):
         return None
 
-    def init_sta(self, output_dir: PathArg, top_module: str, lib_paths: list[str], sdc_path: str):
+    def init_sta(
+        self, output_dir: PathArg, top_module: str, lib_paths: list[Path] | list[str], sdc_path: str
+    ):
         return None
 
     def release_sta(self):

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -508,8 +508,12 @@ The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
 (`abc_load`), which are scalar/list fields consumed within a run.
 
 Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
-path-existence failures are caught before any run begins. `ecc config --resolved`
-surfaces the raw `[pdk.overrides]` input as a project configuration entry.
+path-existence failures are caught before any run begins. Path-existence is checked
+for every path field an override sets, including the optional `tech`, `lefs`, `libs`,
+`mapping_file`, `sdc`, and `spef`: a non-empty value pointing at a missing file fails
+`ecc check` regardless of whether that field is later persisted or regenerated.
+`ecc config --resolved` surfaces the raw `[pdk.overrides]` input as a project
+configuration entry.
 
 The resolved configuration used by each step should be inspectable:
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -500,6 +500,10 @@ The override delta reaches the Yosys builder and other tool steps within a singl
 - **`sdc`/`spef`**: Copied into `origin/` when present; rediscovered by `load_workspace`.
   Out of intended scope.
 
+- **`mapping_file`**: Applied only to the in-memory PDK for the current run. The
+  workspace path does not serialize it and `load_workspace` never restores it, so a
+  `mapping_file` override is dropped on reload. Out of intended scope.
+
 The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
 (`abc_load`), which are scalar/list fields consumed within a run.
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -481,12 +481,27 @@ abc_load = 0.020
 
 Overrides are applied in memory via whole-field replacement at workspace creation.
 The override delta reaches the Yosys builder and other tool steps within a single
-`ecc run`, but is not persisted to workspace metadata. On `load_workspace` (e.g.,
-via `ecc status` or a subsequent run), the base PDK is recomputed and scalar/list
-overrides like `dont_use` are not retained. Path-field overrides (`tech`, `lefs`,
-`libs`) are clobbered on reload from the generated `db.json` and are therefore
-out of intended scope for this mechanism; the primary use case is tuning cell
-lists and synthesis parameters.
+`ecc run`. Persistence behavior varies by field category:
+
+- **Scalar/list fields** (`dont_use`, `buffers`, `fillers`, tie cells, `abc_load`):
+  Applied in memory and consumed within the run (e.g., baked into generated Yosys
+  scripts). Not written to `parameters.json`. On `load_workspace` (e.g., `ecc status`
+  or subsequent run without `[pdk.overrides]` in `ecc.toml`), these fields are
+  recomputed from the base built-in PDK. Effect: single-run only, dropped on reload
+  unless the override is present in `ecc.toml` for the next run.
+
+- **`root`**: Written to `parameters.json` as `PDK Root` and re-read by `load_workspace`.
+  Overriding `root` is redundant with `pdk.root` in `[pdk]`; use `pdk.root` instead.
+
+- **Path fields** (`tech`, `lefs`, `libs`): Written to `db.json` at build time and
+  restored by `load_workspace`. Path overrides survive through `db.json`, not through
+  PDK recomputation. Out of intended scope.
+
+- **`sdc`/`spef`**: Copied into `origin/` when present; rediscovered by `load_workspace`.
+  Out of intended scope.
+
+The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
+(`abc_load`), which are scalar/list fields consumed within a run.
 
 Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
 path-existence failures are caught before any run begins. `ecc config --resolved`

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -464,6 +464,34 @@ filelist (`.f`, `.fl`, or `.filelist`) for multi-source RTL designs. If
 `pdk.root` is empty, the CLI falls back to `CHIPCOMPILER_ICS55_PDK_ROOT` or
 `ICS55_PDK_ROOT`.
 
+### PDK Field Overrides
+
+Users can override individual fields of a built-in PDK (such as `ics55`) directly
+from `ecc.toml` without authoring a complete external PDK JSON:
+
+```toml
+[pdk]
+name = "ics55"
+root = "/path/to/ics55"
+
+[pdk.overrides]
+dont_use = ["DFFSRQX*", "ICG*"]
+abc_load = 0.020
+```
+
+Overrides are applied in memory via whole-field replacement at workspace creation.
+The override delta reaches the Yosys builder and other tool steps within a single
+`ecc run`, but is not persisted to workspace metadata. On `load_workspace` (e.g.,
+via `ecc status` or a subsequent run), the base PDK is recomputed and scalar/list
+overrides like `dont_use` are not retained. Path-field overrides (`tech`, `lefs`,
+`libs`) are clobbered on reload from the generated `db.json` and are therefore
+out of intended scope for this mechanism; the primary use case is tuning cell
+lists and synthesis parameters.
+
+Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
+path-existence failures are caught before any run begins. `ecc config --resolved`
+surfaces the raw `[pdk.overrides]` input as a project configuration entry.
+
 The resolved configuration used by each step should be inspectable:
 
 ```bash

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -483,7 +483,9 @@ Overrides are applied in memory via whole-field replacement at workspace creatio
 The override delta reaches the Yosys builder and other tool steps within a single
 `ecc run`. Persistence behavior varies by field category:
 
-- **Scalar/list fields** (`dont_use`, `buffers`, `fillers`, tie cells, `abc_load`):
+- **Scalar/list fields** (`corners`, `site_core`, `site_io`, `site_corner`,
+  `tap_cell`, `end_cap`, `buffers`, `fillers`, `tie_high_cell`, `tie_high_port`,
+  `tie_low_cell`, `tie_low_port`, `dont_use`, `abc_driver_cell`, `abc_load`):
   Applied in memory and consumed within the run (e.g., baked into generated Yosys
   scripts). Not written to `parameters.json`. On `load_workspace` (e.g., `ecc status`
   or subsequent run without `[pdk.overrides]` in `ecc.toml`), these fields are
@@ -509,9 +511,11 @@ The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
 
 Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
 path-existence failures are caught before any run begins. Path-existence is checked
-for every path field an override sets, including the optional `tech`, `lefs`, `libs`,
-`mapping_file`, `sdc`, and `spef`: a non-empty value pointing at a missing file fails
-`ecc check` regardless of whether that field is later persisted or regenerated.
+for every path field an override sets: the required `tech`, `lefs`, and `libs`
+(checked for every PDK by `PDK.validate()`) and the optional `mapping_file`, `sdc`,
+and `spef` (checked only when an override supplies them). A non-empty value pointing
+at a missing file fails `ecc check` regardless of whether that field is later
+persisted or regenerated.
 `ecc config --resolved` surfaces the raw `[pdk.overrides]` input as a project
 configuration entry.
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -510,8 +510,10 @@ The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
 (`abc_load`), which are scalar/list fields consumed within a run.
 
 Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
-path-existence failures are caught before any run begins. Path-existence is checked
-for every path field an override sets: the required `tech`, `lefs`, and `libs`
+path-existence failures are caught before any run begins. Path values in overrides
+resolve against the project directory (like `pdk.root` and `design.rtl`), and the
+resolved paths are what `ecc run` forwards to workspace creation. Path-existence is
+checked for every path field an override sets: the required `tech`, `lefs`, and `libs`
 (checked for every PDK by `PDK.validate()`) and the optional `mapping_file`, `sdc`,
 and `spef` (checked only when an override supplies them). A non-empty value pointing
 at a missing file fails `ecc check` regardless of whether that field is later

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -490,7 +490,10 @@ The override delta reaches the Yosys builder and other tool steps within a singl
   scripts). Not written to `parameters.json`. On `load_workspace` (e.g., `ecc status`
   or subsequent run without `[pdk.overrides]` in `ecc.toml`), these fields are
   recomputed from the base built-in PDK. Effect: single-run only, dropped on reload
-  unless the override is present in `ecc.toml` for the next run.
+  unless the override is present in `ecc.toml` for the next run. `corners` is the
+  exception in this list: no tool step currently consumes it (PDK-to-RCX propagation
+  is not wired in `refresh_workspace_config`), so a `corners` override only changes
+  the in-memory PDK — exactly like the base PDK's own `corners`.
 
 - **`root`**: Written to `parameters.json` as `PDK Root` and re-read by `load_workspace`.
   Overriding `root` is redundant with `pdk.root` in `[pdk]`; use `pdk.root` instead.

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -9,7 +9,7 @@ class TestCheck:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 0
@@ -20,7 +20,7 @@ class TestCheck:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.chdir(project_dir)
         rc = cli_main.run(["check"])
@@ -126,7 +126,7 @@ class TestCheck:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["check", "--project", project_dir, "--json"])
         assert rc == 0
@@ -235,3 +235,54 @@ class TestMissingConfigErrorRecord:
         data = json.loads(capsys.readouterr().out)
         record = data["records"][0]
         assert "inspect" in record or "inspect_cmd" in record
+
+    def test_check_pdk_overrides_valid(self, tmp_path, monkeypatch, create_cli_project):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\ndont_use = ["ICG*"]\n')
+        monkeypatch.setattr(
+            "chipcompiler.cli.project.config._validate_pdk_contents",
+            lambda name, root, overrides=None: None,
+        )
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 0
+
+    def test_check_pdk_overrides_unknown_key(self, tmp_path, monkeypatch, create_cli_project):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\ndontuse = ["ICG*"]\n')
+        monkeypatch.setattr(
+            "chipcompiler.cli.project.config._pdk_root_from_env",
+            lambda: str(tmp_path / "ics55"),
+        )
+        (tmp_path / "ics55").mkdir(exist_ok=True)
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 1
+
+    def test_check_pdk_overrides_type_mismatch(self, tmp_path, monkeypatch, create_cli_project):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nabc_load = "fast"\n')
+        monkeypatch.setattr(
+            "chipcompiler.cli.project.config._pdk_root_from_env",
+            lambda: str(tmp_path / "ics55"),
+        )
+        (tmp_path / "ics55").mkdir(exist_ok=True)
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 1
+
+    def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path) as f:
+            content = f.read()
+        content = content.replace("[pdk]", '[pdk]\noverrides = "not a table"')
+        with open(toml_path, "w") as f:
+            f.write(content)
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "must be a table" in out

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -320,6 +320,55 @@ class TestMissingConfigErrorRecord:
         assert message in out
         assert "/no/such.file" in out
 
+    def test_check_pdk_overrides_relative_sdc_resolves_against_project_dir(
+        self, tmp_path, monkeypatch, create_cli_project, minimal_ics55_pdk_factory
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        sdc_path = os.path.join(project_dir, "constraints", "design.sdc")
+        with open(sdc_path, "w") as f:
+            f.write("create_clock -period 1 [get_ports clk]\n")
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nsdc = "constraints/design.sdc"\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        assert rc == 0
+
+    def test_check_pdk_overrides_missing_relative_sdc_reports_project_resolved_path(
+        self, tmp_path, monkeypatch, create_cli_project, minimal_ics55_pdk_factory, capsys
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nsdc = "constraints/missing.sdc"\n')
+        monkeypatch.chdir(tmp_path)
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "PDK SDC file not found" in out
+        assert os.path.join(project_dir, "constraints", "missing.sdc") in out
+
+    def test_check_pdk_overrides_lefs_non_string_element(
+        self, tmp_path, create_cli_project, capsys
+    ):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write("\n[pdk.overrides]\nlefs = [1]\n")
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "PDK override 'lefs' elements must be strings" in captured.out
+        assert "Traceback" not in captured.err
+
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):
         project_dir = create_cli_project()
         toml_path = os.path.join(project_dir, "ecc.toml")

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -248,7 +248,9 @@ class TestMissingConfigErrorRecord:
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 0
 
-    def test_check_pdk_overrides_unknown_key(self, tmp_path, monkeypatch, create_cli_project):
+    def test_check_pdk_overrides_unknown_key(
+        self, tmp_path, monkeypatch, create_cli_project, capsys
+    ):
         project_dir = create_cli_project()
         toml_path = os.path.join(project_dir, "ecc.toml")
         with open(toml_path, "a") as f:
@@ -260,8 +262,13 @@ class TestMissingConfigErrorRecord:
         (tmp_path / "ics55").mkdir(exist_ok=True)
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 1
+        out = capsys.readouterr().out
+        assert "unknown PDK override fields" in out
+        assert "dontuse" in out
 
-    def test_check_pdk_overrides_type_mismatch(self, tmp_path, monkeypatch, create_cli_project):
+    def test_check_pdk_overrides_type_mismatch(
+        self, tmp_path, monkeypatch, create_cli_project, capsys
+    ):
         project_dir = create_cli_project()
         toml_path = os.path.join(project_dir, "ecc.toml")
         with open(toml_path, "a") as f:
@@ -273,6 +280,8 @@ class TestMissingConfigErrorRecord:
         (tmp_path / "ics55").mkdir(exist_ok=True)
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 1
+        out = capsys.readouterr().out
+        assert "must be a number" in out
 
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):
         project_dir = create_cli_project()

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -354,19 +354,20 @@ class TestMissingConfigErrorRecord:
         assert "PDK SDC file not found" in out
         assert os.path.join(project_dir, "constraints", "missing.sdc") in out
 
-    def test_check_pdk_overrides_lefs_non_string_element(
-        self, tmp_path, create_cli_project, capsys
+    @pytest.mark.parametrize("field", ["lefs", "dont_use"])
+    def test_check_pdk_overrides_non_string_list_element(
+        self, tmp_path, create_cli_project, capsys, field
     ):
         project_dir = create_cli_project()
         toml_path = os.path.join(project_dir, "ecc.toml")
         with open(toml_path, "a") as f:
-            f.write("\n[pdk.overrides]\nlefs = [1]\n")
+            f.write(f"\n[pdk.overrides]\n{field} = [1]\n")
 
         rc = cli_main.run(["check", "--project", project_dir])
 
         captured = capsys.readouterr()
         assert rc == 1
-        assert "PDK override 'lefs' elements must be strings" in captured.out
+        assert f"PDK override '{field}' elements must be strings" in captured.out
         assert "Traceback" not in captured.err
 
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -236,15 +236,14 @@ class TestMissingConfigErrorRecord:
         record = data["records"][0]
         assert "inspect" in record or "inspect_cmd" in record
 
-    def test_check_pdk_overrides_valid(self, tmp_path, monkeypatch, create_cli_project):
-        project_dir = create_cli_project()
+    def test_check_pdk_overrides_valid(
+        self, tmp_path, monkeypatch, create_cli_project, minimal_ics55_pdk_factory
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
         toml_path = os.path.join(project_dir, "ecc.toml")
         with open(toml_path, "a") as f:
             f.write('\n[pdk.overrides]\ndont_use = ["ICG*"]\n')
-        monkeypatch.setattr(
-            "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root, overrides=None: None,
-        )
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 0
 
@@ -282,6 +281,20 @@ class TestMissingConfigErrorRecord:
         assert rc == 1
         out = capsys.readouterr().out
         assert "must be a number" in out
+
+    def test_check_pdk_overrides_nonexistent_tech(
+        self, tmp_path, create_cli_project, minimal_ics55_pdk_factory, capsys
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\ntech = "/no/such.lef"\n')
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "PDK tech LEF not found" in out or "PDK validation failed" in out
+        assert "/no/such.lef" in out
 
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):
         project_dir = create_cli_project()

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -237,7 +237,7 @@ class TestMissingConfigErrorRecord:
         assert "inspect" in record or "inspect_cmd" in record
 
     def test_check_pdk_overrides_valid(
-        self, tmp_path, monkeypatch, create_cli_project, minimal_ics55_pdk_factory
+        self, tmp_path, create_cli_project, minimal_ics55_pdk_factory
     ):
         pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
         project_dir = create_cli_project(pdk_root=str(pdk_root))
@@ -293,7 +293,7 @@ class TestMissingConfigErrorRecord:
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 1
         out = capsys.readouterr().out
-        assert "PDK tech LEF not found" in out or "PDK validation failed" in out
+        assert "PDK tech LEF not found" in out
         assert "/no/such.lef" in out
 
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 from chipcompiler.cli import main as cli_main
 
 
@@ -295,6 +297,28 @@ class TestMissingConfigErrorRecord:
         out = capsys.readouterr().out
         assert "PDK tech LEF not found" in out
         assert "/no/such.lef" in out
+
+    @pytest.mark.parametrize(
+        ("field", "message"),
+        [
+            ("mapping_file", "PDK mapping file not found"),
+            ("sdc", "PDK SDC file not found"),
+            ("spef", "PDK SPEF file not found"),
+        ],
+    )
+    def test_check_pdk_overrides_nonexistent_optional_path(
+        self, tmp_path, create_cli_project, minimal_ics55_pdk_factory, capsys, field, message
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write(f'\n[pdk.overrides]\n{field} = "/no/such.file"\n')
+        rc = cli_main.run(["check", "--project", project_dir])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert message in out
+        assert "/no/such.file" in out
 
     def test_check_pdk_overrides_non_table(self, tmp_path, create_cli_project, capsys):
         project_dir = create_cli_project()

--- a/test/cli/commands/test_disclosure.py
+++ b/test/cli/commands/test_disclosure.py
@@ -17,7 +17,7 @@ class TestDisclosureCommands:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 0

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -258,4 +258,31 @@ class TestRunFlowPreset:
 
         rc = cli_main.run(["run", "--project", project_dir])
         assert rc == 0
-        assert capture["create_kwargs"]["pdk_overrides"] == {"dont_use": ["ICG*"]}
+        create_kwargs = capture["create_kwargs"]
+        assert create_kwargs is not None
+        assert create_kwargs["pdk_overrides"] == {"dont_use": ["ICG*"]}
+
+    def test_run_forwards_resolved_pdk_override_paths(
+        self, tmp_path, monkeypatch, create_cli_project
+    ):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write(
+                "\n[pdk.overrides]\n"
+                'sdc = "constraints/design.sdc"\n'
+                f'spef = "{tmp_path}/absolute.spef"\n'
+                'dont_use = ["ICG*"]\n'
+            )
+        capture = _install_flow_mocks(monkeypatch)
+
+        rc = cli_main.run(["run", "--project", project_dir])
+
+        assert rc == 0
+        create_kwargs = capture["create_kwargs"]
+        assert create_kwargs is not None
+        assert create_kwargs["pdk_overrides"] == {
+            "sdc": os.path.join(project_dir, "constraints", "design.sdc"),
+            "spef": str(tmp_path / "absolute.spef"),
+            "dont_use": ["ICG*"],
+        }

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -60,7 +60,7 @@ def _install_flow_mocks(monkeypatch):
     )
     monkeypatch.setattr(
         "chipcompiler.cli.project.config._validate_pdk_contents",
-        lambda name, root: None,
+        lambda name, root, overrides=None: None,
     )
 
     return capture
@@ -248,3 +248,14 @@ class TestRunFlowPreset:
 
         assert rc == 0
         assert DummyFlow.instances[0].added_steps == markers["build_harden_flow"]
+
+    def test_run_forwards_pdk_overrides(self, tmp_path, monkeypatch, create_cli_project):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\ndont_use = ["ICG*"]\n')
+        capture = _install_flow_mocks(monkeypatch)
+
+        rc = cli_main.run(["run", "--project", project_dir])
+        assert rc == 0
+        assert capture["create_kwargs"]["pdk_overrides"] == {"dont_use": ["ICG*"]}

--- a/test/cli/conftest.py
+++ b/test/cli/conftest.py
@@ -176,28 +176,3 @@ def mock_pdk_validation_fixture(monkeypatch):
         mock_pdk_validation(monkeypatch)
 
     return factory
-
-
-@pytest.fixture
-def minimal_ics55_pdk_factory():
-    def create_minimal_ics55_pdk(root):
-        from pathlib import Path
-
-        root = Path(root)
-        tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
-        tech_path.parent.mkdir(parents=True, exist_ok=True)
-        tech_path.write_text("VERSION 5.8 ;\n")
-
-        stdcell_root = root / "IP" / "STD_cell" / "ics55_LLSC_H7C_V1p10C100"
-        for flavor in ("ics55_LLSC_H7CR", "ics55_LLSC_H7CL"):
-            lef_path = stdcell_root / flavor / "lef" / f"{flavor}_ecos.lef"
-            lef_path.parent.mkdir(parents=True, exist_ok=True)
-            lef_path.write_text("VERSION 5.8 ;\n")
-
-            lib_path = stdcell_root / flavor / "liberty" / f"{flavor}_ss_rcworst_1p08_125_nldm.lib"
-            lib_path.parent.mkdir(parents=True, exist_ok=True)
-            lib_path.write_text("library(test) { }\n")
-
-        return root
-
-    return create_minimal_ics55_pdk

--- a/test/cli/conftest.py
+++ b/test/cli/conftest.py
@@ -176,3 +176,28 @@ def mock_pdk_validation_fixture(monkeypatch):
         mock_pdk_validation(monkeypatch)
 
     return factory
+
+
+@pytest.fixture
+def minimal_ics55_pdk_factory():
+    def create_minimal_ics55_pdk(root):
+        from pathlib import Path
+
+        root = Path(root)
+        tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
+        tech_path.parent.mkdir(parents=True, exist_ok=True)
+        tech_path.write_text("VERSION 5.8 ;\n")
+
+        stdcell_root = root / "IP" / "STD_cell" / "ics55_LLSC_H7C_V1p10C100"
+        for flavor in ("ics55_LLSC_H7CR", "ics55_LLSC_H7CL"):
+            lef_path = stdcell_root / flavor / "lef" / f"{flavor}_ecos.lef"
+            lef_path.parent.mkdir(parents=True, exist_ok=True)
+            lef_path.write_text("VERSION 5.8 ;\n")
+
+            lib_path = stdcell_root / flavor / "liberty" / f"{flavor}_ss_rcworst_1p08_125_nldm.lib"
+            lib_path.parent.mkdir(parents=True, exist_ok=True)
+            lib_path.write_text("library(test) { }\n")
+
+        return root
+
+    return create_minimal_ics55_pdk

--- a/test/cli/conftest.py
+++ b/test/cli/conftest.py
@@ -123,7 +123,7 @@ def has_disclosure(line):
 def mock_pdk_validation(monkeypatch):
     monkeypatch.setattr(
         "chipcompiler.cli.project.config._validate_pdk_contents",
-        lambda name, root: None,
+        lambda name, root, overrides=None: None,
     )
 
 

--- a/test/cli/inspect/test_config.py
+++ b/test/cli/inspect/test_config.py
@@ -722,3 +722,42 @@ run = "default"
         data = json.loads(capsys.readouterr().out)
         rtl_item = next(i for i in data["records"] if i["config"] == "design.rtl.0")
         assert rtl_item["resolved"] == str(rtl_dir / "gcd.v")
+
+
+def test_config_resolved_pdk_overrides_present(
+    tmp_path,
+    capsys,
+    monkeypatch,
+    create_cli_project,
+    mock_pdk_validation,
+):
+    mock_pdk_validation()
+    project_dir = create_cli_project()
+    toml_path = os.path.join(project_dir, "ecc.toml")
+    with open(toml_path, "a") as f:
+        f.write('\n[pdk.overrides]\ndont_use = ["ICG*", "DFFSRQX*"]\n')
+
+    rc = cli_main.run(["config", "--resolved", "--json", "--project", project_dir])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    keys = [item["config"] for item in data["records"]]
+    assert "pdk.overrides" in keys
+    overrides_item = next(i for i in data["records"] if i["config"] == "pdk.overrides")
+    assert overrides_item["value"] == {"dont_use": ["ICG*", "DFFSRQX*"]}
+
+
+def test_config_resolved_pdk_overrides_absent(
+    tmp_path,
+    capsys,
+    monkeypatch,
+    create_cli_project,
+    mock_pdk_validation,
+):
+    mock_pdk_validation()
+    project_dir = create_cli_project()
+
+    rc = cli_main.run(["config", "--resolved", "--json", "--project", project_dir])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    keys = [item["config"] for item in data["records"]]
+    assert "pdk.overrides" not in keys

--- a/test/cli/params/test_commands.py
+++ b/test/cli/params/test_commands.py
@@ -195,7 +195,7 @@ class TestRunSet:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.setattr(
             "chipcompiler.cli.rendering.progress.should_enable_run_progress",
@@ -276,7 +276,7 @@ class TestRunSet:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.setattr(
             "chipcompiler.cli.rendering.progress.should_enable_run_progress",
@@ -344,7 +344,7 @@ class TestConfigResolved:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         run_dir = os.path.join(project_dir, "runs", "default")
         home = os.path.join(run_dir, "home")
@@ -368,7 +368,7 @@ class TestConfigResolved:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         cli_main.run(["param", "set", "place.target_density", "0.65", "--project", project_dir])
         capsys.readouterr()  # flush set output
@@ -393,7 +393,7 @@ class TestConfigResolved:
         project_dir = create_cli_project(freq=200.0)
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         run_dir = os.path.join(project_dir, "runs", "default")
         home = os.path.join(run_dir, "home")

--- a/test/cli/params/test_provenance.py
+++ b/test/cli/params/test_provenance.py
@@ -39,7 +39,7 @@ class TestCliProvenance:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.setattr(
             "chipcompiler.cli.rendering.progress.should_enable_run_progress",
@@ -101,7 +101,7 @@ class TestCliProvenance:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.setattr(
             "chipcompiler.cli.rendering.progress.should_enable_run_progress",
@@ -168,7 +168,7 @@ class TestCliProvenance:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         monkeypatch.setattr(
             "chipcompiler.cli.rendering.progress.should_enable_run_progress",

--- a/test/cli/params/test_toml_editing.py
+++ b/test/cli/params/test_toml_editing.py
@@ -234,7 +234,7 @@ class TestMultilineTomlValues:
             f.write("not valid json{")
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda pdk_root, pdk_name: [],
+            lambda name, root, overrides=None: [],
         )
         rc = cli_main.run(["config", "--resolved", "--project", project_dir, "--json"])
         assert rc == 1
@@ -248,7 +248,7 @@ class TestMultilineTomlValues:
             json.dump([1, 2, 3], f)
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda pdk_root, pdk_name: [],
+            lambda name, root, overrides=None: [],
         )
         rc = cli_main.run(["config", "--resolved", "--project", project_dir, "--json"])
         assert rc == 1
@@ -262,7 +262,7 @@ class TestMultilineTomlValues:
             json.dump({"nonexistent.param": 42}, f)
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda pdk_root, pdk_name: [],
+            lambda name, root, overrides=None: [],
         )
         rc = cli_main.run(["config", "--resolved", "--project", project_dir, "--json"])
         assert rc == 1

--- a/test/cli/params/test_validation.py
+++ b/test/cli/params/test_validation.py
@@ -84,7 +84,7 @@ class TestNativeTomlTypeValidation:
             f.write(content)
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda pdk_root, pdk_name: [],
+            lambda name, root, overrides=None: [],
         )
         rc = cli_main.run(["check", "--project", project_dir, "--json"])
         assert rc == 0

--- a/test/cli/rendering/test_pretty.py
+++ b/test/cli/rendering/test_pretty.py
@@ -141,7 +141,7 @@ class TestPlainFlagAcceptance:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["check", "--project", project_dir, "--plain"])
         assert rc == 0
@@ -162,7 +162,7 @@ class TestPlainFlagAcceptance:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["config", "--resolved", "--plain", "--project", project_dir])
         assert rc == 0
@@ -186,7 +186,7 @@ class TestPrettyDefaultOutput:
         project_dir = create_cli_project()
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
         rc = cli_main.run(["check", "--project", project_dir])
         assert rc == 0
@@ -264,7 +264,7 @@ class TestPrettyDefaultOutput:
         )
         monkeypatch.setattr(
             "chipcompiler.cli.project.config._validate_pdk_contents",
-            lambda name, root: None,
+            lambda name, root, overrides=None: None,
         )
 
         rc = cli_main.run(["run", "--project", project_dir])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,3 +39,27 @@ def pytest_collection_modifyitems(config, items):
             pdk_root = f"{repo_root}/{pdk_root}"
         if not complete_ics55_pdk_available(pdk_root):
             item.add_marker(skip_missing_pdk)
+
+
+def create_minimal_ics55_pdk(root):
+    root = Path(root)
+    tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
+    tech_path.parent.mkdir(parents=True, exist_ok=True)
+    tech_path.write_text("VERSION 5.8 ;\n")
+
+    stdcell_root = root / "IP" / "STD_cell" / "ics55_LLSC_H7C_V1p10C100"
+    for flavor in ("ics55_LLSC_H7CR", "ics55_LLSC_H7CL"):
+        lef_path = stdcell_root / flavor / "lef" / f"{flavor}_ecos.lef"
+        lef_path.parent.mkdir(parents=True, exist_ok=True)
+        lef_path.write_text("VERSION 5.8 ;\n")
+
+        lib_path = stdcell_root / flavor / "liberty" / f"{flavor}_ss_rcworst_1p08_125_nldm.lib"
+        lib_path.parent.mkdir(parents=True, exist_ok=True)
+        lib_path.write_text("library(test) { }\n")
+
+    return root
+
+
+@pytest.fixture
+def minimal_ics55_pdk_factory():
+    return create_minimal_ics55_pdk

--- a/test/data/conftest.py
+++ b/test/data/conftest.py
@@ -3,24 +3,6 @@ from pathlib import Path
 import pytest
 
 
-def create_minimal_ics55_pdk(root: Path) -> Path:
-    tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
-    tech_path.parent.mkdir(parents=True, exist_ok=True)
-    tech_path.write_text("VERSION 5.8 ;\n")
-
-    stdcell_root = root / "IP" / "STD_cell" / "ics55_LLSC_H7C_V1p10C100"
-    for flavor in ("ics55_LLSC_H7CR", "ics55_LLSC_H7CL"):
-        lef_path = stdcell_root / flavor / "lef" / f"{flavor}_ecos.lef"
-        lef_path.parent.mkdir(parents=True, exist_ok=True)
-        lef_path.write_text("VERSION 5.8 ;\n")
-
-        lib_path = stdcell_root / flavor / "liberty" / f"{flavor}_ss_rcworst_1p08_125_nldm.lib"
-        lib_path.parent.mkdir(parents=True, exist_ok=True)
-        lib_path.write_text("library(test) { }\n")
-
-    return root
-
-
 def create_minimal_sg13g2_pdk(root: Path) -> Path:
     tech_path = root / "libs.ref" / "sg13g2_stdcell" / "lef" / "sg13g2_tech.lef"
     tech_path.parent.mkdir(parents=True, exist_ok=True)
@@ -54,11 +36,6 @@ def sg13g2_parameters() -> dict:
         "Clock": "clk",
         "Frequency max [MHz]": 100,
     }
-
-
-@pytest.fixture
-def minimal_ics55_pdk_factory():
-    return create_minimal_ics55_pdk
 
 
 @pytest.fixture

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -127,16 +127,15 @@ def test_get_pdk_sg13g2_case_insensitive(tmp_path, monkeypatch, minimal_sg13g2_p
 
 
 def test_apply_pdk_overrides_replaces_whole_field(tmp_path, minimal_ics55_pdk_factory):
+    from dataclasses import replace
+
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
     base_pdk = get_pdk("ics55", pdk_root=pdk_root)
-    original_dont_use = base_pdk.dont_use
 
     overridden = apply_pdk_overrides(base_pdk, {"dont_use": ["ICG*"]})
+    expected = replace(base_pdk, dont_use=["ICG*"])
 
-    assert overridden.dont_use == ["ICG*"]
-    assert overridden.dont_use != original_dont_use
-    assert overridden.buffers == base_pdk.buffers
-    assert overridden.root == base_pdk.root
+    assert overridden == expected
 
 
 def test_apply_pdk_overrides_empty_dict_is_noop(tmp_path, minimal_ics55_pdk_factory):
@@ -152,8 +151,18 @@ def test_apply_pdk_overrides_unknown_key_raises(tmp_path, minimal_ics55_pdk_fact
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
     base_pdk = get_pdk("ics55", pdk_root=pdk_root)
 
-    with pytest.raises(ValueError, match="unknown PDK override fields.*dontuse"):
+    with pytest.raises(ValueError) as exc_info:
         apply_pdk_overrides(base_pdk, {"dontuse": ["ICG*"]})
+
+    error_msg = str(exc_info.value)
+    assert "dontuse" in error_msg
+    assert "valid overridable fields" in error_msg
+    assert "dont_use" in error_msg
+    assert "name" not in error_msg or "name" not in error_msg.split("valid overridable fields:")[-1]
+    assert (
+        "version" not in error_msg
+        or "version" not in error_msg.split("valid overridable fields:")[-1]
+    )
 
 
 def test_apply_pdk_overrides_type_mismatch_list_field(tmp_path, minimal_ics55_pdk_factory):
@@ -189,12 +198,15 @@ def test_apply_pdk_overrides_version_rejected(tmp_path, minimal_ics55_pdk_factor
 
 
 def test_get_pdk_with_overrides(tmp_path, minimal_ics55_pdk_factory):
+    from dataclasses import replace
+
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
 
     pdk = get_pdk("ics55", pdk_root=pdk_root, overrides={"dont_use": ["DFFSRQX*"]})
+    expected = replace(base_pdk, dont_use=["DFFSRQX*"])
 
-    assert pdk.dont_use == ["DFFSRQX*"]
-    assert pdk.name == "ics55"
+    assert pdk == expected
 
 
 def test_get_pdk_overrides_none_is_noop(tmp_path, minimal_ics55_pdk_factory):
@@ -203,7 +215,14 @@ def test_get_pdk_overrides_none_is_noop(tmp_path, minimal_ics55_pdk_factory):
     pdk_default = get_pdk("ics55", pdk_root=pdk_root)
     pdk_with_none = get_pdk("ics55", pdk_root=pdk_root, overrides=None)
 
-    assert pdk_with_none.dont_use == pdk_default.dont_use
+    assert pdk_with_none == pdk_default
+
+
+def test_get_pdk_overrides_unknown_key_raises(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    with pytest.raises(ValueError, match="unknown PDK override fields"):
+        get_pdk("ics55", pdk_root=pdk_root, overrides={"bogus": 1})
 
 
 def test_get_pdk_overrides_validated(tmp_path, minimal_ics55_pdk_factory):

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -138,6 +138,20 @@ def test_apply_pdk_overrides_replaces_whole_field(tmp_path, minimal_ics55_pdk_fa
     assert overridden == expected
 
 
+def test_apply_pdk_overrides_nonexistent_optional_path_stays_pure(
+    tmp_path, minimal_ics55_pdk_factory
+):
+    from dataclasses import replace
+
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+    missing_sdc = tmp_path / "missing.sdc"
+
+    overridden = apply_pdk_overrides(base_pdk, {"sdc": str(missing_sdc)})
+
+    assert overridden == replace(base_pdk, sdc=str(missing_sdc))
+
+
 def test_apply_pdk_overrides_empty_dict_is_noop(tmp_path, minimal_ics55_pdk_factory):
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
     base_pdk = get_pdk("ics55", pdk_root=pdk_root)

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -187,8 +187,8 @@ def test_apply_pdk_overrides_type_mismatch_list_field(tmp_path, minimal_ics55_pd
         apply_pdk_overrides(base_pdk, {"dont_use": "ICG*"})
 
 
-@pytest.mark.parametrize("field", ["lefs", "libs"])
-def test_apply_pdk_overrides_rejects_non_string_path_list_element(
+@pytest.mark.parametrize("field", ["lefs", "libs", "buffers", "fillers", "dont_use"])
+def test_apply_pdk_overrides_rejects_non_string_list_element(
     tmp_path, minimal_ics55_pdk_factory, field
 ):
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
@@ -198,7 +198,7 @@ def test_apply_pdk_overrides_rejects_non_string_path_list_element(
         ValueError,
         match=f"PDK override '{field}' elements must be strings, got int at index 1",
     ):
-        apply_pdk_overrides(base_pdk, {field: ["valid.lef", 1]})
+        apply_pdk_overrides(base_pdk, {field: ["ok", 1]})
 
 
 def test_apply_pdk_overrides_type_mismatch_float_field(tmp_path, minimal_ics55_pdk_factory):

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -230,3 +230,40 @@ def test_get_pdk_overrides_validated(tmp_path, minimal_ics55_pdk_factory):
 
     with pytest.raises(ValueError, match="PDK validation failed"):
         get_pdk("ics55", pdk_root=pdk_root, overrides={"tech": "/no/such.lef"})
+
+
+@pytest.mark.parametrize(
+    ("field", "message"),
+    [
+        ("mapping_file", "PDK mapping file not found"),
+        ("sdc", "PDK SDC file not found"),
+        ("spef", "PDK SPEF file not found"),
+    ],
+)
+def test_get_pdk_optional_path_override_nonexistent_raises(
+    tmp_path, minimal_ics55_pdk_factory, field, message
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    with pytest.raises(ValueError, match=message):
+        get_pdk("ics55", pdk_root=pdk_root, overrides={field: "/no/such.file"})
+
+
+@pytest.mark.parametrize("field", ["mapping_file", "sdc", "spef"])
+def test_get_pdk_optional_path_override_existing_ok(tmp_path, minimal_ics55_pdk_factory, field):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    real_file = tmp_path / f"{field}.file"
+    real_file.write_text("content\n")
+
+    pdk = get_pdk("ics55", pdk_root=pdk_root, overrides={field: str(real_file)})
+
+    assert getattr(pdk, field) == real_file
+
+
+def test_pdk_validate_optional_paths_absent_ok(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    assert pdk.mapping_file is None
+    assert pdk.spef is None

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from chipcompiler.data.pdk import get_pdk
+from chipcompiler.data.pdk import apply_pdk_overrides, get_pdk
 
 
 def test_get_pdk_prefers_explicit_root_over_env(tmp_path, monkeypatch, minimal_ics55_pdk_factory):
@@ -124,3 +124,90 @@ def test_get_pdk_sg13g2_case_insensitive(tmp_path, monkeypatch, minimal_sg13g2_p
     pdk = get_pdk("SG13G2")
 
     assert pdk.name == "sg13g2"
+
+
+def test_apply_pdk_overrides_replaces_whole_field(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+    original_dont_use = base_pdk.dont_use
+
+    overridden = apply_pdk_overrides(base_pdk, {"dont_use": ["ICG*"]})
+
+    assert overridden.dont_use == ["ICG*"]
+    assert overridden.dont_use != original_dont_use
+    assert overridden.buffers == base_pdk.buffers
+    assert overridden.root == base_pdk.root
+
+
+def test_apply_pdk_overrides_empty_dict_is_noop(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    overridden = apply_pdk_overrides(base_pdk, {})
+
+    assert overridden is base_pdk
+
+
+def test_apply_pdk_overrides_unknown_key_raises(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="unknown PDK override fields.*dontuse"):
+        apply_pdk_overrides(base_pdk, {"dontuse": ["ICG*"]})
+
+
+def test_apply_pdk_overrides_type_mismatch_list_field(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="must be a list.*got str"):
+        apply_pdk_overrides(base_pdk, {"dont_use": "ICG*"})
+
+
+def test_apply_pdk_overrides_type_mismatch_float_field(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="must be a number.*got str"):
+        apply_pdk_overrides(base_pdk, {"abc_load": "fast"})
+
+
+def test_apply_pdk_overrides_name_rejected(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="'name'.*cannot be overridden"):
+        apply_pdk_overrides(base_pdk, {"name": "custom"})
+
+
+def test_apply_pdk_overrides_version_rejected(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="'version'.*cannot be overridden"):
+        apply_pdk_overrides(base_pdk, {"version": "custom"})
+
+
+def test_get_pdk_with_overrides(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    pdk = get_pdk("ics55", pdk_root=pdk_root, overrides={"dont_use": ["DFFSRQX*"]})
+
+    assert pdk.dont_use == ["DFFSRQX*"]
+    assert pdk.name == "ics55"
+
+
+def test_get_pdk_overrides_none_is_noop(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    pdk_default = get_pdk("ics55", pdk_root=pdk_root)
+    pdk_with_none = get_pdk("ics55", pdk_root=pdk_root, overrides=None)
+
+    assert pdk_with_none.dont_use == pdk_default.dont_use
+
+
+def test_get_pdk_overrides_validated(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+
+    with pytest.raises(ValueError, match="PDK validation failed"):
+        get_pdk("ics55", pdk_root=pdk_root, overrides={"tech": "/no/such.lef"})

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -187,6 +187,20 @@ def test_apply_pdk_overrides_type_mismatch_list_field(tmp_path, minimal_ics55_pd
         apply_pdk_overrides(base_pdk, {"dont_use": "ICG*"})
 
 
+@pytest.mark.parametrize("field", ["lefs", "libs"])
+def test_apply_pdk_overrides_rejects_non_string_path_list_element(
+    tmp_path, minimal_ics55_pdk_factory, field
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(
+        ValueError,
+        match=f"PDK override '{field}' elements must be strings, got int at index 1",
+    ):
+        apply_pdk_overrides(base_pdk, {field: ["valid.lef", 1]})
+
+
 def test_apply_pdk_overrides_type_mismatch_float_field(tmp_path, minimal_ics55_pdk_factory):
     pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
     base_pdk = get_pdk("ics55", pdk_root=pdk_root)

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -1020,3 +1020,77 @@ def test_load_workspace_sg13g2_restores_pdk_root_from_parameters(
     assert loaded.pdk.root == resolved_root
     assert loaded.parameters.data.get("PDK Root") == str(resolved_root)
     assert all(path.is_relative_to(resolved_root) for path in loaded.pdk.libs)
+
+
+def test_create_workspace_with_pdk_overrides_str_branch(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    workspace = create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk="ics55",
+        parameters=default_ics55_parameters,
+        pdk_root=str(pdk_root),
+        pdk_overrides={"dont_use": ["ICG*"]},
+    )
+
+    assert workspace is not None
+    assert workspace.pdk.dont_use == ["ICG*"]
+
+
+def test_create_workspace_with_pdk_overrides_pdk_object_ignored(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    from chipcompiler.data.pdk import get_pdk
+
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+    pdk_obj = get_pdk("ics55", pdk_root=pdk_root)
+    original_dont_use = pdk_obj.dont_use
+
+    workspace_dir = tmp_path / "workspace"
+    workspace = create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk=pdk_obj,
+        parameters=default_ics55_parameters,
+        pdk_overrides={"dont_use": ["ICG*"]},
+    )
+
+    assert workspace is not None
+    assert workspace.pdk.dont_use == original_dont_use
+
+
+def test_workspace_pdk_overrides_not_persisted_on_reload(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    workspace = create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk="ics55",
+        parameters=default_ics55_parameters,
+        pdk_root=str(pdk_root),
+        pdk_overrides={"dont_use": ["ICG*"]},
+    )
+    assert workspace.pdk.dont_use == ["ICG*"]
+
+    loaded = load_workspace(str(workspace_dir))
+
+    from chipcompiler.data.pdk import get_pdk
+
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+    assert loaded.pdk.dont_use == base_pdk.dont_use

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -597,6 +597,59 @@ def test_load_workspace_restores_pdk_root_from_parameters(
     assert all(path.is_relative_to(resolved_root) for path in loaded.pdk.libs)
 
 
+def test_load_workspace_external_pdk_recovers_origin_sdc_spef(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    tech = next((pdk_root / "prtech").rglob("*.lef"))
+    lef = next(pdk_root.rglob("ics55_LLSC_H7CR_ecos.lef"))
+    lib = next(pdk_root.rglob("*.lib"))
+    sdc_source = tmp_path / "source.sdc"
+    sdc_source.write_text("# sdc\n")
+    spef_source = tmp_path / "source.spef"
+    spef_source.write_text("# spef\n")
+    pdk_json = tmp_path / "pdk.json"
+    pdk_json.write_text(
+        json.dumps(
+            {
+                "name": "ics55",
+                "root": str(pdk_root),
+                "tech": str(tech),
+                "lefs": [str(lef)],
+                "libs": [str(lib)],
+                "sdc": str(sdc_source),
+                "spef": str(spef_source),
+            }
+        )
+    )
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk="ics55",
+        parameters=default_ics55_parameters,
+        pdk_json=str(pdk_json),
+    )
+
+    origin_sdc = (workspace_dir / "origin" / "source.sdc").resolve()
+    origin_spef = (workspace_dir / "origin" / "source.spef").resolve()
+    assert origin_sdc.is_file()
+    assert origin_spef.is_file()
+
+    sdc_source.unlink()
+    spef_source.unlink()
+
+    loaded = load_workspace(str(workspace_dir))
+
+    assert loaded is not None
+    assert loaded.pdk.sdc == origin_sdc
+    assert loaded.pdk.spef == origin_spef
+
+
 def test_workspace_config_refresh_uses_updated_parameters(
     tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
 ):

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -1094,3 +1094,25 @@ def test_workspace_pdk_overrides_not_persisted_on_reload(
 
     base_pdk = get_pdk("ics55", pdk_root=pdk_root)
     assert loaded.pdk.dont_use == base_pdk.dont_use
+
+
+def test_create_workspace_pdk_overrides_typo_propagates(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    import pytest
+
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    with pytest.raises(ValueError, match="unknown PDK override fields"):
+        create_workspace(
+            directory=str(workspace_dir),
+            origin_def="",
+            origin_verilog=str(rtl_path),
+            pdk="ics55",
+            parameters=default_ics55_parameters,
+            pdk_root=str(pdk_root),
+            pdk_overrides={"dontuse": ["ICG*"]},
+        )

--- a/test/runtime/test_stdio_server.py
+++ b/test/runtime/test_stdio_server.py
@@ -49,8 +49,8 @@ def _write_subprocess_request(process: subprocess.Popen, method: str, request_id
     process.stdin.flush()
 
 
-def _create_real_workspace(tmp_path: Path) -> Path:
-    pdk_root = _create_minimal_ics55_pdk(tmp_path / "ics55")
+def _create_real_workspace(tmp_path: Path, minimal_ics55_pdk_factory) -> Path:
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
     rtl_path = tmp_path / "gcd.v"
     rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
     workspace_dir = tmp_path / "workspace"
@@ -69,24 +69,6 @@ def _create_real_workspace(tmp_path: Path) -> Path:
         },
     )
     return workspace_dir
-
-
-def _create_minimal_ics55_pdk(root: Path) -> Path:
-    tech_path = root / "prtech" / "techLEF" / "N551P6M_ecos.lef"
-    tech_path.parent.mkdir(parents=True, exist_ok=True)
-    tech_path.write_text("VERSION 5.8 ;\n")
-
-    stdcell_root = root / "IP" / "STD_cell" / "ics55_LLSC_H7C_V1p10C100"
-    for flavor in ("ics55_LLSC_H7CR", "ics55_LLSC_H7CL"):
-        lef_path = stdcell_root / flavor / "lef" / f"{flavor}_ecos.lef"
-        lef_path.parent.mkdir(parents=True, exist_ok=True)
-        lef_path.write_text("VERSION 5.8 ;\n")
-
-        lib_path = stdcell_root / flavor / "liberty" / f"{flavor}_ss_rcworst_1p08_125_nldm.lib"
-        lib_path.parent.mkdir(parents=True, exist_ok=True)
-        lib_path.write_text("library(test) { }\n")
-
-    return root
 
 
 def test_stdio_server_writes_only_content_length_framed_responses():
@@ -215,8 +197,8 @@ def test_rpc_stdio_subprocess_persistent_db_smoke():
     assert "db.release" in responses[0]["result"]["capabilities"]
 
 
-def test_rpc_stdio_subprocess_workspace_open_home_smoke(tmp_path):
-    ws = _create_real_workspace(tmp_path)
+def test_rpc_stdio_subprocess_workspace_open_home_smoke(tmp_path, minimal_ics55_pdk_factory):
+    ws = _create_real_workspace(tmp_path, minimal_ics55_pdk_factory)
     process = subprocess.Popen(
         [sys.executable, "-m", "chipcompiler.cli.main", "rpc", "serve", "--stdio"],
         cwd=os.getcwd(),

--- a/test/tools/ecc_sizer/_sizer_helpers.py
+++ b/test/tools/ecc_sizer/_sizer_helpers.py
@@ -19,8 +19,8 @@ def _workspace(tmp_path):
         design=OriginDesign(name="gcd", top_module="gcd"),
         pdk=PDK(
             tech=Path("tech.lef"),
-            lefs=["std.lef"],
-            libs=["slow.lib"],
+            lefs=[Path("std.lef")],
+            libs=[Path("slow.lib")],
             sdc=Path("clock.sdc"),
             spef=Path("route.spef"),
         ),

--- a/test/tools/ecc_sizer/test_module.py
+++ b/test/tools/ecc_sizer/test_module.py
@@ -78,8 +78,8 @@ def test_sizer_config_preserves_runtime_parseable_order(tmp_path, monkeypatch):
 
     workspace = _workspace(tmp_path)
     workspace.pdk.tech = str(tmp_path / "tech_lef" / "tech.lef")
-    workspace.pdk.lefs = [str(tmp_path / "lef_dir" / "std_cell.lef")]
-    workspace.pdk.libs = [str(tmp_path / "lib_dir" / "slow_corner.lib")]
+    workspace.pdk.lefs = [tmp_path / "lef_dir" / "std_cell.lef"]
+    workspace.pdk.libs = [tmp_path / "lib_dir" / "slow_corner.lib"]
     workspace.pdk.sdc = str(tmp_path / "constraints" / "main_clock.sdc")
     workspace.pdk.spef = str(tmp_path / "rcx" / "route_parasitic.spef")
 

--- a/test/tools/yosys/test_global_var_builder.py
+++ b/test/tools/yosys/test_global_var_builder.py
@@ -53,7 +53,7 @@ def _build_workspace_and_step(tmp_path, *, rtl_name="top.v", create_rtl=True, fi
             input_filelist=str(filelist) if filelist is not None else "",
         ),
         pdk=PDK(
-            libs=[str(lib_a), str(lib_b)],
+            libs=[lib_a, lib_b],
             dont_use=["DFF*", "CELL WITH SPACE"],
             tie_low_cell="TIELO",
             tie_low_port="Z",

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "ecc"
-version = "0.1.0a5"
+version = "0.1.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "ecc-dreamplace" },


### PR DESCRIPTION
## What Changed

- Fix https://github.com/openecos-projects/ecc/issues/164
- Pin icsprout55-pdk to 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53 for ecc-dreamplace error

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [x] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [x] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [x] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
