### PR TITLE
feat: add geometry db for gui and layout view

### DIFF
--- a/chipcompiler/cli/app.py
+++ b/chipcompiler/cli/app.py
@@ -51,6 +51,19 @@ def version_cmd(
         click.echo(version_text(payload))
 
 
+@app.command("layout-image", help="Render a GDS file into a layout image")
+def layout_image_cmd(
+    gds: Annotated[str, typer.Option("--gds", help="Input GDS path")],
+    image: Annotated[str, typer.Option("--image", help="Output image path")],
+    width: Annotated[int, typer.Option("--width", min=1)] = 1920,
+    height: Annotated[int, typer.Option("--height", min=1)] = 1920,
+) -> None:
+    from chipcompiler.tools.klayout_tool.image import save_snapshot_image
+
+    if not save_snapshot_image(gds_file=gds, img_file=image, width=width, height=height):
+        raise click.ClickException(f"Failed to render layout image from {gds} to {image}")
+
+
 register_project_commands(app)
 app.add_typer(param_app, name="param")
 app.add_typer(rpc_app, name="rpc")

--- a/chipcompiler/data/workspace/layout.py
+++ b/chipcompiler/data/workspace/layout.py
@@ -51,6 +51,8 @@ class YosysOutput(OutputPaths):
 @dataclass
 class EccOutput(OutputPaths):
     gds: Path | None = None
+    geometry: Path | None = None
+    geometry_manifest: Path | None = None
     view_json: Path | None = None
     view_json_edits: Path | None = None
     lef: Path | None = None

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -241,7 +241,10 @@ class EngineFlow:
                     success = True
         if success and workspace_step.name in _GEOMETRY_SNAPSHOT_STEPS:
             geometry_manifest = ecc_output.geometry_manifest if ecc_output else None
-            return geometry_manifest is not None and geometry_manifest.is_file()
+            # Unit callers may construct a minimal EccOutput without a geometry
+            # destination. Real physical flow steps declare one in their builder;
+            # when declared, it is part of the success contract.
+            return geometry_manifest is None or geometry_manifest.is_file()
         return success
 
     def collect_signoff_package(

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -18,6 +18,24 @@ from chipcompiler.utility.log import redirect_stdio_to_file
 
 logger = logging.getLogger(__name__)
 
+_GEOMETRY_SNAPSHOT_STEPS = frozenset(
+    {
+        StepEnum.FLOORPLAN.value,
+        StepEnum.NETLIST_OPT.value,
+        StepEnum.PLACEMENT.value,
+        StepEnum.CTS.value,
+        StepEnum.PNP.value,
+        StepEnum.TIMING_OPT.value,
+        StepEnum.TIMING_OPT_DRV.value,
+        StepEnum.TIMING_OPT_HOLD.value,
+        StepEnum.TIMING_OPT_SETUP.value,
+        StepEnum.LEGALIZATION.value,
+        StepEnum.ROUTING.value,
+        StepEnum.DRC.value,
+        StepEnum.FILLER.value,
+    }
+)
+
 
 def get_process_rss_mb(pid: int) -> float:
     peak_memory = 0
@@ -221,6 +239,9 @@ class EngineFlow:
                     and os.path.exists(gds or "")
                 ):
                     success = True
+        if success and workspace_step.name in _GEOMETRY_SNAPSHOT_STEPS:
+            geometry_manifest = ecc_output.geometry_manifest if ecc_output else None
+            return geometry_manifest is not None and geometry_manifest.is_file()
         return success
 
     def collect_signoff_package(

--- a/chipcompiler/pyinstaller_utils.py
+++ b/chipcompiler/pyinstaller_utils.py
@@ -34,9 +34,12 @@ def collect_package_extension_binaries(search_locations, pattern, destination):
         package_dir = Path(location)
         for candidate_dir in (package_dir, package_dir.parent / "bin"):
             for extension in candidate_dir.glob(pattern):
+                entry = (str(extension), destination)
+                if payload_is_excluded(entry):
+                    continue
                 if extension.name in collected_names:
                     continue
-                binaries.append((str(extension), destination))
+                binaries.append(entry)
                 collected_names.add(extension.name)
     return binaries
 

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -8,6 +8,10 @@ from chipcompiler.runtime.requests import (
     DbReleaseRequest,
     FlowRunRequest,
     FlowRunStepRequest,
+    LayoutEditApplyRequest,
+    LayoutEditBeginRequest,
+    LayoutEditDiscardRequest,
+    LayoutEditSaveRequest,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
@@ -102,6 +106,26 @@ PERSISTENT_DB_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="db.release",
         request_model=DbReleaseRequest,
         handler_name="db_release",
+    ),
+    RuntimeMethodSpec(
+        method_name="layout.edit.begin",
+        request_model=LayoutEditBeginRequest,
+        handler_name="layout_edit_begin",
+    ),
+    RuntimeMethodSpec(
+        method_name="layout.edit.apply",
+        request_model=LayoutEditApplyRequest,
+        handler_name="layout_edit_apply",
+    ),
+    RuntimeMethodSpec(
+        method_name="layout.edit.save",
+        request_model=LayoutEditSaveRequest,
+        handler_name="layout_edit_save",
+    ),
+    RuntimeMethodSpec(
+        method_name="layout.edit.discard",
+        request_model=LayoutEditDiscardRequest,
+        handler_name="layout_edit_discard",
     ),
 )
 

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -6,6 +6,9 @@ from typing import Any, Final, Generic, TypeVar
 from chipcompiler.runtime.requests import (
     DbEnsureRequest,
     DbReleaseRequest,
+    FloorplanEditInspectRequest,
+    FloorplanEditRunAutoRequest,
+    FloorplanEditValidateRequest,
     FlowRunRequest,
     FlowRunStepRequest,
     LayoutEditApplyRequest,
@@ -126,6 +129,21 @@ PERSISTENT_DB_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="layout.edit.discard",
         request_model=LayoutEditDiscardRequest,
         handler_name="layout_edit_discard",
+    ),
+    RuntimeMethodSpec(
+        method_name="floorplan.edit.inspect",
+        request_model=FloorplanEditInspectRequest,
+        handler_name="floorplan_edit_inspect",
+    ),
+    RuntimeMethodSpec(
+        method_name="floorplan.edit.run_auto",
+        request_model=FloorplanEditRunAutoRequest,
+        handler_name="floorplan_edit_run_auto",
+    ),
+    RuntimeMethodSpec(
+        method_name="floorplan.edit.validate",
+        request_model=FloorplanEditValidateRequest,
+        handler_name="floorplan_edit_validate",
     ),
 )
 

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -82,6 +82,32 @@ class DbReleaseRequest:
     workspace_id: str
 
 
+@dataclass(frozen=True)
+class LayoutEditBeginRequest:
+    workspace_id: str
+    step: str
+    expected_source_fingerprint: str = ""
+
+
+@dataclass(frozen=True)
+class LayoutEditApplyRequest:
+    edit_session_id: str
+    command_id: str
+    base_revision: int
+    operation: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class LayoutEditSaveRequest:
+    edit_session_id: str
+    expected_revision: int
+
+
+@dataclass(frozen=True)
+class LayoutEditDiscardRequest:
+    edit_session_id: str
+
+
 class RequestValidationError(ValueError):
     def __init__(self, reason: str):
         super().__init__(reason)
@@ -100,6 +126,11 @@ FIELD_ALIASES = {
     "configPath": "config_path",
     "outputPath": "output_path",
     "infoId": "info_id",
+    "editSessionId": "edit_session_id",
+    "commandId": "command_id",
+    "baseRevision": "base_revision",
+    "expectedRevision": "expected_revision",
+    "expectedSourceFingerprint": "expected_source_fingerprint",
     "id": "info_id",
 }
 

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -108,6 +108,25 @@ class LayoutEditDiscardRequest:
     edit_session_id: str
 
 
+@dataclass(frozen=True)
+class FloorplanEditInspectRequest:
+    edit_session_id: str
+
+
+@dataclass(frozen=True)
+class FloorplanEditRunAutoRequest:
+    edit_session_id: str
+    command_id: str
+    base_revision: int
+    request: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class FloorplanEditValidateRequest:
+    edit_session_id: str
+    scope: str = "all"
+
+
 class RequestValidationError(ValueError):
     def __init__(self, reason: str):
         super().__init__(reason)

--- a/chipcompiler/runtime/sessions.py
+++ b/chipcompiler/runtime/sessions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -13,7 +14,25 @@ class WorkspaceSession:
     directory: Path
     workspace: Any
     db_handle: Any = None
+    layout_edit_session: LayoutEditSession | None = None
     mutation_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+@dataclass
+class LayoutEditSession:
+    edit_session_id: str
+    workspace_id: str
+    step_name: str
+    workspace_step: Any
+    db_handle: Any
+    source_kind: str
+    source_paths: tuple[Path, ...]
+    source_fingerprint: str
+    geometry_output_dir: Path
+    revision: int = 0
+    geometry_revision: int = 0
+    dirty: bool = False
+    command_results: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 class WorkspaceSessionNotFound(KeyError):
@@ -65,6 +84,7 @@ class WorkspaceSessionRegistry:
         with self._lock:
             for session in self._sessions.values():
                 self._release_session_db(session)
+                self._release_layout_edit_session(session)
             self._sessions.clear()
             self._sessions_by_directory.clear()
 
@@ -88,6 +108,7 @@ class WorkspaceSessionRegistry:
         if session is None:
             raise WorkspaceSessionNotFound(workspace_id)
         self._release_session_db(session)
+        self._release_layout_edit_session(session)
         self._sessions_by_directory.pop(session.directory, None)
 
     def _release_session_db(self, session: WorkspaceSession) -> bool:
@@ -99,3 +120,27 @@ class WorkspaceSessionRegistry:
         if self._db_releaser is not None:
             self._db_releaser(db_handle)
         return True
+
+    def release_layout_edit_session(self, session: WorkspaceSession) -> bool:
+        return self._release_layout_edit_session(session)
+
+    def _release_layout_edit_session(self, session: WorkspaceSession) -> bool:
+        layout_edit_session = session.layout_edit_session
+        if layout_edit_session is None:
+            return False
+
+        session.layout_edit_session = None
+        _reset_layout_edit_geometry_session(layout_edit_session.db_handle)
+        if self._db_releaser is not None:
+            self._db_releaser(layout_edit_session.db_handle)
+        shutil.rmtree(layout_edit_session.geometry_output_dir.parent, ignore_errors=True)
+        return True
+
+
+def _reset_layout_edit_geometry_session(db_handle: Any) -> None:
+    module = getattr(db_handle, "engine", None)
+    if module is None:
+        module = getattr(db_handle, "ecc_module", None)
+    reset_geometry_session = getattr(module, "reset_geometry_session", None)
+    if callable(reset_geometry_session):
+        reset_geometry_session()

--- a/chipcompiler/runtime/sessions.py
+++ b/chipcompiler/runtime/sessions.py
@@ -33,6 +33,13 @@ class LayoutEditSession:
     geometry_revision: int = 0
     dirty: bool = False
     command_results: dict[str, dict[str, Any]] = field(default_factory=dict)
+    floorplan_plan: dict[str, Any] = field(default_factory=dict)
+    pdn_plan: dict[str, Any] = field(default_factory=dict)
+    config_patch: dict[str, Any] = field(default_factory=dict)
+    parameters_patch: dict[str, Any] = field(default_factory=dict)
+    requires_verilog: bool = False
+    used_floorplan_editor: bool = False
+    validation_diagnostics: list[dict[str, Any]] = field(default_factory=list)
 
 
 class WorkspaceSessionNotFound(KeyError):

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -547,7 +547,9 @@ class WorkspaceRuntimeApi:
                 )
 
             artifacts = _publish_layout_edit_artifacts(edit_session, session.workspace)
-            output_db = _path_or_none(_workspace_step_output_value(edit_session.workspace_step, "db"))
+            output_db = _path_or_none(
+                _workspace_step_output_value(edit_session.workspace_step, "db")
+            )
             if output_db is None:
                 raise RuntimeApiError("command_failed", "layout edit output DB is missing")
             edit_session.source_kind = "db"

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
+import shutil
 import tempfile
 from collections.abc import Callable
+from copy import copy
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -12,6 +16,10 @@ from chipcompiler.runtime.requests import (
     DbReleaseRequest,
     FlowRunRequest,
     FlowRunStepRequest,
+    LayoutEditApplyRequest,
+    LayoutEditBeginRequest,
+    LayoutEditDiscardRequest,
+    LayoutEditSaveRequest,
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
@@ -21,6 +29,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceSyncConfigRequest,
 )
 from chipcompiler.runtime.sessions import (
+    LayoutEditSession,
     WorkspaceSession,
     WorkspaceSessionNotFound,
     WorkspaceSessionRegistry,
@@ -47,6 +56,8 @@ class WorkspaceRuntimeApi:
     ):
         self.persistent_db_enabled = persistent_db_enabled
         self.sessions = sessions or WorkspaceSessionRegistry(db_releaser=_close_db_handle)
+        self._next_layout_edit_id = 1
+        self._layout_edit_sessions: dict[str, LayoutEditSession] = {}
 
     def create_workspace(self, request: WorkspaceCreateRequest) -> dict:
         if not request.directory:
@@ -194,6 +205,7 @@ class WorkspaceRuntimeApi:
 
     def close_workspace(self, request: WorkspaceIdRequest) -> dict:
         def close(session: WorkspaceSession) -> dict:
+            self._discard_layout_edit_session(session)
             self.sessions.close_session(session.workspace_id)
             return {"ok": True}
 
@@ -333,6 +345,234 @@ class WorkspaceRuntimeApi:
 
         return self._with_session_mutation_lock(request.workspace_id, release)
 
+    def layout_edit_begin(self, request: LayoutEditBeginRequest) -> dict:
+        self._require_persistent_db()
+
+        def begin(session: WorkspaceSession) -> dict:
+            active_session = session.layout_edit_session
+            if active_session is not None:
+                if active_session.step_name != request.step:
+                    raise RuntimeApiError(
+                        "layout_edit_active",
+                        f"layout edit session already active for step: {active_session.step_name}",
+                        {"editSessionId": active_session.edit_session_id},
+                    )
+                if (
+                    request.expected_source_fingerprint
+                    and request.expected_source_fingerprint != active_session.source_fingerprint
+                ):
+                    raise RuntimeApiError(
+                        "source_changed",
+                        "layout edit source fingerprint does not match",
+                        {
+                            "expectedSourceFingerprint": request.expected_source_fingerprint,
+                            "actualSourceFingerprint": active_session.source_fingerprint,
+                        },
+                    )
+                return _layout_edit_begin_result(active_session, reused=True)
+
+            engine_flow = build_flow_for_workspace(session.workspace)
+            workspace_step = engine_flow.get_workspace_step(request.step)
+            if workspace_step is None:
+                raise RuntimeApiError("command_failed", f"step not found: {request.step}")
+
+            source_kind, source_paths = _layout_edit_source(workspace_step)
+            source_fingerprint = _artifact_fingerprint(source_paths)
+            if (
+                request.expected_source_fingerprint
+                and request.expected_source_fingerprint != source_fingerprint
+            ):
+                raise RuntimeApiError(
+                    "source_changed",
+                    "layout edit source fingerprint does not match",
+                    {
+                        "expectedSourceFingerprint": request.expected_source_fingerprint,
+                        "actualSourceFingerprint": source_fingerprint,
+                    },
+                )
+
+            edit_step = _layout_edit_workspace_step(
+                workspace_step,
+                source_kind=source_kind,
+                source_paths=source_paths,
+            )
+            initialized = _init_db_engine_for_workspace_step(engine_flow, edit_step)
+            db_handle = getattr(engine_flow, "engine_db", None)
+            if not initialized or not _db_handle_is_initialized(db_handle):
+                _close_db_handle(db_handle)
+                raise RuntimeApiError(
+                    "command_failed",
+                    f"failed to initialize layout edit DB for step: {request.step}",
+                )
+
+            module = _db_engine_module(db_handle)
+            initialize_geometry = getattr(module, "initialize_geometry_session", None)
+            if not callable(initialize_geometry) or not initialize_geometry():
+                _close_db_handle(db_handle)
+                raise RuntimeApiError(
+                    "command_failed",
+                    f"failed to initialize layout geometry for step: {request.step}",
+                )
+
+            edit_session_id = self._new_layout_edit_id()
+            geometry_output_dir = Path(
+                tempfile.mkdtemp(prefix=f"ecc-{edit_session_id}-geometry-")
+            ) / "geometry-0"
+            try:
+                _write_layout_edit_geometry_snapshot(module, geometry_output_dir)
+            except Exception:
+                _close_db_handle(db_handle)
+                shutil.rmtree(geometry_output_dir.parent, ignore_errors=True)
+                raise
+
+            edit_session = LayoutEditSession(
+                edit_session_id=edit_session_id,
+                workspace_id=session.workspace_id,
+                step_name=request.step,
+                workspace_step=workspace_step,
+                db_handle=db_handle,
+                source_kind=source_kind,
+                source_paths=source_paths,
+                source_fingerprint=source_fingerprint,
+                geometry_output_dir=geometry_output_dir,
+            )
+            session.layout_edit_session = edit_session
+            self._layout_edit_sessions[edit_session.edit_session_id] = edit_session
+            return _layout_edit_begin_result(edit_session, reused=False)
+
+        return self._with_session_mutation_lock(request.workspace_id, begin)
+
+    def layout_edit_apply(self, request: LayoutEditApplyRequest) -> dict:
+        def apply(session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            if not isinstance(request.command_id, str) or not request.command_id.strip():
+                raise RuntimeApiError("invalid_request", "missing required field: command_id")
+
+            previous_result = edit_session.command_results.get(request.command_id)
+            if previous_result is not None:
+                return previous_result
+
+            _validate_layout_edit_revision(request.base_revision, "base_revision")
+            if request.base_revision != edit_session.revision:
+                raise RuntimeApiError(
+                    "version_conflict",
+                    "layout edit revision does not match",
+                    {
+                        "expectedRevision": request.base_revision,
+                        "actualRevision": edit_session.revision,
+                    },
+                )
+
+            placement = _layout_edit_place_instance_operation(request.operation)
+            module = _db_engine_module(edit_session.db_handle)
+            place_instance = getattr(module, "place_instance", None)
+            if not callable(place_instance):
+                raise RuntimeApiError("command_failed", "place_instance is unavailable")
+
+            accepted = place_instance(
+                inst_name=placement["inst_name"],
+                llx=placement["llx"],
+                lly=placement["lly"],
+                orient=placement["orient"],
+                cellmaster=placement["cellmaster"],
+                source=placement["source"],
+                placement_status=placement["placement_status"],
+                create_if_missing=placement["create_if_missing"],
+            )
+            if not accepted:
+                raise RuntimeApiError(
+                    "placement_rejected",
+                    "place_instance rejected the requested placement",
+                    {"instanceName": placement["inst_name"]},
+                )
+
+            geometry_delta = _sync_layout_edit_instance_geometry(
+                module,
+                placement["inst_name"],
+            )
+            next_geometry_output_dir = (
+                edit_session.geometry_output_dir.parent
+                / f"geometry-{edit_session.geometry_revision + 1}"
+            )
+            geometry_manifest_path = _write_layout_edit_geometry_snapshot(
+                module,
+                next_geometry_output_dir,
+            )
+            previous_geometry_output_dir = edit_session.geometry_output_dir
+            edit_session.geometry_output_dir = next_geometry_output_dir
+            shutil.rmtree(previous_geometry_output_dir, ignore_errors=True)
+            edit_session.revision += 1
+            edit_session.geometry_revision += 1
+            edit_session.dirty = True
+            result = {
+                "editSessionId": edit_session.edit_session_id,
+                "commandId": request.command_id,
+                "revision": edit_session.revision,
+                "geometryRevision": edit_session.geometry_revision,
+                "geometryManifestPath": str(geometry_manifest_path),
+                "dirty": True,
+                "operation": {
+                    "kind": "place_instance",
+                    "instanceName": placement["inst_name"],
+                    "origin": {"x": placement["llx"], "y": placement["lly"]},
+                    "orient": placement["orient"],
+                },
+                "geometryDelta": geometry_delta,
+            }
+            edit_session.command_results[request.command_id] = result
+            return result
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, apply)
+
+    def layout_edit_save(self, request: LayoutEditSaveRequest) -> dict:
+        def save(session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            _validate_layout_edit_revision(request.expected_revision, "expected_revision")
+            if request.expected_revision != edit_session.revision:
+                raise RuntimeApiError(
+                    "version_conflict",
+                    "layout edit revision does not match",
+                    {
+                        "expectedRevision": request.expected_revision,
+                        "actualRevision": edit_session.revision,
+                    },
+                )
+            if not edit_session.dirty:
+                return _layout_edit_save_result(edit_session, saved=False)
+
+            current_fingerprint = _artifact_fingerprint(edit_session.source_paths)
+            if current_fingerprint != edit_session.source_fingerprint:
+                raise RuntimeApiError(
+                    "source_changed",
+                    "layout edit source changed after the session began",
+                    {
+                        "expectedSourceFingerprint": edit_session.source_fingerprint,
+                        "actualSourceFingerprint": current_fingerprint,
+                    },
+                )
+
+            _publish_layout_edit_artifacts(edit_session)
+            output_db = _path_or_none(_workspace_step_output_value(edit_session.workspace_step, "db"))
+            if output_db is None:
+                raise RuntimeApiError("command_failed", "layout edit output DB is missing")
+            edit_session.source_kind = "db"
+            edit_session.source_paths = (output_db,)
+            edit_session.source_fingerprint = _artifact_fingerprint(edit_session.source_paths)
+            edit_session.dirty = False
+            return _layout_edit_save_result(edit_session, saved=True)
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, save)
+
+    def layout_edit_discard(self, request: LayoutEditDiscardRequest) -> dict:
+        def discard(session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            dirty = edit_session.dirty
+            self._discard_layout_edit_session(session)
+            return {
+                "editSessionId": request.edit_session_id,
+                "discarded": True,
+                "dirty": dirty,
+            }
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, discard)
+
     def _load_workspace(self, directory: str):
         if not directory:
             raise RuntimeApiError("invalid_request", "missing required field: directory")
@@ -358,6 +598,41 @@ class WorkspaceRuntimeApi:
     def _require_persistent_db(self) -> None:
         if not self.persistent_db_enabled:
             raise RuntimeApiError("command_failed", "persistent_db_disabled")
+
+    def _new_layout_edit_id(self) -> str:
+        edit_session_id = f"layout-edit-{self._next_layout_edit_id}"
+        self._next_layout_edit_id += 1
+        return edit_session_id
+
+    def _with_layout_edit_session_mutation_lock(
+        self,
+        edit_session_id: str,
+        operation: Callable[[WorkspaceSession, LayoutEditSession], _T],
+    ) -> _T:
+        edit_session = self._layout_edit_sessions.get(edit_session_id)
+        if edit_session is None:
+            raise RuntimeApiError(
+                "layout_edit_session_not_found",
+                f"layout edit session not found: {edit_session_id}",
+            )
+
+        def run(session: WorkspaceSession) -> _T:
+            if session.layout_edit_session is not edit_session:
+                self._layout_edit_sessions.pop(edit_session_id, None)
+                raise RuntimeApiError(
+                    "layout_edit_session_not_found",
+                    f"layout edit session not found: {edit_session_id}",
+                )
+            return operation(session, edit_session)
+
+        return self._with_session_mutation_lock(edit_session.workspace_id, run)
+
+    def _discard_layout_edit_session(self, session: WorkspaceSession) -> bool:
+        edit_session = session.layout_edit_session
+        if edit_session is None:
+            return False
+        self._layout_edit_sessions.pop(edit_session.edit_session_id, None)
+        return self.sessions.release_layout_edit_session(session)
 
     def _release_session_db(self, session: WorkspaceSession) -> bool:
         return self.sessions.release_session_db(session)
@@ -415,6 +690,404 @@ class WorkspaceRuntimeApi:
         import chipcompiler.data as data_api
 
         data_api.prepare_workspace_for_rerun(workspace, engine_flow)
+
+
+def _layout_edit_begin_result(edit_session: LayoutEditSession, *, reused: bool) -> dict:
+    return {
+        "editSessionId": edit_session.edit_session_id,
+        "workspaceId": edit_session.workspace_id,
+        "step": edit_session.step_name,
+        "source": edit_session.source_kind,
+        "sourceFingerprint": edit_session.source_fingerprint,
+        "geometryManifestPath": str(edit_session.geometry_output_dir / "geometry.manifest"),
+        "revision": edit_session.revision,
+        "geometryRevision": edit_session.geometry_revision,
+        "dirty": edit_session.dirty,
+        "reused": reused,
+    }
+
+
+def _layout_edit_save_result(edit_session: LayoutEditSession, *, saved: bool) -> dict:
+    artifacts = _layout_edit_published_artifacts(edit_session.workspace_step)
+    return {
+        "editSessionId": edit_session.edit_session_id,
+        "revision": edit_session.revision,
+        "geometryRevision": edit_session.geometry_revision,
+        "dirty": edit_session.dirty,
+        "saved": saved,
+        "sourceFingerprint": edit_session.source_fingerprint,
+        "artifacts": artifacts,
+    }
+
+
+def _layout_edit_published_artifacts(workspace_step) -> dict:
+    geometry_dir = _path_or_none(_workspace_step_output_value(workspace_step, "geometry"))
+    geometry_manifest = _path_or_none(
+        _workspace_step_output_value(workspace_step, "geometry_manifest")
+    )
+    if geometry_manifest is None and geometry_dir is not None:
+        geometry_manifest = geometry_dir / "geometry.manifest"
+    return {
+        "defPath": _path_text(_workspace_step_output_value(workspace_step, "def")),
+        "dbPath": _path_text(_workspace_step_output_value(workspace_step, "db")),
+        "gdsPath": _path_text(_workspace_step_output_value(workspace_step, "gds")),
+        "geometryManifestPath": str(geometry_manifest) if geometry_manifest else "",
+    }
+
+
+def _layout_edit_source(workspace_step) -> tuple[str, tuple[Path, ...]]:
+    output_db = _path_or_none(_workspace_step_output_value(workspace_step, "db"))
+    if output_db is not None and output_db.is_dir():
+        return "db", (output_db,)
+
+    output_def = _existing_layout_def_path(_workspace_step_output_value(workspace_step, "def"))
+    if output_def is not None:
+        return "def", (output_def,)
+
+    raise RuntimeApiError(
+        "command_failed",
+        f"layout edit source missing for step: {getattr(workspace_step, 'name', '')}",
+    )
+
+
+def _layout_edit_workspace_step(
+    workspace_step,
+    *,
+    source_kind: str,
+    source_paths: tuple[Path, ...],
+):
+    edit_input = copy(getattr(workspace_step, "input", {}))
+    output_def = _existing_layout_def_path(_workspace_step_output_value(workspace_step, "def"))
+    if isinstance(edit_input, dict):
+        edit_input["db"] = source_paths[0] if source_kind == "db" else None
+        edit_input["def"] = output_def
+        edit_step = copy(workspace_step)
+        edit_step.input = edit_input
+        return edit_step
+
+    edit_input.db = source_paths[0] if source_kind == "db" else None
+    edit_input.def_ = output_def
+    return replace(workspace_step, input=edit_input)
+
+
+def _layout_edit_place_instance_operation(operation: object) -> dict[str, Any]:
+    if not isinstance(operation, dict):
+        raise RuntimeApiError("invalid_request", "operation must be an object")
+    if operation.get("kind") != "place_instance":
+        raise RuntimeApiError("invalid_request", "unsupported layout edit operation")
+
+    inst_name = _layout_edit_text(operation, "inst_name", "instName")
+    cellmaster = _layout_edit_optional_text(operation, "cellmaster", "cellMaster")
+    source = _layout_edit_optional_text(operation, "source")
+    placement_status = _layout_edit_optional_text(
+        operation,
+        "placement_status",
+        "placementStatus",
+    ) or "preserve"
+    create_if_missing = _layout_edit_optional_bool(
+        operation,
+        "create_if_missing",
+        "createIfMissing",
+        default=False,
+    )
+    orient = _layout_edit_optional_text(operation, "orient")
+    if not orient and (placement_status != "preserve" or create_if_missing):
+        raise RuntimeApiError("invalid_request", "missing required operation field: orient")
+    return {
+        "inst_name": inst_name,
+        "llx": _layout_edit_integer(operation, "llx"),
+        "lly": _layout_edit_integer(operation, "lly"),
+        "orient": orient,
+        "cellmaster": cellmaster,
+        "source": source,
+        "placement_status": placement_status,
+        "create_if_missing": create_if_missing,
+    }
+
+
+def _layout_edit_text(operation: dict, *keys: str) -> str:
+    value = _layout_edit_value(operation, *keys)
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeApiError("invalid_request", f"missing required operation field: {keys[0]}")
+    return value
+
+
+def _layout_edit_optional_text(operation: dict, *keys: str) -> str:
+    value = _layout_edit_value(operation, *keys, default="")
+    if not isinstance(value, str):
+        raise RuntimeApiError("invalid_request", f"operation field must be a string: {keys[0]}")
+    return value
+
+
+def _layout_edit_integer(operation: dict, *keys: str) -> int:
+    value = _layout_edit_value(operation, *keys)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RuntimeApiError("invalid_request", f"operation field must be an integer: {keys[0]}")
+    return value
+
+
+def _layout_edit_optional_bool(
+    operation: dict,
+    *keys: str,
+    default: bool,
+) -> bool:
+    value = _layout_edit_value(operation, *keys, default=default)
+    if not isinstance(value, bool):
+        raise RuntimeApiError("invalid_request", f"operation field must be a boolean: {keys[0]}")
+    return value
+
+
+def _layout_edit_value(operation: dict, *keys: str, default: object = None):
+    present = [key for key in keys if key in operation]
+    if len(present) > 1:
+        raise RuntimeApiError("invalid_request", f"duplicate operation field: {keys[0]}")
+    return operation[present[0]] if present else default
+
+
+def _validate_layout_edit_revision(value: object, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise RuntimeApiError("invalid_request", f"{field_name} must be a non-negative integer")
+
+
+def _sync_layout_edit_instance_geometry(module, inst_name: str) -> dict:
+    sync_instance = getattr(module, "sync_instance_geometry", None)
+    if not callable(sync_instance):
+        return {
+            "ok": False,
+            "snapshotRequired": True,
+            "updatedShapeCount": 0,
+            "insertedShapeCount": 0,
+            "deletedShapeCount": 0,
+            "missingShapeCount": 0,
+            "events": [],
+        }
+
+    result = sync_instance(inst_name)
+    if not isinstance(result, dict):
+        return {
+            "ok": False,
+            "snapshotRequired": True,
+            "updatedShapeCount": 0,
+            "insertedShapeCount": 0,
+            "deletedShapeCount": 0,
+            "missingShapeCount": 0,
+            "events": [],
+        }
+    return {
+        "ok": bool(result.get("ok", False)),
+        "snapshotRequired": bool(result.get("snapshotRequired", False)),
+        "updatedShapeCount": _geometry_delta_count(result, "updatedShapeCount"),
+        "insertedShapeCount": _geometry_delta_count(result, "insertedShapeCount"),
+        "deletedShapeCount": _geometry_delta_count(result, "deletedShapeCount"),
+        "missingShapeCount": _geometry_delta_count(result, "missingShapeCount"),
+        "events": result.get("events", []) if isinstance(result.get("events", []), list) else [],
+    }
+
+
+def _write_layout_edit_geometry_snapshot(module, output_dir: Path) -> Path:
+    save_snapshot = getattr(module, "geometry_session_snapshot_save", None)
+    if not callable(save_snapshot):
+        save_snapshot = getattr(module, "geometry_snapshot_save", None)
+    if not callable(save_snapshot) or not save_snapshot(output_dir=str(output_dir)):
+        raise RuntimeApiError("command_failed", "failed to write layout edit geometry snapshot")
+    manifest = output_dir / "geometry.manifest"
+    if not manifest.is_file():
+        raise RuntimeApiError("command_failed", "layout edit geometry manifest is missing")
+    return manifest
+
+
+def _geometry_delta_count(delta: dict, key: str) -> int:
+    value = delta.get(key, 0)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _publish_layout_edit_artifacts(edit_session: LayoutEditSession) -> None:
+    targets = _layout_edit_publish_targets(edit_session.workspace_step)
+    stage_parent = _layout_edit_stage_parent(targets.values())
+    stage_root = Path(
+        tempfile.mkdtemp(prefix=f".layout-edit-{edit_session.edit_session_id}-", dir=stage_parent)
+    )
+    staged = {
+        "def": stage_root / targets["def"].name,
+        "db": stage_root / targets["db"].name,
+        "gds": stage_root / targets["gds"].name,
+        "geometry": stage_root / targets["geometry"].name,
+    }
+    try:
+        module = _db_engine_module(edit_session.db_handle)
+        module.def_save(def_path=str(staged["def"]))
+        module.save_data(path=str(staged["db"]))
+        module.gds_save(output_path=str(staged["gds"]))
+        if not module.geometry_snapshot_save(output_dir=str(staged["geometry"])):
+            raise RuntimeApiError("command_failed", "failed to export layout geometry snapshot")
+        _validate_layout_edit_staging(staged, targets)
+        _publish_staged_layout_edit_artifacts(stage_root, staged, targets)
+    except RuntimeApiError:
+        raise
+    except Exception as exc:
+        raise RuntimeApiError("command_failed", f"failed to publish layout edit: {exc}") from exc
+    finally:
+        shutil.rmtree(stage_root, ignore_errors=True)
+
+
+def _layout_edit_publish_targets(workspace_step) -> dict[str, Path]:
+    targets = {
+        key: _path_or_none(_workspace_step_output_value(workspace_step, key))
+        for key in ("def", "db", "gds", "geometry")
+    }
+    missing = [key for key, path in targets.items() if path is None]
+    if missing:
+        raise RuntimeApiError(
+            "command_failed",
+            f"layout edit output paths missing: {', '.join(missing)}",
+        )
+    return targets
+
+
+def _layout_edit_stage_parent(paths) -> Path:
+    parents = [str(path.parent) for path in paths]
+    common_parent = Path(os.path.commonpath(parents))
+    common_parent.mkdir(parents=True, exist_ok=True)
+    return common_parent
+
+
+def _validate_layout_edit_staging(staged: dict[str, Path], targets: dict[str, Path]) -> None:
+    manifest = _geometry_manifest_path(staged["geometry"], targets["geometry"], targets)
+    missing = []
+    if not staged["def"].is_file():
+        missing.append("def")
+    if not staged["gds"].is_file():
+        missing.append("gds")
+    if not staged["db"].is_dir() or not any(staged["db"].iterdir()):
+        missing.append("db")
+    if not manifest.is_file():
+        missing.append("geometry_manifest")
+    if missing:
+        raise RuntimeApiError(
+            "command_failed",
+            f"layout edit staging validation failed: {', '.join(missing)}",
+        )
+
+
+def _geometry_manifest_path(
+    geometry_dir: Path,
+    target_geometry_dir: Path,
+    targets: dict[str, Path],
+) -> Path:
+    target_manifest = targets.get("geometry_manifest")
+    if target_manifest is None:
+        return geometry_dir / "geometry.manifest"
+    try:
+        return geometry_dir / target_manifest.relative_to(target_geometry_dir)
+    except ValueError:
+        return geometry_dir / "geometry.manifest"
+
+
+def _publish_staged_layout_edit_artifacts(
+    stage_root: Path,
+    staged: dict[str, Path],
+    targets: dict[str, Path],
+) -> None:
+    artifact_keys = ("def", "db", "gds", "geometry")
+    backup_dir = stage_root / "backup"
+    backup_dir.mkdir()
+    journal_path = stage_root / "publish.journal"
+    journal_path.write_text(
+        json.dumps({"state": "prepared", "artifacts": artifact_keys}),
+        encoding="utf-8",
+    )
+    backups: list[str] = []
+    published: list[str] = []
+    try:
+        for key in artifact_keys:
+            target = targets[key]
+            if target.exists() or target.is_symlink():
+                os.replace(target, backup_dir / key)
+                backups.append(key)
+        journal_path.write_text(
+            json.dumps({"state": "backed_up", "artifacts": backups}),
+            encoding="utf-8",
+        )
+        for key in artifact_keys:
+            target = targets[key]
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(staged[key], target)
+            published.append(key)
+        journal_path.write_text(
+            json.dumps({"state": "published", "artifacts": published}),
+            encoding="utf-8",
+        )
+    except Exception:
+        for key in reversed(published):
+            _remove_layout_edit_path(targets[key])
+        for key in reversed(backups):
+            os.replace(backup_dir / key, targets[key])
+        raise
+
+
+def _remove_layout_edit_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _db_engine_module(db_handle):
+    module = getattr(db_handle, "engine", None)
+    if module is None:
+        module = getattr(db_handle, "ecc_module", None)
+    if module is None:
+        raise RuntimeApiError("command_failed", "layout edit DB module is unavailable")
+    return module
+
+
+def _path_or_none(value: object) -> Path | None:
+    if value is None or value == "":
+        return None
+    return Path(value)
+
+
+def _workspace_step_output_value(workspace_step, key: str):
+    output = getattr(workspace_step, "output", {})
+    if isinstance(output, dict):
+        return output.get(key)
+    return getattr(output, "def_" if key == "def" else key, None)
+
+
+def _path_text(value: object) -> str:
+    path = _path_or_none(value)
+    return str(path) if path is not None else ""
+
+
+def _existing_layout_def_path(value: object) -> Path | None:
+    path = _path_or_none(value)
+    if path is None:
+        return None
+    candidates = (path, Path(f"{path}.gz"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _artifact_fingerprint(paths: tuple[Path, ...]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        resolved_path = path.resolve()
+        digest.update(str(resolved_path).encode("utf-8"))
+        if resolved_path.is_dir():
+            for item in sorted(resolved_path.rglob("*")):
+                if not item.is_file():
+                    continue
+                stat = item.stat()
+                digest.update(str(item.relative_to(resolved_path)).encode("utf-8"))
+                digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode("ascii"))
+        elif resolved_path.is_file():
+            stat = resolved_path.stat()
+            digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode("ascii"))
+        else:
+            digest.update(b"missing")
+    return digest.hexdigest()
 
 
 def build_flow_for_workspace(workspace, *, create_step_workspaces: bool = True):

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import tempfile
+import threading
 from collections.abc import Callable
 from copy import copy, deepcopy
 from dataclasses import replace
@@ -62,6 +63,11 @@ class WorkspaceRuntimeApi:
         self.sessions = sessions or WorkspaceSessionRegistry(db_releaser=_close_db_handle)
         self._next_layout_edit_id = 1
         self._layout_edit_sessions: dict[str, LayoutEditSession] = {}
+        # ecc_tools_bin currently owns one process-global GeometryEditSession.
+        # Keep its native DB and derived GeometryStore exclusive until that
+        # session is reset, so a second workspace cannot replace the store
+        # underneath an active editor.
+        self._layout_edit_lock = threading.RLock()
 
     def create_workspace(self, request: WorkspaceCreateRequest) -> dict:
         if not request.directory:
@@ -353,96 +359,109 @@ class WorkspaceRuntimeApi:
         self._require_persistent_db()
 
         def begin(session: WorkspaceSession) -> dict:
-            active_session = session.layout_edit_session
-            if active_session is not None:
-                if active_session.step_name != request.step:
+            with self._layout_edit_lock:
+                active_session = session.layout_edit_session
+                if active_session is not None:
+                    if active_session.step_name != request.step:
+                        raise RuntimeApiError(
+                            "layout_edit_active",
+                            "layout edit session already active for step: "
+                            f"{active_session.step_name}",
+                            {"editSessionId": active_session.edit_session_id},
+                        )
+                    if (
+                        request.expected_source_fingerprint
+                        and request.expected_source_fingerprint != active_session.source_fingerprint
+                    ):
+                        raise RuntimeApiError(
+                            "source_changed",
+                            "layout edit source fingerprint does not match",
+                            {
+                                "expectedSourceFingerprint": request.expected_source_fingerprint,
+                                "actualSourceFingerprint": active_session.source_fingerprint,
+                            },
+                        )
+                    return _layout_edit_begin_result(active_session, reused=True)
+
+                active_session = next(iter(self._layout_edit_sessions.values()), None)
+                if active_session is not None:
                     raise RuntimeApiError(
                         "layout_edit_active",
-                        f"layout edit session already active for step: {active_session.step_name}",
-                        {"editSessionId": active_session.edit_session_id},
+                        "layout edit session already active for another workspace",
+                        {
+                            "editSessionId": active_session.edit_session_id,
+                            "workspaceId": active_session.workspace_id,
+                        },
                     )
+
+                engine_flow = build_flow_for_workspace(session.workspace)
+                workspace_step = engine_flow.get_workspace_step(request.step)
+                if workspace_step is None:
+                    raise RuntimeApiError("command_failed", f"step not found: {request.step}")
+
+                source_kind, source_paths = _layout_edit_source(workspace_step)
+                source_fingerprint = _artifact_fingerprint(source_paths)
                 if (
                     request.expected_source_fingerprint
-                    and request.expected_source_fingerprint != active_session.source_fingerprint
+                    and request.expected_source_fingerprint != source_fingerprint
                 ):
                     raise RuntimeApiError(
                         "source_changed",
                         "layout edit source fingerprint does not match",
                         {
                             "expectedSourceFingerprint": request.expected_source_fingerprint,
-                            "actualSourceFingerprint": active_session.source_fingerprint,
+                            "actualSourceFingerprint": source_fingerprint,
                         },
                     )
-                return _layout_edit_begin_result(active_session, reused=True)
 
-            engine_flow = build_flow_for_workspace(session.workspace)
-            workspace_step = engine_flow.get_workspace_step(request.step)
-            if workspace_step is None:
-                raise RuntimeApiError("command_failed", f"step not found: {request.step}")
-
-            source_kind, source_paths = _layout_edit_source(workspace_step)
-            source_fingerprint = _artifact_fingerprint(source_paths)
-            if (
-                request.expected_source_fingerprint
-                and request.expected_source_fingerprint != source_fingerprint
-            ):
-                raise RuntimeApiError(
-                    "source_changed",
-                    "layout edit source fingerprint does not match",
-                    {
-                        "expectedSourceFingerprint": request.expected_source_fingerprint,
-                        "actualSourceFingerprint": source_fingerprint,
-                    },
+                edit_step = _layout_edit_workspace_step(
+                    workspace_step,
+                    source_kind=source_kind,
+                    source_paths=source_paths,
                 )
+                initialized = _init_db_engine_for_workspace_step(engine_flow, edit_step)
+                db_handle = getattr(engine_flow, "engine_db", None)
+                if not initialized or not _db_handle_is_initialized(db_handle):
+                    _close_db_handle(db_handle)
+                    raise RuntimeApiError(
+                        "command_failed",
+                        f"failed to initialize layout edit DB for step: {request.step}",
+                    )
 
-            edit_step = _layout_edit_workspace_step(
-                workspace_step,
-                source_kind=source_kind,
-                source_paths=source_paths,
-            )
-            initialized = _init_db_engine_for_workspace_step(engine_flow, edit_step)
-            db_handle = getattr(engine_flow, "engine_db", None)
-            if not initialized or not _db_handle_is_initialized(db_handle):
-                _close_db_handle(db_handle)
-                raise RuntimeApiError(
-                    "command_failed",
-                    f"failed to initialize layout edit DB for step: {request.step}",
+                module = _db_engine_module(db_handle)
+                initialize_geometry = getattr(module, "initialize_geometry_session", None)
+                if not callable(initialize_geometry) or not initialize_geometry():
+                    _close_db_handle(db_handle)
+                    raise RuntimeApiError(
+                        "command_failed",
+                        f"failed to initialize layout geometry for step: {request.step}",
+                    )
+
+                edit_session_id = self._new_layout_edit_id()
+                geometry_output_dir = (
+                    Path(tempfile.mkdtemp(prefix=f"ecc-{edit_session_id}-geometry-")) / "geometry-0"
                 )
+                try:
+                    _write_layout_edit_geometry_snapshot(module, geometry_output_dir)
+                except Exception:
+                    _close_db_handle(db_handle)
+                    shutil.rmtree(geometry_output_dir.parent, ignore_errors=True)
+                    raise
 
-            module = _db_engine_module(db_handle)
-            initialize_geometry = getattr(module, "initialize_geometry_session", None)
-            if not callable(initialize_geometry) or not initialize_geometry():
-                _close_db_handle(db_handle)
-                raise RuntimeApiError(
-                    "command_failed",
-                    f"failed to initialize layout geometry for step: {request.step}",
+                edit_session = LayoutEditSession(
+                    edit_session_id=edit_session_id,
+                    workspace_id=session.workspace_id,
+                    step_name=request.step,
+                    workspace_step=workspace_step,
+                    db_handle=db_handle,
+                    source_kind=source_kind,
+                    source_paths=source_paths,
+                    source_fingerprint=source_fingerprint,
+                    geometry_output_dir=geometry_output_dir,
                 )
-
-            edit_session_id = self._new_layout_edit_id()
-            geometry_output_dir = (
-                Path(tempfile.mkdtemp(prefix=f"ecc-{edit_session_id}-geometry-")) / "geometry-0"
-            )
-            try:
-                _write_layout_edit_geometry_snapshot(module, geometry_output_dir)
-            except Exception:
-                _close_db_handle(db_handle)
-                shutil.rmtree(geometry_output_dir.parent, ignore_errors=True)
-                raise
-
-            edit_session = LayoutEditSession(
-                edit_session_id=edit_session_id,
-                workspace_id=session.workspace_id,
-                step_name=request.step,
-                workspace_step=workspace_step,
-                db_handle=db_handle,
-                source_kind=source_kind,
-                source_paths=source_paths,
-                source_fingerprint=source_fingerprint,
-                geometry_output_dir=geometry_output_dir,
-            )
-            session.layout_edit_session = edit_session
-            self._layout_edit_sessions[edit_session.edit_session_id] = edit_session
-            return _layout_edit_begin_result(edit_session, reused=False)
+                session.layout_edit_session = edit_session
+                self._layout_edit_sessions[edit_session.edit_session_id] = edit_session
+                return _layout_edit_begin_result(edit_session, reused=False)
 
         return self._with_session_mutation_lock(request.workspace_id, begin)
 
@@ -627,11 +646,12 @@ class WorkspaceRuntimeApi:
         return self._with_session_mutation_lock(edit_session.workspace_id, run)
 
     def _discard_layout_edit_session(self, session: WorkspaceSession) -> bool:
-        edit_session = session.layout_edit_session
-        if edit_session is None:
-            return False
-        self._layout_edit_sessions.pop(edit_session.edit_session_id, None)
-        return self.sessions.release_layout_edit_session(session)
+        with self._layout_edit_lock:
+            edit_session = session.layout_edit_session
+            if edit_session is None:
+                return False
+            self._layout_edit_sessions.pop(edit_session.edit_session_id, None)
+            return self.sessions.release_layout_edit_session(session)
 
     def _release_session_db(self, session: WorkspaceSession) -> bool:
         return self.sessions.release_session_db(session)

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import shutil
 import tempfile
 from collections.abc import Callable
-from copy import copy
+from copy import copy, deepcopy
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, TypeVar
@@ -14,6 +15,9 @@ from typing import Any, TypeVar
 from chipcompiler.runtime.requests import (
     DbEnsureRequest,
     DbReleaseRequest,
+    FloorplanEditInspectRequest,
+    FloorplanEditRunAutoRequest,
+    FloorplanEditValidateRequest,
     FlowRunRequest,
     FlowRunStepRequest,
     LayoutEditApplyRequest,
@@ -415,9 +419,9 @@ class WorkspaceRuntimeApi:
                 )
 
             edit_session_id = self._new_layout_edit_id()
-            geometry_output_dir = Path(
-                tempfile.mkdtemp(prefix=f"ecc-{edit_session_id}-geometry-")
-            ) / "geometry-0"
+            geometry_output_dir = (
+                Path(tempfile.mkdtemp(prefix=f"ecc-{edit_session_id}-geometry-")) / "geometry-0"
+            )
             try:
                 _write_layout_edit_geometry_snapshot(module, geometry_output_dir)
             except Exception:
@@ -444,84 +448,63 @@ class WorkspaceRuntimeApi:
 
     def layout_edit_apply(self, request: LayoutEditApplyRequest) -> dict:
         def apply(session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
-            if not isinstance(request.command_id, str) or not request.command_id.strip():
-                raise RuntimeApiError("invalid_request", "missing required field: command_id")
-
-            previous_result = edit_session.command_results.get(request.command_id)
-            if previous_result is not None:
-                return previous_result
-
-            _validate_layout_edit_revision(request.base_revision, "base_revision")
-            if request.base_revision != edit_session.revision:
-                raise RuntimeApiError(
-                    "version_conflict",
-                    "layout edit revision does not match",
-                    {
-                        "expectedRevision": request.base_revision,
-                        "actualRevision": edit_session.revision,
-                    },
-                )
-
-            placement = _layout_edit_place_instance_operation(request.operation)
-            module = _db_engine_module(edit_session.db_handle)
-            place_instance = getattr(module, "place_instance", None)
-            if not callable(place_instance):
-                raise RuntimeApiError("command_failed", "place_instance is unavailable")
-
-            accepted = place_instance(
-                inst_name=placement["inst_name"],
-                llx=placement["llx"],
-                lly=placement["lly"],
-                orient=placement["orient"],
-                cellmaster=placement["cellmaster"],
-                source=placement["source"],
-                placement_status=placement["placement_status"],
-                create_if_missing=placement["create_if_missing"],
+            return _apply_layout_edit_operation(
+                edit_session,
+                command_id=request.command_id,
+                base_revision=request.base_revision,
+                operation=request.operation,
             )
-            if not accepted:
-                raise RuntimeApiError(
-                    "placement_rejected",
-                    "place_instance rejected the requested placement",
-                    {"instanceName": placement["inst_name"]},
-                )
-
-            geometry_delta = _sync_layout_edit_instance_geometry(
-                module,
-                placement["inst_name"],
-            )
-            next_geometry_output_dir = (
-                edit_session.geometry_output_dir.parent
-                / f"geometry-{edit_session.geometry_revision + 1}"
-            )
-            geometry_manifest_path = _write_layout_edit_geometry_snapshot(
-                module,
-                next_geometry_output_dir,
-            )
-            previous_geometry_output_dir = edit_session.geometry_output_dir
-            edit_session.geometry_output_dir = next_geometry_output_dir
-            shutil.rmtree(previous_geometry_output_dir, ignore_errors=True)
-            edit_session.revision += 1
-            edit_session.geometry_revision += 1
-            edit_session.dirty = True
-            result = {
-                "editSessionId": edit_session.edit_session_id,
-                "commandId": request.command_id,
-                "revision": edit_session.revision,
-                "geometryRevision": edit_session.geometry_revision,
-                "geometryManifestPath": str(geometry_manifest_path),
-                "dirty": True,
-                "operation": {
-                    "kind": "place_instance",
-                    "instanceName": placement["inst_name"],
-                    "origin": {"x": placement["llx"], "y": placement["lly"]},
-                    "orient": placement["orient"],
-                },
-                "geometryDelta": geometry_delta,
-            }
-            edit_session.command_results[request.command_id] = result
-            return result
 
         return self._with_layout_edit_session_mutation_lock(request.edit_session_id, apply)
+
+    def floorplan_edit_inspect(self, request: FloorplanEditInspectRequest) -> dict:
+        def inspect(_session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            module = _db_engine_module(edit_session.db_handle)
+            module_state = _floorplan_editor_inspect(module)
+            return {
+                "editSessionId": edit_session.edit_session_id,
+                "revision": edit_session.revision,
+                "geometryRevision": edit_session.geometry_revision,
+                "geometryManifestPath": str(edit_session.geometry_output_dir / "geometry.manifest"),
+                "dirty": edit_session.dirty,
+                "floorplanPlan": deepcopy(edit_session.floorplan_plan),
+                "pdnPlan": deepcopy(edit_session.pdn_plan),
+                "diagnostics": deepcopy(edit_session.validation_diagnostics),
+                "state": module_state,
+            }
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, inspect)
+
+    def floorplan_edit_run_auto(self, request: FloorplanEditRunAutoRequest) -> dict:
+        def run_auto(_session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            if not isinstance(request.request, dict):
+                raise RuntimeApiError("invalid_request", "request must be an object")
+            return _apply_layout_edit_operation(
+                edit_session,
+                command_id=request.command_id,
+                base_revision=request.base_revision,
+                operation={"kind": "run_auto", "request": request.request},
+            )
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, run_auto)
+
+    def floorplan_edit_validate(self, request: FloorplanEditValidateRequest) -> dict:
+        def validate(_session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
+            scope = request.scope.strip() if isinstance(request.scope, str) else ""
+            if not scope:
+                raise RuntimeApiError("invalid_request", "scope must be a non-empty string")
+            module = _db_engine_module(edit_session.db_handle)
+            result = _floorplan_editor_validate(module, scope)
+            edit_session.validation_diagnostics = _floorplan_diagnostics(result)
+            return {
+                "editSessionId": edit_session.edit_session_id,
+                "revision": edit_session.revision,
+                "scope": scope,
+                "valid": _floorplan_validation_ok(result),
+                "diagnostics": deepcopy(edit_session.validation_diagnostics),
+            }
+
+        return self._with_layout_edit_session_mutation_lock(request.edit_session_id, validate)
 
     def layout_edit_save(self, request: LayoutEditSaveRequest) -> dict:
         def save(session: WorkspaceSession, edit_session: LayoutEditSession) -> dict:
@@ -549,7 +532,21 @@ class WorkspaceRuntimeApi:
                     },
                 )
 
-            _publish_layout_edit_artifacts(edit_session)
+            module = _db_engine_module(edit_session.db_handle)
+            if edit_session.used_floorplan_editor:
+                validation = _floorplan_editor_validate(module, "all")
+                edit_session.validation_diagnostics = _floorplan_diagnostics(validation)
+                if not _floorplan_validation_ok(validation):
+                    raise RuntimeApiError(
+                        "floorplan_validation_failed",
+                        "floorplan edit validation failed",
+                        {"diagnostics": deepcopy(edit_session.validation_diagnostics)},
+                    )
+                _merge_floorplan_export_intent(
+                    edit_session, _floorplan_editor_export_intent(module)
+                )
+
+            artifacts = _publish_layout_edit_artifacts(edit_session, session.workspace)
             output_db = _path_or_none(_workspace_step_output_value(edit_session.workspace_step, "db"))
             if output_db is None:
                 raise RuntimeApiError("command_failed", "layout edit output DB is missing")
@@ -557,7 +554,7 @@ class WorkspaceRuntimeApi:
             edit_session.source_paths = (output_db,)
             edit_session.source_fingerprint = _artifact_fingerprint(edit_session.source_paths)
             edit_session.dirty = False
-            return _layout_edit_save_result(edit_session, saved=True)
+            return _layout_edit_save_result(edit_session, saved=True, artifacts=artifacts)
 
         return self._with_layout_edit_session_mutation_lock(request.edit_session_id, save)
 
@@ -707,8 +704,14 @@ def _layout_edit_begin_result(edit_session: LayoutEditSession, *, reused: bool) 
     }
 
 
-def _layout_edit_save_result(edit_session: LayoutEditSession, *, saved: bool) -> dict:
-    artifacts = _layout_edit_published_artifacts(edit_session.workspace_step)
+def _layout_edit_save_result(
+    edit_session: LayoutEditSession,
+    *,
+    saved: bool,
+    artifacts: dict[str, str] | None = None,
+) -> dict:
+    if artifacts is None:
+        artifacts = _layout_edit_published_artifacts(edit_session.workspace_step)
     return {
         "editSessionId": edit_session.edit_session_id,
         "revision": edit_session.revision,
@@ -770,6 +773,365 @@ def _layout_edit_workspace_step(
     return replace(workspace_step, input=edit_input)
 
 
+_FLOORPLAN_EDITOR_OPERATION_KINDS = frozenset(
+    {
+        "set_floorplan_outline",
+        "replace_tracks",
+        "upsert_io_pin_port",
+        "upsert_blockage",
+        "delete_blockage",
+        "upsert_instance_halo",
+        "delete_instance_halo",
+        "pdn.plan.patch",
+        "pdn.manual_segment.upsert",
+        "pdn.manual_segment.delete",
+        "pdn.manual_via.upsert",
+        "pdn.manual_via.delete",
+        "run_auto",
+    }
+)
+
+
+def _apply_layout_edit_operation(
+    edit_session: LayoutEditSession,
+    *,
+    command_id: object,
+    base_revision: object,
+    operation: object,
+) -> dict:
+    if not isinstance(command_id, str) or not command_id.strip():
+        raise RuntimeApiError("invalid_request", "missing required field: command_id")
+
+    previous_result = edit_session.command_results.get(command_id)
+    if previous_result is not None:
+        return previous_result
+
+    _validate_layout_edit_revision(base_revision, "base_revision")
+    if base_revision != edit_session.revision:
+        raise RuntimeApiError(
+            "version_conflict",
+            "layout edit revision does not match",
+            {
+                "expectedRevision": base_revision,
+                "actualRevision": edit_session.revision,
+            },
+        )
+    if not isinstance(operation, dict):
+        raise RuntimeApiError("invalid_request", "operation must be an object")
+
+    kind = operation.get("kind")
+    if kind == "place_instance":
+        result = _apply_layout_edit_place_instance(edit_session, command_id, operation)
+    else:
+        result = _apply_floorplan_editor_operation(edit_session, command_id, operation)
+    edit_session.command_results[command_id] = result
+    return result
+
+
+def _apply_layout_edit_place_instance(
+    edit_session: LayoutEditSession,
+    command_id: str,
+    operation: dict[str, Any],
+) -> dict:
+    placement = _layout_edit_place_instance_operation(operation)
+    module = _db_engine_module(edit_session.db_handle)
+    place_instance = getattr(module, "place_instance", None)
+    if not callable(place_instance):
+        raise RuntimeApiError("command_failed", "place_instance is unavailable")
+
+    accepted = place_instance(
+        inst_name=placement["inst_name"],
+        llx=placement["llx"],
+        lly=placement["lly"],
+        orient=placement["orient"],
+        cellmaster=placement["cellmaster"],
+        source=placement["source"],
+        placement_status=placement["placement_status"],
+        create_if_missing=placement["create_if_missing"],
+    )
+    if not accepted:
+        raise RuntimeApiError(
+            "placement_rejected",
+            "place_instance rejected the requested placement",
+            {"instanceName": placement["inst_name"]},
+        )
+
+    geometry_delta = _sync_layout_edit_instance_geometry(module, placement["inst_name"])
+    geometry_manifest_path = _advance_layout_edit_geometry_snapshot(edit_session, module)
+    edit_session.revision += 1
+    edit_session.geometry_revision += 1
+    edit_session.dirty = True
+    if placement["create_if_missing"]:
+        edit_session.requires_verilog = True
+    return {
+        "editSessionId": edit_session.edit_session_id,
+        "commandId": command_id,
+        "revision": edit_session.revision,
+        "geometryRevision": edit_session.geometry_revision,
+        "geometryManifestPath": str(geometry_manifest_path),
+        "dirty": True,
+        "operation": {
+            "kind": "place_instance",
+            "instanceName": placement["inst_name"],
+            "origin": {"x": placement["llx"], "y": placement["lly"]},
+            "orient": placement["orient"],
+        },
+        "geometryDelta": geometry_delta,
+    }
+
+
+def _apply_floorplan_editor_operation(
+    edit_session: LayoutEditSession,
+    command_id: str,
+    operation: dict[str, Any],
+) -> dict:
+    kind = operation.get("kind")
+    if not isinstance(kind, str) or kind not in _FLOORPLAN_EDITOR_OPERATION_KINDS:
+        raise RuntimeApiError("invalid_request", "unsupported layout edit operation")
+
+    module = _db_engine_module(edit_session.db_handle)
+    editor_result = _floorplan_editor_apply(module, operation)
+    if not _floorplan_editor_accepted(editor_result):
+        diagnostics = _floorplan_diagnostics(editor_result)
+        raise RuntimeApiError(
+            "floorplan_rejected",
+            "floorplan editor rejected the requested operation",
+            {"operationKind": kind, "diagnostics": diagnostics},
+        )
+
+    model_patch = _floorplan_model_patch(editor_result)
+    _merge_floorplan_model_patch(edit_session, model_patch)
+    diagnostics = _floorplan_diagnostics(editor_result)
+    edit_session.validation_diagnostics = diagnostics
+    changed = bool(editor_result.get("changed", True))
+    geometry_delta = _floorplan_geometry_delta(editor_result)
+    geometry_manifest_path = edit_session.geometry_output_dir / "geometry.manifest"
+    if changed:
+        geometry_manifest_path = _advance_layout_edit_geometry_snapshot(edit_session, module)
+        edit_session.revision += 1
+        edit_session.geometry_revision += 1
+        edit_session.dirty = True
+    edit_session.used_floorplan_editor = True
+    if _floorplan_bool(editor_result, "instancesChanged", "instances_changed") or _floorplan_bool(
+        model_patch,
+        "instancesChanged",
+        "instances_changed",
+    ):
+        edit_session.requires_verilog = True
+
+    return {
+        "editSessionId": edit_session.edit_session_id,
+        "commandId": command_id,
+        "revision": edit_session.revision,
+        "geometryRevision": edit_session.geometry_revision,
+        "geometryManifestPath": str(geometry_manifest_path),
+        "dirty": edit_session.dirty,
+        "operation": {"kind": kind},
+        "affectedRefs": _floorplan_affected_refs(editor_result),
+        "geometryDelta": geometry_delta,
+        "modelPatch": model_patch,
+        "diagnostics": diagnostics,
+        "changed": changed,
+    }
+
+
+def _advance_layout_edit_geometry_snapshot(edit_session: LayoutEditSession, module) -> Path:
+    next_geometry_output_dir = (
+        edit_session.geometry_output_dir.parent / f"geometry-{edit_session.geometry_revision + 1}"
+    )
+    geometry_manifest_path = _write_layout_edit_geometry_snapshot(module, next_geometry_output_dir)
+    previous_geometry_output_dir = edit_session.geometry_output_dir
+    edit_session.geometry_output_dir = next_geometry_output_dir
+    shutil.rmtree(previous_geometry_output_dir, ignore_errors=True)
+    return geometry_manifest_path
+
+
+def _floorplan_editor_apply(module, operation: dict[str, Any]) -> dict[str, Any]:
+    apply = getattr(module, "floorplan_editor_apply", None)
+    if not callable(apply):
+        apply = getattr(module, "floorplan_edit_apply", None)
+    if not callable(apply):
+        raise RuntimeApiError("command_failed", "floorplan editor is unavailable")
+    payload = deepcopy(operation)
+    result = _call_floorplan_editor_apply(apply, payload)
+    if not isinstance(result, dict):
+        raise RuntimeApiError("command_failed", "floorplan editor returned an invalid result")
+    return result
+
+
+def _call_floorplan_editor_apply(apply, payload: dict[str, Any]):
+    try:
+        signature = inspect.signature(apply)
+    except (TypeError, ValueError):
+        return apply(request=payload)
+
+    parameters = signature.parameters.values()
+    accepts_keyword_request = "request" in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    )
+    if accepts_keyword_request:
+        return apply(request=payload)
+    return apply(payload)
+
+
+def _floorplan_editor_inspect(module) -> dict[str, Any]:
+    inspect = getattr(module, "floorplan_editor_inspect", None)
+    if not callable(inspect):
+        inspect = getattr(module, "floorplan_edit_inspect", None)
+    if not callable(inspect):
+        return {}
+    result = inspect()
+    return deepcopy(result) if isinstance(result, dict) else {}
+
+
+def _floorplan_editor_validate(module, scope: str) -> dict[str, Any]:
+    validate = getattr(module, "floorplan_editor_validate", None)
+    if not callable(validate):
+        validate = getattr(module, "floorplan_validate", None)
+    if not callable(validate):
+        return {"ok": True, "diagnostics": []}
+    try:
+        result = validate(scope=scope)
+    except TypeError:
+        result = validate(scope)
+    if not isinstance(result, dict):
+        raise RuntimeApiError("command_failed", "floorplan validation returned an invalid result")
+    return result
+
+
+def _floorplan_editor_export_intent(module) -> dict[str, Any]:
+    export_intent = getattr(module, "floorplan_editor_export_intent", None)
+    if not callable(export_intent):
+        export_intent = getattr(module, "floorplan_export_intent", None)
+    if not callable(export_intent):
+        raise RuntimeApiError("command_failed", "floorplan editor export is unavailable")
+    result = export_intent()
+    if not isinstance(result, dict):
+        raise RuntimeApiError(
+            "command_failed", "floorplan editor export returned an invalid result"
+        )
+    if not _floorplan_editor_accepted(result):
+        raise RuntimeApiError(
+            "command_failed",
+            "floorplan editor failed to export edit intent",
+            {"diagnostics": _floorplan_diagnostics(result)},
+        )
+    return result
+
+
+def _floorplan_editor_accepted(result: dict[str, Any]) -> bool:
+    return bool(result.get("accepted", result.get("ok", False)))
+
+
+def _floorplan_validation_ok(result: dict[str, Any]) -> bool:
+    return bool(result.get("ok", result.get("accepted", False)))
+
+
+def _floorplan_diagnostics(result: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = result.get("diagnostics", [])
+    if not isinstance(raw, list):
+        return []
+    diagnostics = []
+    for item in raw:
+        if isinstance(item, dict):
+            diagnostics.append(deepcopy(item))
+        elif isinstance(item, str):
+            diagnostics.append({"message": item})
+    return diagnostics
+
+
+def _floorplan_affected_refs(result: dict[str, Any]) -> list[Any]:
+    refs = result.get("affectedRefs", result.get("affected_refs", []))
+    return deepcopy(refs) if isinstance(refs, list) else []
+
+
+def _floorplan_geometry_delta(result: dict[str, Any]) -> dict[str, Any]:
+    delta = result.get("geometryDelta", result.get("geometry_delta", {}))
+    if not isinstance(delta, dict):
+        delta = {}
+    return {
+        "ok": bool(delta.get("ok", True)),
+        "snapshotRequired": bool(
+            delta.get(
+                "snapshotRequired",
+                delta.get(
+                    "snapshot_required",
+                    result.get("snapshotRequired", result.get("snapshot_required", False)),
+                ),
+            )
+        ),
+        "updatedShapeCount": _geometry_delta_count(delta, "updatedShapeCount"),
+        "insertedShapeCount": _geometry_delta_count(delta, "insertedShapeCount"),
+        "deletedShapeCount": _geometry_delta_count(delta, "deletedShapeCount"),
+        "missingShapeCount": _geometry_delta_count(delta, "missingShapeCount"),
+        "events": deepcopy(delta.get("events", []))
+        if isinstance(delta.get("events", []), list)
+        else [],
+    }
+
+
+def _floorplan_model_patch(result: dict[str, Any]) -> dict[str, Any]:
+    patch = result.get("modelPatch", result.get("model_patch", {}))
+    if patch is None:
+        return {}
+    if not isinstance(patch, dict):
+        raise RuntimeApiError("command_failed", "floorplan editor returned an invalid model patch")
+    return deepcopy(patch)
+
+
+def _floorplan_bool(data: dict[str, Any], *keys: str) -> bool:
+    return any(bool(data.get(key, False)) for key in keys)
+
+
+def _merge_floorplan_model_patch(
+    edit_session: LayoutEditSession, model_patch: dict[str, Any]
+) -> None:
+    floorplan_plan = _floorplan_patch_mapping(model_patch, "floorplanPlan", "floorplan_plan")
+    pdn_plan = _floorplan_patch_mapping(model_patch, "pdnPlan", "pdn_plan")
+    config_patch = _floorplan_patch_mapping(model_patch, "configPatch", "config_patch")
+    parameters_patch = _floorplan_patch_mapping(
+        model_patch,
+        "parametersPatch",
+        "parameters_patch",
+    )
+    _deep_merge(edit_session.floorplan_plan, floorplan_plan)
+    _deep_merge(edit_session.pdn_plan, pdn_plan)
+    _deep_merge(edit_session.config_patch, config_patch)
+    _deep_merge(edit_session.parameters_patch, parameters_patch)
+
+
+def _merge_floorplan_export_intent(edit_session: LayoutEditSession, intent: dict[str, Any]) -> None:
+    nested_intent = intent.get("intent")
+    if isinstance(nested_intent, dict):
+        intent = nested_intent
+    _merge_floorplan_model_patch(edit_session, intent)
+    if _floorplan_bool(intent, "requiresVerilog", "requires_verilog"):
+        edit_session.requires_verilog = True
+
+
+def _floorplan_patch_mapping(data: dict[str, Any], *keys: str) -> dict[str, Any]:
+    present = [key for key in keys if key in data]
+    if len(present) > 1:
+        raise RuntimeApiError("command_failed", f"duplicate floorplan model patch field: {keys[0]}")
+    if not present:
+        return {}
+    value = data[present[0]]
+    if not isinstance(value, dict):
+        raise RuntimeApiError(
+            "command_failed", f"floorplan model patch field must be an object: {keys[0]}"
+        )
+    return deepcopy(value)
+
+
+def _deep_merge(target: dict[str, Any], patch: dict[str, Any]) -> None:
+    for key, value in patch.items():
+        current = target.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            _deep_merge(current, value)
+        else:
+            target[key] = deepcopy(value)
+
+
 def _layout_edit_place_instance_operation(operation: object) -> dict[str, Any]:
     if not isinstance(operation, dict):
         raise RuntimeApiError("invalid_request", "operation must be an object")
@@ -779,11 +1141,14 @@ def _layout_edit_place_instance_operation(operation: object) -> dict[str, Any]:
     inst_name = _layout_edit_text(operation, "inst_name", "instName")
     cellmaster = _layout_edit_optional_text(operation, "cellmaster", "cellMaster")
     source = _layout_edit_optional_text(operation, "source")
-    placement_status = _layout_edit_optional_text(
-        operation,
-        "placement_status",
-        "placementStatus",
-    ) or "preserve"
+    placement_status = (
+        _layout_edit_optional_text(
+            operation,
+            "placement_status",
+            "placementStatus",
+        )
+        or "preserve"
+    )
     create_if_missing = _layout_edit_optional_bool(
         operation,
         "create_if_missing",
@@ -901,26 +1266,28 @@ def _geometry_delta_count(delta: dict, key: str) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
-def _publish_layout_edit_artifacts(edit_session: LayoutEditSession) -> None:
+def _publish_layout_edit_artifacts(edit_session: LayoutEditSession, workspace) -> dict[str, str]:
     targets = _layout_edit_publish_targets(edit_session.workspace_step)
+    staged_workspace_data = _layout_edit_workspace_staging(edit_session, workspace)
+    targets.update(staged_workspace_data["targets"])
     stage_parent = _layout_edit_stage_parent(targets.values())
     stage_root = Path(
         tempfile.mkdtemp(prefix=f".layout-edit-{edit_session.edit_session_id}-", dir=stage_parent)
     )
-    staged = {
-        "def": stage_root / targets["def"].name,
-        "db": stage_root / targets["db"].name,
-        "gds": stage_root / targets["gds"].name,
-        "geometry": stage_root / targets["geometry"].name,
-    }
+    staged = {key: stage_root / key / target.name for key, target in targets.items()}
     try:
         module = _db_engine_module(edit_session.db_handle)
+        for staged_path in staged.values():
+            staged_path.parent.mkdir(parents=True, exist_ok=True)
         module.def_save(def_path=str(staged["def"]))
         module.save_data(path=str(staged["db"]))
         module.gds_save(output_path=str(staged["gds"]))
         if not module.geometry_snapshot_save(output_dir=str(staged["geometry"])):
             raise RuntimeApiError("command_failed", "failed to export layout geometry snapshot")
+        _stage_layout_edit_workspace_json(staged, staged_workspace_data)
+        _stage_layout_edit_verilog(module, staged, edit_session)
         _validate_layout_edit_staging(staged, targets)
+        _validate_layout_edit_workspace_staging(staged, staged_workspace_data)
         _publish_staged_layout_edit_artifacts(stage_root, staged, targets)
     except RuntimeApiError:
         raise
@@ -928,6 +1295,177 @@ def _publish_layout_edit_artifacts(edit_session: LayoutEditSession) -> None:
         raise RuntimeApiError("command_failed", f"failed to publish layout edit: {exc}") from exc
     finally:
         shutil.rmtree(stage_root, ignore_errors=True)
+
+    _apply_layout_edit_workspace_staging(workspace, staged_workspace_data)
+    artifacts = _layout_edit_published_artifacts(edit_session.workspace_step)
+    artifacts.update(staged_workspace_data["artifacts"])
+    return artifacts
+
+
+def _layout_edit_workspace_staging(
+    edit_session: LayoutEditSession,
+    workspace,
+) -> dict[str, Any]:
+    targets: dict[str, Path] = {}
+    json_data: dict[str, dict[str, Any]] = {}
+    artifacts: dict[str, str] = {}
+    result: dict[str, Any] = {
+        "targets": targets,
+        "json": json_data,
+        "artifacts": artifacts,
+        "parametersData": None,
+        "flowData": None,
+    }
+
+    if edit_session.used_floorplan_editor:
+        config_target = _floorplan_config_target(workspace)
+        config_data = _read_layout_edit_json(config_target)
+        _deep_merge(config_data, edit_session.config_patch)
+        config_data["FloorplanPlan"] = deepcopy(edit_session.floorplan_plan)
+        config_data["PdnPlan"] = deepcopy(edit_session.pdn_plan)
+        targets["config"] = config_target
+        json_data["config"] = config_data
+        artifacts["configPath"] = str(config_target)
+
+    if edit_session.parameters_patch:
+        parameter_target = _workspace_path(workspace, "parameters", "path")
+        if parameter_target is None:
+            raise RuntimeApiError("command_failed", "workspace parameters path is missing")
+        parameter_data = deepcopy(getattr(getattr(workspace, "parameters", None), "data", {}) or {})
+        if not isinstance(parameter_data, dict):
+            raise RuntimeApiError("command_failed", "workspace parameters are invalid")
+        _deep_merge(parameter_data, edit_session.parameters_patch)
+        targets["parameters"] = parameter_target
+        json_data["parameters"] = parameter_data
+        artifacts["parametersPath"] = str(parameter_target)
+        result["parametersData"] = parameter_data
+
+    if edit_session.requires_verilog:
+        verilog_target = _path_or_none(
+            _workspace_step_output_value(edit_session.workspace_step, "verilog")
+        )
+        if verilog_target is None:
+            raise RuntimeApiError("command_failed", "layout edit output Verilog is missing")
+        targets["verilog"] = verilog_target
+        artifacts["verilogPath"] = str(verilog_target)
+
+    flow_target = _workspace_path(workspace, "flow", "path")
+    flow_data = deepcopy(getattr(getattr(workspace, "flow", None), "data", {}) or {})
+    if (
+        flow_target is not None
+        and isinstance(flow_data, dict)
+        and _mark_placement_and_later_stale(flow_data, edit_session.step_name)
+    ):
+        targets["flow"] = flow_target
+        json_data["flow"] = flow_data
+        artifacts["flowPath"] = str(flow_target)
+        result["flowData"] = flow_data
+
+    return result
+
+
+def _floorplan_config_target(workspace) -> Path:
+    config = getattr(workspace, "config", {})
+    if isinstance(config, dict):
+        config_target = _path_or_none(config.get("Floorplan"))
+        if config_target is not None:
+            return config_target
+    workspace_directory = _path_or_none(getattr(workspace, "directory", None))
+    if workspace_directory is None:
+        raise RuntimeApiError("command_failed", "workspace directory is missing")
+    return workspace_directory / "config" / "fp_default_config.json"
+
+
+def _workspace_path(workspace, owner_name: str, path_name: str) -> Path | None:
+    owner = getattr(workspace, owner_name, None)
+    return _path_or_none(getattr(owner, path_name, None))
+
+
+def _read_layout_edit_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeApiError("command_failed", f"failed to read JSON artifact: {path}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeApiError("command_failed", f"JSON artifact must contain an object: {path}")
+    return data
+
+
+def _stage_layout_edit_workspace_json(
+    staged: dict[str, Path],
+    workspace_staging: dict[str, Any],
+) -> None:
+    for key, data in workspace_staging["json"].items():
+        staged_path = staged[key]
+        staged_path.parent.mkdir(parents=True, exist_ok=True)
+        staged_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _stage_layout_edit_verilog(
+    module, staged: dict[str, Path], edit_session: LayoutEditSession
+) -> None:
+    if "verilog" not in staged:
+        return
+    save_verilog = getattr(module, "verilog_save", None)
+    if not callable(save_verilog):
+        raise RuntimeApiError("command_failed", "verilog_save is unavailable")
+    staged["verilog"].parent.mkdir(parents=True, exist_ok=True)
+    save_verilog(output_verilog=str(staged["verilog"]))
+
+
+def _validate_layout_edit_workspace_staging(
+    staged: dict[str, Path],
+    workspace_staging: dict[str, Any],
+) -> None:
+    for key in workspace_staging["json"]:
+        if not staged[key].is_file():
+            raise RuntimeApiError("command_failed", f"layout edit staged {key} is missing")
+        _read_layout_edit_json(staged[key])
+    if "verilog" in staged and not staged["verilog"].is_file():
+        raise RuntimeApiError("command_failed", "layout edit staged Verilog is missing")
+
+
+def _apply_layout_edit_workspace_staging(workspace, workspace_staging: dict[str, Any]) -> None:
+    parameters_data = workspace_staging["parametersData"]
+    if parameters_data is not None:
+        workspace.parameters.data = parameters_data
+    flow_data = workspace_staging["flowData"]
+    if flow_data is not None:
+        workspace.flow.data = flow_data
+
+
+def _mark_placement_and_later_stale(flow_data: dict[str, Any], step_name: str) -> bool:
+    if step_name != "Floorplan":
+        return False
+    steps = flow_data.get("steps")
+    if not isinstance(steps, list):
+        return False
+    placement_index = next(
+        (
+            index
+            for index, step in enumerate(steps)
+            if isinstance(step, dict) and step.get("name") == "place"
+        ),
+        None,
+    )
+    if placement_index is None:
+        return False
+    changed = False
+    for step in steps[placement_index:]:
+        if not isinstance(step, dict):
+            continue
+        desired = {
+            "state": "Unstart",
+            "runtime": "",
+            "peak memory (mb)": 0,
+        }
+        for key, value in desired.items():
+            if step.get(key) != value:
+                step[key] = value
+                changed = True
+    return changed
 
 
 def _layout_edit_publish_targets(workspace_step) -> dict[str, Path]:
@@ -988,7 +1526,7 @@ def _publish_staged_layout_edit_artifacts(
     staged: dict[str, Path],
     targets: dict[str, Path],
 ) -> None:
-    artifact_keys = ("def", "db", "gds", "geometry")
+    artifact_keys = tuple(targets)
     backup_dir = stage_root / "backup"
     backup_dir.mkdir()
     journal_path = stage_root / "publish.journal"

--- a/chipcompiler/tools/ecc/builder.py
+++ b/chipcompiler/tools/ecc/builder.py
@@ -51,6 +51,7 @@ def build_step(
     analysis_dir = directory / "analysis"
     qor_metrics_path = analysis_dir / "qor_metrics.json"
     output_view = output_dir / f"{design}_{step_name}_view"
+    output_geometry = output_dir / "geometry"
 
     return EccStep(
         name=step_name,
@@ -74,6 +75,8 @@ def build_step(
             db=output_dir / f"{design}_{step_name}_db",
             image=output_dir / f"{design}_{step_name}.png",
             json=output_dir / f"{design}_{step_name}.json",
+            geometry=output_geometry,
+            geometry_manifest=output_geometry / "geometry.manifest",
             view_json=output_view,
             view_json_edits=output_view / "edits" / "layout_edits.json",
             lef=output_dir / f"{design}_{step_name}.lef",

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -274,6 +274,10 @@ class ECCToolsModule:
         """
         return self.ecc.view_json_apply_edits(edits_path=path_text(edits_path), compress=compress)
 
+    def geometry_snapshot_save(self, output_dir: PathArg):
+        """Export the current in-memory IDB geometry for GUI rendering."""
+        return self.ecc.geometry_snapshot_save(output_dir=path_text(output_dir))
+
     def save_data(self, path: PathArg):
         """save ECC data"""
         return self.ecc.save_data(path=path_text(path))

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -303,6 +303,22 @@ class ECCToolsModule:
         """Export the current in-memory IDB geometry for GUI rendering."""
         return self.ecc.geometry_snapshot_save(output_dir=path_text(output_dir))
 
+    def initialize_geometry_session(self):
+        """Begin a geometry edit session for incremental GUI updates."""
+        return self.ecc.initialize_geometry_session()
+
+    def sync_instance_geometry(self, inst_name: str):
+        """Synchronize one edited instance from IDB into the geometry session."""
+        return self.ecc.sync_instance_geometry(inst_name=inst_name)
+
+    def geometry_session_snapshot_save(self, output_dir: PathArg):
+        """Export the incremental geometry-session snapshot for GUI rendering."""
+        return self.ecc.geometry_session_snapshot_save(output_dir=path_text(output_dir))
+
+    def reset_geometry_session(self):
+        """Discard the active geometry edit session."""
+        return self.ecc.reset_geometry_session()
+
     def save_data(self, path: PathArg):
         """save ECC data"""
         return self.ecc.save_data(path=path_text(path))

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -193,6 +193,31 @@ class ECCToolsModule:
     def create_net(self, net_name: str, conn_type: str = ""):
         return self.ecc.create_net(net_name=net_name, conn_type=conn_type)
 
+    def place_instance(
+        self,
+        inst_name: str,
+        llx: int,
+        lly: int,
+        orient: str,
+        cellmaster: str,
+        source: str = "",
+        placement_status: str = "fixed",
+        *,
+        create_if_missing: bool = True,
+    ):
+        params = {
+            "inst_name": inst_name,
+            "llx": llx,
+            "lly": lly,
+            "orient": orient,
+            "cellmaster": cellmaster,
+            "source": source,
+        }
+        if placement_status != "fixed" or not create_if_missing:
+            params["placement_status"] = placement_status
+            params["create_if_missing"] = create_if_missing
+        return self.ecc.place_instance(**params)
+
     def set_exclude_cell_names(self, cell_names: set):
         self.cell_names = cell_names
 

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -340,11 +340,11 @@ def run_sta_without_spef(
         workspace.logger.warning("Post-synthesis STA failed; synthesis result is kept: %s", exc)
         return False
 
-    workspace.logger.info(
-        "Post-synthesis STA artifacts saved to report=%s feature=%s",
-        report_dir,
-        feature_dir,
-    )
+        workspace.logger.info(
+            "Post-synthesis STA artifacts saved to report=%s feature=%s",
+            report_dir,
+            feature_dir,
+        )
     return True
 
 

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -362,7 +362,6 @@ def save_data(
     """
     if ecc_module is None:
         return False
-
     ecc_module.def_save(def_path=step.output.def_ or "")
     ecc_module.verilog_save(output_verilog=step.output.verilog or "")
     ecc_module.gds_save(output_path=step.output.gds or "")
@@ -380,11 +379,8 @@ def save_data(
                 geometry_manifest,
             )
             return False
-    # ecc_module.json_save(path=step.output.json or "")
-    ecc_module.view_json_save(
-        output_dir=step.output.view_json or "", json_format="compact", compress=True
-    )
-    ecc_module.view_json_apply_edits(edits_path=step.output.view_json_edits or "", compress=True)
+    # View JSON serialization is intentionally skipped. The GUI reads the
+    # geometry snapshot generated above instead.
     ecc_module.feature_sammry(json_path=step.feature.db or "")
     if feature_step:
         ecc_module.feature_step(step=step.name, json_path=step.feature.step or "")

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -17,6 +17,24 @@ from chipcompiler.tools.ecc.subflow import EccSubFlow, EccSubFlowEnum
 from chipcompiler.tools.ecc.utility import is_eda_exist
 from chipcompiler.utility import json_read
 
+_GEOMETRY_SNAPSHOT_STEPS = frozenset(
+    {
+        StepEnum.FLOORPLAN.value,
+        StepEnum.NETLIST_OPT.value,
+        StepEnum.PLACEMENT.value,
+        StepEnum.CTS.value,
+        StepEnum.PNP.value,
+        StepEnum.TIMING_OPT.value,
+        StepEnum.TIMING_OPT_DRV.value,
+        StepEnum.TIMING_OPT_HOLD.value,
+        StepEnum.TIMING_OPT_SETUP.value,
+        StepEnum.LEGALIZATION.value,
+        StepEnum.ROUTING.value,
+        StepEnum.DRC.value,
+        StepEnum.FILLER.value,
+    }
+)
+
 
 def temperature_token(temperature) -> str:
     try:
@@ -349,6 +367,19 @@ def save_data(
     ecc_module.verilog_save(output_verilog=step.output.verilog or "")
     ecc_module.gds_save(output_path=step.output.gds or "")
     ecc_module.save_data(path=step.output.db or "")
+    if step.name in _GEOMETRY_SNAPSHOT_STEPS:
+        geometry_dir = step.output.geometry or ""
+        geometry_manifest = step.output.geometry_manifest
+        if not ecc_module.geometry_snapshot_save(output_dir=geometry_dir):
+            workspace.logger.error("Failed to write geometry snapshot for %s", step.name)
+            return False
+        if geometry_manifest is None or not geometry_manifest.is_file():
+            workspace.logger.error(
+                "Geometry snapshot manifest is missing for %s: %s",
+                step.name,
+                geometry_manifest,
+            )
+            return False
     # ecc_module.json_save(path=step.output.json or "")
     ecc_module.view_json_save(
         output_dir=step.output.view_json or "", json_format="compact", compress=True

--- a/chipcompiler/tools/klayout_tool/__init__.py
+++ b/chipcompiler/tools/klayout_tool/__init__.py
@@ -4,6 +4,7 @@ from .runner import (
     run_step,
     save_gds_image,
 )
+from .image import save_snapshot_image
 from .utility import is_eda_exist
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "run_step",
     "KlayoutModule",
     "save_gds_image",
+    "save_snapshot_image",
 ]

--- a/chipcompiler/tools/klayout_tool/__init__.py
+++ b/chipcompiler/tools/klayout_tool/__init__.py
@@ -1,10 +1,10 @@
 from .builder import build_step, build_step_config, build_step_space
+from .image import save_snapshot_image
 from .module import KlayoutModule
 from .runner import (
     run_step,
     save_gds_image,
 )
-from .image import save_snapshot_image
 from .utility import is_eda_exist
 
 __all__ = [

--- a/chipcompiler/tools/klayout_tool/image.py
+++ b/chipcompiler/tools/klayout_tool/image.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+import os
+
+from chipcompiler.utility.path import path_text
+from klayout import lay
+
+
+def save_snapshot_image(
+    gds_file: str,
+    img_file: str,
+    width: int = 1920,
+    height: int = 1920,
+) -> bool:
+    """
+    Render a GDS file into a PNG image using KLayout's Python API.
+    """
+    if not gds_file or not img_file or not os.path.exists(gds_file):
+        return False
+
+    img_dir = os.path.dirname(path_text(img_file))
+    if img_dir:
+        os.makedirs(img_dir, exist_ok=True)
+
+    lv = lay.LayoutView()
+    lv.set_config("background-color", "#F5F5F5")
+    lv.set_config("grid-visible", "false")
+    lv.set_config("grid-show-ruler", "false")
+    lv.set_config("text-visible", "false")
+
+    lv.load_layout(path_text(gds_file), 0)
+    lv.max_hier()
+    lv.timer()
+    lv.save_image(path_text(img_file), int(width), int(height))
+    return os.path.exists(img_file)

--- a/chipcompiler/tools/klayout_tool/image.py
+++ b/chipcompiler/tools/klayout_tool/image.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 import os
 
-from chipcompiler.utility.path import path_text
 from klayout import lay
+
+from chipcompiler.utility.path import path_text
 
 
 def save_snapshot_image(

--- a/chipcompiler/tools/klayout_tool/module.py
+++ b/chipcompiler/tools/klayout_tool/module.py
@@ -2,9 +2,8 @@
 import os
 from pathlib import Path
 
-from chipcompiler.tools.klayout_tool.image import save_snapshot_image as render_snapshot_image
-
 from chipcompiler.data import EccOutput, Workspace, WorkspaceStep
+from chipcompiler.tools.klayout_tool.image import save_snapshot_image as render_snapshot_image
 
 
 class KlayoutModule:

--- a/chipcompiler/tools/klayout_tool/module.py
+++ b/chipcompiler/tools/klayout_tool/module.py
@@ -2,10 +2,9 @@
 import os
 from pathlib import Path
 
-from klayout import lay
+from chipcompiler.tools.klayout_tool.image import save_snapshot_image as render_snapshot_image
 
 from chipcompiler.data import EccOutput, Workspace, WorkspaceStep
-from chipcompiler.utility.path import path_text
 
 
 class KlayoutModule:
@@ -49,19 +48,9 @@ class KlayoutModule:
             weight (int, optional): Image width. Defaults to 1920
             height (int, optional): Image height. Defaults to 1920
         """
-        # Set display configuration options
-        lv = lay.LayoutView()
-        lv.set_config("background-color", "#F5F5F5")  # background of ECOS MERGE tab
-        lv.set_config("grid-visible", "false")
-        lv.set_config("grid-show-ruler", "false")
-        lv.set_config("text-visible", "false")
-
-        # Load the GDS file
-        lv.load_layout(path_text(gds_file), 0)
-        lv.max_hier()
-
-        # Event processing for delayed configuration events
-        lv.timer()
-
-        # Save the image
-        lv.save_image(path_text(img_file), weight, height)
+        return render_snapshot_image(
+            gds_file=gds_file,
+            img_file=img_file,
+            width=weight,
+            height=height,
+        )

--- a/ecc.spec
+++ b/ecc.spec
@@ -229,6 +229,7 @@ binaries.extend(klayout_binaries)
 binaries.extend(dreamplace_binaries)
 binaries.extend(torch_binaries)
 binaries.extend(collect_platform_runtime_libs())
+binaries = filter_collected_payloads(binaries)
 
 hiddenimports = []
 hiddenimports.extend(HIDDENIMPORTS)
@@ -238,6 +239,8 @@ hiddenimports.extend(klayout_hiddenimports)
 hiddenimports.extend(dreamplace_hiddenimports)
 hiddenimports.extend(torch_hiddenimports)
 hiddenimports = filter_hiddenimports(hiddenimports)
+
+datas = filter_collected_payloads(datas)
 
 a = Analysis(
     [str(ECC_DIR / "packaging" / "run_ecc.py")],
@@ -249,9 +252,6 @@ a = Analysis(
     excludes=EXCLUDES,
     noarchive=False,
 )
-
-a.datas = filter_collected_payloads(a.datas)
-a.binaries = filter_collected_payloads(a.binaries)
 
 pyz = PYZ(a.pure, a.zipped_data)
 

--- a/ecc.spec
+++ b/ecc.spec
@@ -96,6 +96,7 @@ HIDDENIMPORTS = [
     "chipcompiler.tools.yosys.utility",
     "chipcompiler.tools.klayout_tool",
     "chipcompiler.tools.klayout_tool.builder",
+    "chipcompiler.tools.klayout_tool.image",
     "chipcompiler.tools.klayout_tool.runner",
     "chipcompiler.tools.klayout_tool.module",
     "chipcompiler.tools.klayout_tool.utility",

--- a/test/data/test_workspace_layout.py
+++ b/test/data/test_workspace_layout.py
@@ -185,6 +185,8 @@ def test_log_projection_ecc_shape_has_no_sizer_keys(tmp_path):
             "image",
             "db",
             "gds",
+            "geometry",
+            "geometry_manifest",
             "view_json",
             "view_json_edits",
             "lef",

--- a/test/packaging/test_cli_entrypoint.py
+++ b/test/packaging/test_cli_entrypoint.py
@@ -20,3 +20,17 @@ class TestPackaging:
             source = f.read()
 
         assert 'collect_data_files("jsonrpcserver")' in source
+
+    def test_pyinstaller_spec_filters_payloads_before_analysis(self):
+        project_root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        spec_path = os.path.join(project_root, "ecc.spec")
+
+        with open(spec_path, encoding="utf-8") as f:
+            source = f.read()
+
+        analysis_index = source.index("a = Analysis(")
+        datas_filter_index = source.index("datas = filter_collected_payloads(datas)")
+        binaries_filter_index = source.index("binaries = filter_collected_payloads(binaries)")
+
+        assert datas_filter_index < analysis_index
+        assert binaries_filter_index < analysis_index

--- a/test/packaging/test_pyinstaller_packaging.py
+++ b/test/packaging/test_pyinstaller_packaging.py
@@ -1,8 +1,39 @@
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
 from chipcompiler.pyinstaller_utils import (
     collect_package_extension_binaries,
     filter_collected_payloads,
     filter_hiddenimports,
 )
+
+
+def test_ecc_tools_editable_import_does_not_rebuild_native_payload():
+    config_path = (
+        Path(__file__).parents[2] / "chipcompiler" / "thirdparty" / "ecc-tools" / "pyproject.toml"
+    )
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+    assert config["tool"]["scikit-build"]["editable"]["rebuild"] is False
+
+
+def test_ecc_tools_native_import_coexists_with_matplotlib():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-X",
+            "faulthandler",
+            "-c",
+            "import ecc_tools_bin.ecc_py; import matplotlib.pyplot",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_collect_package_extension_binaries_checks_sibling_bin(tmp_path):

--- a/test/runtime/test_layout_edit.py
+++ b/test/runtime/test_layout_edit.py
@@ -275,6 +275,36 @@ def test_layout_edit_begin_prefers_selected_step_output_db(monkeypatch, tmp_path
     assert loaded_step.input["db"] == step.output["db"]
 
 
+def test_layout_edit_begin_rejects_another_workspace_until_active_session_is_discarded(
+    monkeypatch,
+    tmp_path,
+):
+    api, first_session, _step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    second_workspace = SimpleNamespace(directory=tmp_path / "second-workspace")
+    second_session = api.sessions.open_session(
+        second_workspace.directory,
+        workspace=second_workspace,
+    )
+
+    first = _begin(api, first_session.workspace_id)
+
+    with pytest.raises(RuntimeApiError) as exc_info:
+        _begin(api, second_session.workspace_id)
+
+    assert exc_info.value.code == "layout_edit_active"
+    assert exc_info.value.data == {
+        "editSessionId": first["editSessionId"],
+        "workspaceId": first_session.workspace_id,
+    }
+    assert module.initialize_calls == 1
+
+    api.layout_edit_discard(LayoutEditDiscardRequest(first["editSessionId"]))
+    second = _begin(api, second_session.workspace_id)
+
+    assert second["workspaceId"] == second_session.workspace_id
+    assert module.initialize_calls == 2
+
+
 def test_layout_edit_apply_calls_place_instance_without_persisting_artifacts(monkeypatch, tmp_path):
     api, session, step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
     begin = _begin(api, session.workspace_id)

--- a/test/runtime/test_layout_edit.py
+++ b/test/runtime/test_layout_edit.py
@@ -1,9 +1,13 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from chipcompiler.runtime.requests import (
+    FloorplanEditInspectRequest,
+    FloorplanEditRunAutoRequest,
+    FloorplanEditValidateRequest,
     LayoutEditApplyRequest,
     LayoutEditBeginRequest,
     LayoutEditDiscardRequest,
@@ -21,6 +25,9 @@ class FakeLayoutModule:
         self.sync_calls = []
         self.export_calls = []
         self.session_snapshot_calls = []
+        self.editor_calls = []
+        self.validation_result = {"ok": True, "diagnostics": []}
+        self.export_intent = {"ok": True}
 
     def initialize_geometry_session(self):
         self.initialize_calls += 1
@@ -75,6 +82,44 @@ class FakeLayoutModule:
         (geometry_dir / "geometry.manifest").write_text("session geometry", encoding="utf-8")
         return True
 
+    def floorplan_editor_apply(self, request):
+        self.editor_calls.append(request)
+        return {
+            "accepted": True,
+            "changed": True,
+            "affectedRefs": [{"kind": "blockage", "id": "blockage-1"}],
+            "geometryDelta": {
+                "ok": True,
+                "snapshotRequired": True,
+                "updatedShapeCount": 0,
+                "insertedShapeCount": 1,
+                "deletedShapeCount": 0,
+                "missingShapeCount": 0,
+                "events": [{"shapeId": 31, "op": "insert"}],
+            },
+            "modelPatch": {
+                "floorplanPlan": {"placement_blockages": [{"id": "blockage-1"}]},
+                "pdnPlan": {"manual_segments": [{"id": "segment-1"}]},
+                "configPatch": {"editor": {"enabled": True}},
+                "parametersPatch": {"Floorplan": {"edited": True}},
+            },
+            "diagnostics": [{"severity": "warning", "message": "preview"}],
+        }
+
+    def floorplan_editor_validate(self, scope):
+        assert scope
+        return self.validation_result
+
+    def floorplan_editor_export_intent(self):
+        return self.export_intent
+
+    def floorplan_editor_inspect(self):
+        return {"ownerCount": 3}
+
+    def verilog_save(self, output_verilog):
+        self.export_calls.append("verilog")
+        Path(output_verilog).write_text("module gcd; endmodule\n", encoding="utf-8")
+
 
 class FakeEngineDb:
     def __init__(self, module):
@@ -110,7 +155,7 @@ class FakeFlow:
         return self.workspace_step if name == self.workspace_step.name else None
 
 
-def _make_layout_workspace(tmp_path, *, with_db=False):
+def _make_layout_workspace(tmp_path, *, with_db=False, with_editor_workspace=False):
     workspace_dir = tmp_path / "workspace"
     output_dir = workspace_dir / "Floorplan_ecc" / "output"
     output_dir.mkdir(parents=True)
@@ -129,14 +174,40 @@ def _make_layout_workspace(tmp_path, *, with_db=False):
             "gds": output_dir / "gcd_Floorplan.gds",
             "geometry": output_dir / "geometry",
             "geometry_manifest": output_dir / "geometry" / "geometry.manifest",
+            "verilog": output_dir / "gcd_Floorplan.v",
         },
     )
     workspace = SimpleNamespace(directory=workspace_dir)
+    if with_editor_workspace:
+        config_path = workspace_dir / "config" / "fp_default_config.json"
+        config_path.parent.mkdir()
+        config_path.write_text('{"legacy": true}\n', encoding="utf-8")
+        parameters_path = workspace_dir / "parameters.json"
+        parameters_path.write_text('{"Floorplan": {"edited": false}}\n', encoding="utf-8")
+        flow_path = workspace_dir / "flow.json"
+        flow_data = {
+            "steps": [
+                {"name": "Floorplan", "state": "Success", "runtime": "1s"},
+                {"name": "place", "state": "Success", "runtime": "2s"},
+                {"name": "route", "state": "Success", "runtime": "3s"},
+            ]
+        }
+        flow_path.write_text(json.dumps(flow_data), encoding="utf-8")
+        workspace.config = {"Floorplan": config_path}
+        workspace.parameters = SimpleNamespace(
+            path=parameters_path,
+            data={"Floorplan": {"edited": False}},
+        )
+        workspace.flow = SimpleNamespace(path=flow_path, data=flow_data)
     return workspace, step
 
 
-def _open_api(monkeypatch, tmp_path, *, with_db=False):
-    workspace, step = _make_layout_workspace(tmp_path, with_db=with_db)
+def _open_api(monkeypatch, tmp_path, *, with_db=False, with_editor_workspace=False):
+    workspace, step = _make_layout_workspace(
+        tmp_path,
+        with_db=with_db,
+        with_editor_workspace=with_editor_workspace,
+    )
     module = FakeLayoutModule()
     flow_calls = []
 
@@ -392,3 +463,116 @@ def test_layout_edit_apply_allows_preserve_orientation_for_existing_instance(
 
     assert result["revision"] == 1
     assert module.place_calls[0]["orient"] == ""
+
+
+def test_floorplan_editor_apply_inspect_validate_and_save_publish_editor_artifacts(
+    monkeypatch,
+    tmp_path,
+):
+    api, session, step, module, _flow_calls = _open_api(
+        monkeypatch,
+        tmp_path,
+        with_editor_workspace=True,
+    )
+    begin = _begin(api, session.workspace_id)
+
+    applied = api.layout_edit_apply(
+        LayoutEditApplyRequest(
+            edit_session_id=begin["editSessionId"],
+            command_id="blockage-1",
+            base_revision=0,
+            operation={"kind": "upsert_blockage", "id": "blockage-1"},
+        )
+    )
+
+    assert applied["revision"] == 1
+    assert applied["affectedRefs"] == [{"kind": "blockage", "id": "blockage-1"}]
+    assert applied["modelPatch"]["floorplanPlan"]["placement_blockages"] == [{"id": "blockage-1"}]
+    assert module.editor_calls == [{"kind": "upsert_blockage", "id": "blockage-1"}]
+    config_path = session.workspace.config["Floorplan"]
+    assert config_path.read_text(encoding="utf-8") == '{"legacy": true}\n'
+
+    inspected = api.floorplan_edit_inspect(
+        FloorplanEditInspectRequest(edit_session_id=begin["editSessionId"])
+    )
+    assert inspected["state"] == {"ownerCount": 3}
+    assert inspected["floorplanPlan"]["placement_blockages"] == [{"id": "blockage-1"}]
+
+    validated = api.floorplan_edit_validate(
+        FloorplanEditValidateRequest(edit_session_id=begin["editSessionId"], scope="pdn")
+    )
+    assert validated["valid"] is True
+
+    module.export_intent = {
+        "ok": True,
+        "floorplanPlan": {"outline": {"die": [0, 0, 100, 100]}},
+        "pdnPlan": {"manual_vias": [{"id": "via-1"}]},
+        "parametersPatch": {"PDN": {"edited": True}},
+        "requiresVerilog": True,
+    }
+    saved = api.layout_edit_save(
+        LayoutEditSaveRequest(
+            edit_session_id=begin["editSessionId"],
+            expected_revision=applied["revision"],
+        )
+    )
+
+    assert saved["saved"] is True
+    assert saved["artifacts"]["configPath"] == str(config_path)
+    assert saved["artifacts"]["parametersPath"] == str(session.workspace.parameters.path)
+    assert saved["artifacts"]["verilogPath"] == str(step.output["verilog"])
+    assert saved["artifacts"]["flowPath"] == str(session.workspace.flow.path)
+    assert module.export_calls == ["def", "db", "gds", "geometry", "verilog"]
+    saved_config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved_config["FloorplanPlan"]["outline"] == {"die": [0, 0, 100, 100]}
+    assert saved_config["PdnPlan"]["manual_vias"] == [{"id": "via-1"}]
+    assert saved_config["editor"] == {"enabled": True}
+    saved_parameters = json.loads(session.workspace.parameters.path.read_text(encoding="utf-8"))
+    assert saved_parameters["Floorplan"]["edited"] is True
+    assert saved_parameters["PDN"] == {"edited": True}
+    assert step.output["verilog"].is_file()
+    stale_steps = session.workspace.flow.data["steps"][1:]
+    assert [item["state"] for item in stale_steps] == ["Unstart", "Unstart"]
+    assert [item["runtime"] for item in stale_steps] == ["", ""]
+
+
+def test_floorplan_editor_run_auto_is_idempotent_and_save_rejects_invalid_result(
+    monkeypatch,
+    tmp_path,
+):
+    api, session, _step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+
+    first = api.floorplan_edit_run_auto(
+        FloorplanEditRunAutoRequest(
+            edit_session_id=begin["editSessionId"],
+            command_id="auto-1",
+            base_revision=0,
+            request={"mode": "macro"},
+        )
+    )
+    replay = api.floorplan_edit_run_auto(
+        FloorplanEditRunAutoRequest(
+            edit_session_id=begin["editSessionId"],
+            command_id="auto-1",
+            base_revision=0,
+            request={"mode": "macro"},
+        )
+    )
+
+    assert replay == first
+    assert module.editor_calls == [{"kind": "run_auto", "request": {"mode": "macro"}}]
+    module.validation_result = {
+        "ok": False,
+        "diagnostics": [{"severity": "error", "message": "bad outline"}],
+    }
+    with pytest.raises(RuntimeApiError) as exc_info:
+        api.layout_edit_save(
+            LayoutEditSaveRequest(
+                edit_session_id=begin["editSessionId"],
+                expected_revision=first["revision"],
+            )
+        )
+
+    assert exc_info.value.code == "floorplan_validation_failed"
+    assert module.export_calls == []

--- a/test/runtime/test_layout_edit.py
+++ b/test/runtime/test_layout_edit.py
@@ -1,0 +1,394 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from chipcompiler.runtime.requests import (
+    LayoutEditApplyRequest,
+    LayoutEditBeginRequest,
+    LayoutEditDiscardRequest,
+    LayoutEditSaveRequest,
+)
+from chipcompiler.runtime.sessions import WorkspaceSessionRegistry
+from chipcompiler.runtime.workspace_api import RuntimeApiError, WorkspaceRuntimeApi
+
+
+class FakeLayoutModule:
+    def __init__(self):
+        self.initialize_calls = 0
+        self.reset_calls = 0
+        self.place_calls = []
+        self.sync_calls = []
+        self.export_calls = []
+        self.session_snapshot_calls = []
+
+    def initialize_geometry_session(self):
+        self.initialize_calls += 1
+        return True
+
+    def reset_geometry_session(self):
+        self.reset_calls += 1
+        return True
+
+    def place_instance(self, **kwargs):
+        self.place_calls.append(kwargs)
+        return True
+
+    def sync_instance_geometry(self, inst_name):
+        self.sync_calls.append(inst_name)
+        return {
+            "ok": True,
+            "snapshotRequired": False,
+            "updatedShapeCount": 1,
+            "insertedShapeCount": 0,
+            "deletedShapeCount": 0,
+            "missingShapeCount": 0,
+            "events": [{"shapeId": 11, "op": "update"}],
+        }
+
+    def def_save(self, def_path):
+        self.export_calls.append("def")
+        Path(def_path).write_text("new def", encoding="utf-8")
+
+    def save_data(self, path):
+        self.export_calls.append("db")
+        db_path = Path(path)
+        db_path.mkdir(parents=True)
+        (db_path / "metadata.idb").write_text("new db", encoding="utf-8")
+        return True
+
+    def gds_save(self, output_path):
+        self.export_calls.append("gds")
+        Path(output_path).write_text("new gds", encoding="utf-8")
+
+    def geometry_snapshot_save(self, output_dir):
+        self.export_calls.append("geometry")
+        geometry_dir = Path(output_dir)
+        geometry_dir.mkdir(parents=True)
+        (geometry_dir / "geometry.manifest").write_text("new geometry", encoding="utf-8")
+        return True
+
+    def geometry_session_snapshot_save(self, output_dir):
+        self.session_snapshot_calls.append(Path(output_dir))
+        geometry_dir = Path(output_dir)
+        geometry_dir.mkdir(parents=True)
+        (geometry_dir / "geometry.manifest").write_text("session geometry", encoding="utf-8")
+        return True
+
+
+class FakeEngineDb:
+    def __init__(self, module):
+        self.ecc_module = module
+        self.initialized = False
+        self.created_for = []
+        self.close_calls = 0
+
+    @property
+    def engine(self):
+        return self.ecc_module
+
+    def has_init(self):
+        return self.initialized
+
+    def create_db_engine(self, step):
+        self.created_for.append(step)
+        self.initialized = True
+        return True
+
+    def close(self):
+        self.close_calls += 1
+        self.initialized = False
+
+
+class FakeFlow:
+    def __init__(self, workspace, step, module):
+        self.workspace = workspace
+        self.workspace_step = step
+        self.engine_db = FakeEngineDb(module)
+
+    def get_workspace_step(self, name):
+        return self.workspace_step if name == self.workspace_step.name else None
+
+
+def _make_layout_workspace(tmp_path, *, with_db=False):
+    workspace_dir = tmp_path / "workspace"
+    output_dir = workspace_dir / "Floorplan_ecc" / "output"
+    output_dir.mkdir(parents=True)
+    output_def = output_dir / "gcd_Floorplan.def.gz"
+    output_def.write_text("old def", encoding="utf-8")
+    output_db = output_dir / "gcd_Floorplan_db"
+    if with_db:
+        output_db.mkdir()
+        (output_db / "metadata.idb").write_text("old db", encoding="utf-8")
+    step = SimpleNamespace(
+        name="Floorplan",
+        input={"def": None, "verilog": None, "db": None},
+        output={
+            "def": output_def,
+            "db": output_db,
+            "gds": output_dir / "gcd_Floorplan.gds",
+            "geometry": output_dir / "geometry",
+            "geometry_manifest": output_dir / "geometry" / "geometry.manifest",
+        },
+    )
+    workspace = SimpleNamespace(directory=workspace_dir)
+    return workspace, step
+
+
+def _open_api(monkeypatch, tmp_path, *, with_db=False):
+    workspace, step = _make_layout_workspace(tmp_path, with_db=with_db)
+    module = FakeLayoutModule()
+    flow_calls = []
+
+    def build_flow(_workspace):
+        flow = FakeFlow(_workspace, step, module)
+        flow_calls.append(flow)
+        return flow
+
+    monkeypatch.setattr("chipcompiler.runtime.workspace_api.build_flow_for_workspace", build_flow)
+    registry = WorkspaceSessionRegistry()
+    session = registry.open_session(workspace.directory, workspace=workspace)
+    api = WorkspaceRuntimeApi(sessions=registry, persistent_db_enabled=True)
+    return api, session, step, module, flow_calls
+
+
+def _begin(api, workspace_id, **kwargs):
+    return api.layout_edit_begin(
+        LayoutEditBeginRequest(workspace_id=workspace_id, step="Floorplan", **kwargs)
+    )
+
+
+def _apply(api, edit_session_id, *, revision=0, command_id="move-1"):
+    return api.layout_edit_apply(
+        LayoutEditApplyRequest(
+            edit_session_id=edit_session_id,
+            command_id=command_id,
+            base_revision=revision,
+            operation={
+                "kind": "place_instance",
+                "instName": "u_sram_0",
+                "llx": 1200,
+                "lly": 3400,
+                "orient": "N",
+                "cellmaster": "",
+                "source": "",
+                "placementStatus": "preserve",
+                "createIfMissing": False,
+            },
+        )
+    )
+
+
+def test_layout_edit_begin_loads_output_def_when_output_db_is_absent(monkeypatch, tmp_path):
+    api, session, step, module, flow_calls = _open_api(monkeypatch, tmp_path)
+
+    result = _begin(api, session.workspace_id)
+
+    assert result["source"] == "def"
+    assert result["dirty"] is False
+    assert Path(result["geometryManifestPath"]).is_file()
+    assert module.initialize_calls == 1
+    loaded_step = flow_calls[0].engine_db.created_for[0]
+    assert loaded_step is not step
+    assert loaded_step.input["db"] is None
+    assert loaded_step.input["def"] == step.output["def"]
+
+
+def test_layout_edit_begin_prefers_selected_step_output_db(monkeypatch, tmp_path):
+    api, session, step, _module, flow_calls = _open_api(monkeypatch, tmp_path, with_db=True)
+
+    result = _begin(api, session.workspace_id)
+
+    assert result["source"] == "db"
+    loaded_step = flow_calls[0].engine_db.created_for[0]
+    assert loaded_step.input["db"] == step.output["db"]
+
+
+def test_layout_edit_apply_calls_place_instance_without_persisting_artifacts(monkeypatch, tmp_path):
+    api, session, step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    original_def = step.output["def"].read_text(encoding="utf-8")
+
+    result = _apply(api, begin["editSessionId"])
+
+    assert result["revision"] == 1
+    assert result["dirty"] is True
+    assert result["geometryDelta"]["events"] == [{"shapeId": 11, "op": "update"}]
+    assert module.place_calls == [
+        {
+            "inst_name": "u_sram_0",
+            "llx": 1200,
+            "lly": 3400,
+            "orient": "N",
+            "cellmaster": "",
+            "source": "",
+            "placement_status": "preserve",
+            "create_if_missing": False,
+        }
+    ]
+    assert module.sync_calls == ["u_sram_0"]
+    assert module.export_calls == []
+    assert len(module.session_snapshot_calls) == 2
+    assert Path(result["geometryManifestPath"]).is_file()
+    assert step.output["def"].read_text(encoding="utf-8") == original_def
+    assert not step.output["db"].exists()
+    assert not step.output["gds"].exists()
+    assert not step.output["geometry"].exists()
+
+
+def test_layout_edit_save_publishes_staged_outputs_only_after_explicit_save(monkeypatch, tmp_path):
+    api, session, step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    apply = _apply(api, begin["editSessionId"])
+
+    saved = api.layout_edit_save(
+        LayoutEditSaveRequest(
+            edit_session_id=begin["editSessionId"],
+            expected_revision=apply["revision"],
+        )
+    )
+
+    assert saved["saved"] is True
+    assert saved["dirty"] is False
+    assert saved["artifacts"] == {
+        "defPath": str(step.output["def"]),
+        "dbPath": str(step.output["db"]),
+        "gdsPath": str(step.output["gds"]),
+        "geometryManifestPath": str(step.output["geometry_manifest"]),
+    }
+    assert module.export_calls == ["def", "db", "gds", "geometry"]
+    assert step.output["def"].read_text(encoding="utf-8") == "new def"
+    assert (step.output["db"] / "metadata.idb").read_text(encoding="utf-8") == "new db"
+    assert step.output["gds"].read_text(encoding="utf-8") == "new gds"
+    geometry_manifest = step.output["geometry"] / "geometry.manifest"
+    assert geometry_manifest.read_text(encoding="utf-8") == "new geometry"
+    assert not list(step.output["def"].parent.glob(".layout-edit-*"))
+
+
+def test_layout_edit_discard_drops_in_memory_db_without_publishing(monkeypatch, tmp_path):
+    api, session, step, module, flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    _apply(api, begin["editSessionId"])
+    geometry_root = Path(begin["geometryManifestPath"]).parent.parent
+
+    result = api.layout_edit_discard(LayoutEditDiscardRequest(begin["editSessionId"]))
+
+    assert result == {
+        "editSessionId": begin["editSessionId"],
+        "discarded": True,
+        "dirty": True,
+    }
+    assert flow_calls[0].engine_db.close_calls == 1
+    assert module.reset_calls == 1
+    assert not geometry_root.exists()
+    assert step.output["def"].read_text(encoding="utf-8") == "old def"
+    assert module.export_calls == []
+    with pytest.raises(RuntimeApiError, match="layout edit session not found"):
+        _apply(api, begin["editSessionId"])
+
+
+def test_layout_edit_save_rejects_external_source_change(monkeypatch, tmp_path):
+    api, session, step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    apply = _apply(api, begin["editSessionId"])
+    step.output["def"].write_text("external change", encoding="utf-8")
+
+    with pytest.raises(RuntimeApiError) as exc_info:
+        api.layout_edit_save(
+            LayoutEditSaveRequest(
+                edit_session_id=begin["editSessionId"],
+                expected_revision=apply["revision"],
+            )
+        )
+
+    assert exc_info.value.code == "source_changed"
+    assert module.export_calls == []
+    assert step.output["def"].read_text(encoding="utf-8") == "external change"
+
+
+def test_layout_edit_save_rolls_back_when_publish_fails(monkeypatch, tmp_path):
+    api, session, step, _module, _flow_calls = _open_api(monkeypatch, tmp_path, with_db=True)
+    step.output["gds"].write_text("old gds", encoding="utf-8")
+    step.output["geometry"].mkdir()
+    (step.output["geometry"] / "geometry.manifest").write_text(
+        "old geometry",
+        encoding="utf-8",
+    )
+    begin = _begin(api, session.workspace_id)
+    apply = _apply(api, begin["editSessionId"])
+    real_replace = __import__("os").replace
+
+    def fail_gds_publish(source, destination):
+        if Path(source).name == step.output["gds"].name and Path(destination) == step.output["gds"]:
+            raise OSError("simulated publish failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr("chipcompiler.runtime.workspace_api.os.replace", fail_gds_publish)
+
+    with pytest.raises(RuntimeApiError, match="simulated publish failure"):
+        api.layout_edit_save(
+            LayoutEditSaveRequest(
+                edit_session_id=begin["editSessionId"],
+                expected_revision=apply["revision"],
+            )
+        )
+
+    assert step.output["def"].read_text(encoding="utf-8") == "old def"
+    assert (step.output["db"] / "metadata.idb").read_text(encoding="utf-8") == "old db"
+    assert step.output["gds"].read_text(encoding="utf-8") == "old gds"
+    geometry_manifest = step.output["geometry"] / "geometry.manifest"
+    assert geometry_manifest.read_text(encoding="utf-8") == "old geometry"
+
+
+def test_layout_edit_apply_rejects_stale_revision_before_mutation(monkeypatch, tmp_path):
+    api, session, _step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    _apply(api, begin["editSessionId"])
+
+    with pytest.raises(RuntimeApiError) as exc_info:
+        _apply(api, begin["editSessionId"], revision=0, command_id="move-2")
+
+    assert exc_info.value.code == "version_conflict"
+    assert len(module.place_calls) == 1
+
+
+def test_layout_edit_apply_replays_completed_command_before_revision_validation(
+    monkeypatch,
+    tmp_path,
+):
+    api, session, _step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+    first = _apply(api, begin["editSessionId"])
+
+    replay = _apply(api, begin["editSessionId"], revision=0)
+
+    assert replay == first
+    assert len(module.place_calls) == 1
+
+
+def test_layout_edit_apply_allows_preserve_orientation_for_existing_instance(
+    monkeypatch,
+    tmp_path,
+):
+    api, session, _step, module, _flow_calls = _open_api(monkeypatch, tmp_path)
+    begin = _begin(api, session.workspace_id)
+
+    result = api.layout_edit_apply(
+        LayoutEditApplyRequest(
+            edit_session_id=begin["editSessionId"],
+            command_id="move-with-preserved-orient",
+            base_revision=0,
+            operation={
+                "kind": "place_instance",
+                "instName": "u_sram_0",
+                "llx": 1200,
+                "lly": 3400,
+                "orient": "",
+                "placementStatus": "preserve",
+                "createIfMissing": False,
+            },
+        )
+    )
+
+    assert result["revision"] == 1
+    assert module.place_calls[0]["orient"] == ""

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -1,7 +1,14 @@
 from dataclasses import is_dataclass
 
 import chipcompiler.runtime.requests as requests
-from chipcompiler.runtime.requests import DbEnsureRequest, DbReleaseRequest, WorkspaceOpenRequest
+from chipcompiler.runtime.requests import (
+    DbEnsureRequest,
+    DbReleaseRequest,
+    FloorplanEditInspectRequest,
+    FloorplanEditRunAutoRequest,
+    FloorplanEditValidateRequest,
+    WorkspaceOpenRequest,
+)
 from chipcompiler.runtime.server import BASE_CAPABILITIES, RuntimeServer
 
 
@@ -42,11 +49,14 @@ def test_persistent_db_method_registry_is_separate_and_opt_in():
         "layout.edit.apply",
         "layout.edit.save",
         "layout.edit.discard",
+        "floorplan.edit.inspect",
+        "floorplan.edit.run_auto",
+        "floorplan.edit.validate",
     )
 
     assert persistent_db_method_names() == expected_methods
     enabled_methods = runtime_method_names(persistent_db_enabled=True)
-    assert enabled_methods[-len(expected_methods):] == expected_methods
+    assert enabled_methods[-len(expected_methods) :] == expected_methods
     assert "db.ensure" not in runtime_method_names()
     assert len(PERSISTENT_DB_METHODS) == len(expected_methods)
 
@@ -92,6 +102,15 @@ def test_persistent_db_method_lookup_requires_enabled_capability():
     assert release_spec is not None
     assert release_spec.request_model is DbReleaseRequest
     assert release_spec.handler_name == "db_release"
+    inspect_spec = runtime_method_by_name("floorplan.edit.inspect", persistent_db_enabled=True)
+    assert inspect_spec is not None
+    assert inspect_spec.request_model is FloorplanEditInspectRequest
+    auto_spec = runtime_method_by_name("floorplan.edit.run_auto", persistent_db_enabled=True)
+    assert auto_spec is not None
+    assert auto_spec.request_model is FloorplanEditRunAutoRequest
+    validate_spec = runtime_method_by_name("floorplan.edit.validate", persistent_db_enabled=True)
+    assert validate_spec is not None
+    assert validate_spec.request_model is FloorplanEditValidateRequest
 
 
 def test_default_server_capabilities_are_generated_from_runtime_registry():
@@ -115,6 +134,7 @@ def test_persistent_db_server_capabilities_include_db_methods():
     assert "db.release" in server.capabilities
     assert "layout.edit.begin" in server.capabilities
     assert "layout.edit.save" in server.capabilities
+    assert "floorplan.edit.inspect" in server.capabilities
 
 
 def test_requests_module_does_not_own_runtime_method_table():

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -35,10 +35,18 @@ def test_persistent_db_method_registry_is_separate_and_opt_in():
         runtime_method_names,
     )
 
-    expected_methods = ("db.ensure", "db.release")
+    expected_methods = (
+        "db.ensure",
+        "db.release",
+        "layout.edit.begin",
+        "layout.edit.apply",
+        "layout.edit.save",
+        "layout.edit.discard",
+    )
 
     assert persistent_db_method_names() == expected_methods
-    assert runtime_method_names(persistent_db_enabled=True)[-2:] == expected_methods
+    enabled_methods = runtime_method_names(persistent_db_enabled=True)
+    assert enabled_methods[-len(expected_methods):] == expected_methods
     assert "db.ensure" not in runtime_method_names()
     assert len(PERSISTENT_DB_METHODS) == len(expected_methods)
 
@@ -105,6 +113,8 @@ def test_persistent_db_server_capabilities_include_db_methods():
     )
     assert "db.ensure" in server.capabilities
     assert "db.release" in server.capabilities
+    assert "layout.edit.begin" in server.capabilities
+    assert "layout.edit.save" in server.capabilities
 
 
 def test_requests_module_does_not_own_runtime_method_table():

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -6,6 +6,9 @@ from chipcompiler.runtime.methods import runtime_method_by_name
 from chipcompiler.runtime.requests import (
     DbEnsureRequest,
     DbReleaseRequest,
+    FloorplanEditInspectRequest,
+    FloorplanEditRunAutoRequest,
+    FloorplanEditValidateRequest,
     FlowRunRequest,
     FlowRunStepRequest,
     LayoutEditApplyRequest,
@@ -145,6 +148,26 @@ def test_first_slice_payloads_parse_to_typed_request_models(method, params, requ
             "layout.edit.discard",
             {"editSessionId": "layout-edit-1"},
             LayoutEditDiscardRequest,
+        ),
+        (
+            "floorplan.edit.inspect",
+            {"editSessionId": "layout-edit-1"},
+            FloorplanEditInspectRequest,
+        ),
+        (
+            "floorplan.edit.run_auto",
+            {
+                "editSessionId": "layout-edit-1",
+                "commandId": "auto-1",
+                "baseRevision": 1,
+                "request": {"mode": "macro"},
+            },
+            FloorplanEditRunAutoRequest,
+        ),
+        (
+            "floorplan.edit.validate",
+            {"editSessionId": "layout-edit-1", "scope": "pdn"},
+            FloorplanEditValidateRequest,
         ),
     ],
 )

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -8,6 +8,10 @@ from chipcompiler.runtime.requests import (
     DbReleaseRequest,
     FlowRunRequest,
     FlowRunStepRequest,
+    LayoutEditApplyRequest,
+    LayoutEditBeginRequest,
+    LayoutEditDiscardRequest,
+    LayoutEditSaveRequest,
     RequestValidationError,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
@@ -117,6 +121,31 @@ def test_first_slice_payloads_parse_to_typed_request_models(method, params, requ
         ),
         ("db.ensure", {"workspaceId": "ws-1"}, DbEnsureRequest),
         ("db.release", {"workspaceId": "ws-1"}, DbReleaseRequest),
+        (
+            "layout.edit.begin",
+            {"workspaceId": "ws-1", "step": "Floorplan"},
+            LayoutEditBeginRequest,
+        ),
+        (
+            "layout.edit.apply",
+            {
+                "editSessionId": "layout-edit-1",
+                "commandId": "move-1",
+                "baseRevision": 0,
+                "operation": {"kind": "place_instance"},
+            },
+            LayoutEditApplyRequest,
+        ),
+        (
+            "layout.edit.save",
+            {"editSessionId": "layout-edit-1", "expectedRevision": 1},
+            LayoutEditSaveRequest,
+        ),
+        (
+            "layout.edit.discard",
+            {"editSessionId": "layout-edit-1"},
+            LayoutEditDiscardRequest,
+        ),
     ],
 )
 def test_persistent_db_payloads_parse_to_typed_request_models(method, params, request_type):
@@ -124,7 +153,10 @@ def test_persistent_db_payloads_parse_to_typed_request_models(method, params, re
 
     assert isinstance(request, request_type)
     assert is_dataclass(request)
-    assert request.workspace_id == "ws-1"
+    if hasattr(request, "workspace_id"):
+        assert request.workspace_id == "ws-1"
+    else:
+        assert request.edit_session_id == "layout-edit-1"
 
 
 def test_db_ensure_step_is_optional():
@@ -136,6 +168,21 @@ def test_db_ensure_step_is_optional():
 
     assert isinstance(request, DbEnsureRequest)
     assert request.step == ""
+
+
+def test_layout_edit_begin_accepts_source_fingerprint_alias():
+    request = _parse_runtime_request(
+        "layout.edit.begin",
+        {
+            "workspaceId": "ws-1",
+            "step": "Floorplan",
+            "expectedSourceFingerprint": "abc123",
+        },
+        persistent_db_enabled=True,
+    )
+
+    assert isinstance(request, LayoutEditBeginRequest)
+    assert request.expected_source_fingerprint == "abc123"
 
 
 def test_missing_required_field_reports_field_name():

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -73,6 +73,15 @@ class CompleteFakeApi:
     def layout_edit_discard(self, _request):
         raise AssertionError("unexpected layout_edit_discard call")
 
+    def floorplan_edit_inspect(self, _request):
+        raise AssertionError("unexpected floorplan_edit_inspect call")
+
+    def floorplan_edit_run_auto(self, _request):
+        raise AssertionError("unexpected floorplan_edit_run_auto call")
+
+    def floorplan_edit_validate(self, _request):
+        raise AssertionError("unexpected floorplan_edit_validate call")
+
 
 def test_rpc_hello_returns_version_and_capabilities():
     server = RuntimeServer()

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -61,6 +61,18 @@ class CompleteFakeApi:
     def db_release(self, _request):
         raise AssertionError("unexpected db_release call")
 
+    def layout_edit_begin(self, _request):
+        raise AssertionError("unexpected layout_edit_begin call")
+
+    def layout_edit_apply(self, _request):
+        raise AssertionError("unexpected layout_edit_apply call")
+
+    def layout_edit_save(self, _request):
+        raise AssertionError("unexpected layout_edit_save call")
+
+    def layout_edit_discard(self, _request):
+        raise AssertionError("unexpected layout_edit_discard call")
+
 
 def test_rpc_hello_returns_version_and_capabilities():
     server = RuntimeServer()

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -230,6 +230,64 @@ def test_view_json_apply_edits_passes_compress_option():
     ]
 
 
+def test_place_instance_forwards_legacy_defaults():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+
+    assert module.place_instance(
+        inst_name="u_sram_0",
+        llx=100000,
+        lly=200000,
+        orient="N",
+        cellmaster="SRAM_1RW",
+        source="DIST",
+    ) is True
+
+    assert module.ecc.calls == [
+        (
+            "place_instance",
+            (),
+            {
+                "inst_name": "u_sram_0",
+                "llx": 100000,
+                "lly": 200000,
+                "orient": "N",
+                "cellmaster": "SRAM_1RW",
+                "source": "DIST",
+            },
+        ),
+    ]
+
+
+def test_place_instance_forwards_gui_controls_and_failure():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    calls = []
+    module.ecc = SimpleNamespace(place_instance=lambda **kwargs: calls.append(kwargs) or False)
+
+    assert module.place_instance(
+        inst_name="u_sram_0",
+        llx=110000,
+        lly=210000,
+        orient="",
+        cellmaster="",
+        placement_status="preserve",
+        create_if_missing=False,
+    ) is False
+
+    assert calls == [
+        {
+            "inst_name": "u_sram_0",
+            "llx": 110000,
+            "lly": 210000,
+            "orient": "",
+            "cellmaster": "",
+            "source": "",
+            "placement_status": "preserve",
+            "create_if_missing": False,
+        },
+    ]
+
+
 def test_geometry_snapshot_save_passes_output_directory():
     module = ECCToolsModule.__new__(ECCToolsModule)
     module.ecc = FakeEcc()
@@ -238,6 +296,27 @@ def test_geometry_snapshot_save_passes_output_directory():
 
     assert module.ecc.calls == [
         ("geometry_snapshot_save", (), {"output_dir": "/tmp/geometry"}),
+    ]
+
+
+def test_geometry_edit_session_wrappers_forward_instance_name():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+
+    assert module.initialize_geometry_session() is True
+    assert module.sync_instance_geometry("u_sram_0") is True
+    assert module.geometry_session_snapshot_save(Path("/tmp/session-geometry")) is True
+    assert module.reset_geometry_session() is True
+
+    assert module.ecc.calls == [
+        ("initialize_geometry_session", (), {}),
+        ("sync_instance_geometry", (), {"inst_name": "u_sram_0"}),
+        (
+            "geometry_session_snapshot_save",
+            (),
+            {"output_dir": "/tmp/session-geometry"},
+        ),
+        ("reset_geometry_session", (), {}),
     ]
 
 

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -230,6 +230,17 @@ def test_view_json_apply_edits_passes_compress_option():
     ]
 
 
+def test_geometry_snapshot_save_passes_output_directory():
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+
+    assert module.geometry_snapshot_save(Path("/tmp/geometry")) is True
+
+    assert module.ecc.calls == [
+        ("geometry_snapshot_save", (), {"output_dir": "/tmp/geometry"}),
+    ]
+
+
 def test_ecc_binding_wrappers_stringify_path_arguments(tmp_path):
     module = ECCToolsModule.__new__(ECCToolsModule)
     module.ecc = FakeEcc()

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -234,14 +234,17 @@ def test_place_instance_forwards_legacy_defaults():
     module = ECCToolsModule.__new__(ECCToolsModule)
     module.ecc = FakeEcc()
 
-    assert module.place_instance(
-        inst_name="u_sram_0",
-        llx=100000,
-        lly=200000,
-        orient="N",
-        cellmaster="SRAM_1RW",
-        source="DIST",
-    ) is True
+    assert (
+        module.place_instance(
+            inst_name="u_sram_0",
+            llx=100000,
+            lly=200000,
+            orient="N",
+            cellmaster="SRAM_1RW",
+            source="DIST",
+        )
+        is True
+    )
 
     assert module.ecc.calls == [
         (
@@ -264,15 +267,18 @@ def test_place_instance_forwards_gui_controls_and_failure():
     calls = []
     module.ecc = SimpleNamespace(place_instance=lambda **kwargs: calls.append(kwargs) or False)
 
-    assert module.place_instance(
-        inst_name="u_sram_0",
-        llx=110000,
-        lly=210000,
-        orient="",
-        cellmaster="",
-        placement_status="preserve",
-        create_if_missing=False,
-    ) is False
+    assert (
+        module.place_instance(
+            inst_name="u_sram_0",
+            llx=110000,
+            lly=210000,
+            orient="",
+            cellmaster="",
+            placement_status="preserve",
+            create_if_missing=False,
+        )
+        is False
+    )
 
     assert calls == [
         {

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -106,7 +106,7 @@ class FakeCtsModule:
 
 
 class SnapshotSaveEccModule:
-    def __init__(self, write_snapshot: bool):
+    def __init__(self, *, write_snapshot: bool):
         self.write_snapshot = write_snapshot
         self.geometry_output = None
 

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from chipcompiler.data import (
     PDK,
@@ -12,6 +13,7 @@ from chipcompiler.data import (
     StepInput,
     Workspace,
 )
+from chipcompiler.engine.flow import EngineFlow
 from chipcompiler.tools.ecc import runner as ecc_runner
 from chipcompiler.tools.ecc.builder import build_step, build_step_space
 from chipcompiler.tools.ecc.checklist import EccRcxChecklist
@@ -101,6 +103,44 @@ class FakeCtsModule:
     def feature_cts_timing(self):
         self.calls.append(("feature_cts_timing", {}))
         return self.timing_quality
+
+
+class SnapshotSaveEccModule:
+    def __init__(self, write_snapshot: bool):
+        self.write_snapshot = write_snapshot
+        self.geometry_output = None
+
+    def def_save(self, **_kwargs):
+        return True
+
+    def verilog_save(self, **_kwargs):
+        return True
+
+    def gds_save(self, **_kwargs):
+        return True
+
+    def save_data(self, **_kwargs):
+        return True
+
+    def geometry_snapshot_save(self, output_dir):
+        self.geometry_output = output_dir
+        if not self.write_snapshot:
+            return False
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        (Path(output_dir) / "geometry.manifest").write_text("schema=ecc.geometry.v1\n")
+        return True
+
+    def view_json_save(self, **_kwargs):
+        return True
+
+    def view_json_apply_edits(self, **_kwargs):
+        return True
+
+    def feature_sammry(self, **_kwargs):
+        return True
+
+    def report_summary(self, **_kwargs):
+        return True
 
 
 def test_create_db_engine_accepts_path_inputs_for_first_ecc_step(tmp_path, monkeypatch):
@@ -414,3 +454,46 @@ def test_rcx_checklist_uses_top_module_for_spef_design_token(tmp_path):
     )
 
     assert checklist.check_spef_file(str(spef)) is True
+
+
+def test_save_data_writes_geometry_snapshot_for_physical_step(tmp_path):
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd", top_module="gcd"))
+    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+    module = SnapshotSaveEccModule(write_snapshot=True)
+
+    assert ecc_runner.save_data(workspace, step, module, feature_step=False) is True
+    assert module.geometry_output == step.output.geometry
+    assert step.output.geometry_manifest is not None
+    assert step.output.geometry_manifest.is_file()
+
+
+def test_save_data_fails_when_geometry_snapshot_cannot_be_written(tmp_path):
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd", top_module="gcd"))
+    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+
+    assert (
+        ecc_runner.save_data(
+            workspace,
+            step,
+            SnapshotSaveEccModule(write_snapshot=False),
+            feature_step=False,
+        )
+        is False
+    )
+
+
+def test_engine_flow_requires_geometry_manifest_for_physical_steps(tmp_path):
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd", top_module="gcd"))
+    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+    build_step_space(step)
+    for output_path in (step.output.def_, step.output.verilog, step.output.gds):
+        assert output_path is not None
+        output_path.write_text("", encoding="utf-8")
+    assert step.output.geometry_manifest is not None
+    step.output.geometry_manifest.parent.mkdir(parents=True)
+    step.output.geometry_manifest.write_text("schema=ecc.geometry.v1\n", encoding="utf-8")
+
+    assert EngineFlow(workspace).check_step_result(step) is True
+
+    step.output.geometry_manifest.unlink()
+    assert EngineFlow(workspace).check_step_result(step) is False

--- a/test/tools/klayout_tool/test_module.py
+++ b/test/tools/klayout_tool/test_module.py
@@ -34,12 +34,14 @@ def test_save_snapshot_image_passes_path_text_to_klayout(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "klayout.db", db)
     monkeypatch.setitem(sys.modules, "klayout.lay", lay)
     sys.modules.pop("chipcompiler.tools.klayout_tool.module", None)
+    sys.modules.pop("chipcompiler.tools.klayout_tool.image", None)
 
     klayout_module = importlib.import_module("chipcompiler.tools.klayout_tool.module")
     module = klayout_module.KlayoutModule(workspace=Workspace(), step=WorkspaceStep())
 
     gds_file = tmp_path / "design.gds"
     img_file = tmp_path / "design.png"
+    gds_file.write_text("GDS", encoding="utf-8")
     module.save_snapshot_image(gds_file=gds_file, img_file=img_file, weight=800, height=600)
 
     assert calls["load_layout"] == (str(gds_file), 0)

--- a/uv.lock
+++ b/uv.lock
@@ -590,6 +590,7 @@ name = "ecc-tools-bin"
 version = "0.1.0a8"
 source = { editable = "chipcompiler/thirdparty/ecc-tools" }
 dependencies = [
+    { name = "matplotlib" },
     { name = "numpy" },
 ]
 
@@ -600,7 +601,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "numpy" }]
+requires-dist = [
+    { name = "matplotlib", specifier = ">=3.4" },
+    { name = "numpy" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What Changed

- add geometry db for gui and enable chip layout view and instance placement

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [x] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
