### PR TITLE
refactor: delete ecc snapshot

### DIFF
--- a/chipcompiler/data/workspace/__init__.py
+++ b/chipcompiler/data/workspace/__init__.py
@@ -863,7 +863,7 @@ def update_step_config(workspace: Workspace, step: WorkspaceStep) -> None:
 
     if step.name == StepEnum.RCX.value:
         rcx = json_read(workspace.config[f"{StepEnum.RCX.value}"])
-        rcx_output_dir = path_text(step.output.dir)
+        rcx_output_dir = path_text(step.data.dir)
         spef_design_name = workspace.design.top_module or workspace.design.name
         rcx["output"] = rcx_output_dir
         for corner in rcx.get("corners", []):

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -33,7 +33,7 @@ _GEOMETRY_SNAPSHOT_STEPS = frozenset(
         StepEnum.DRC.value,
         StepEnum.FILLER.value,
         StepEnum.RCX.value,
-        StepEnum.STA.value
+        StepEnum.STA.value,
     }
 )
 

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -32,6 +32,8 @@ _GEOMETRY_SNAPSHOT_STEPS = frozenset(
         StepEnum.ROUTING.value,
         StepEnum.DRC.value,
         StepEnum.FILLER.value,
+        StepEnum.RCX.value,
+        StepEnum.STA.value
     }
 )
 
@@ -47,7 +49,7 @@ def temperature_token(temperature) -> str:
 
 
 def copy_rcx_spef_outputs(workspace: Workspace, step: WorkspaceStep):
-    output_dir_text = os.fspath(step.output.dir or "" or "")
+    output_dir_text = os.fspath(step.data.dir or "" or "")
     if not output_dir_text:
         return
 

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -5,11 +5,7 @@ from pathlib import Path
 import chipcompiler.data as data_api
 import chipcompiler.data.workspace as workspace_data
 from chipcompiler.data import (
-    OriginDesign,
-    OutputPaths,
     StepEnum,
-    StepInput,
-    WorkspaceStep,
     create_workspace,
     load_workspace,
 )
@@ -20,7 +16,6 @@ from chipcompiler.data.workspace import (
     prepare_workspace_for_rerun,
     refresh_workspace_config,
     sync_workspace_config_to_parameters,
-    update_step_config,
 )
 from chipcompiler.utility import json_read, json_write
 
@@ -50,34 +45,6 @@ ROUTABILITY_FLAG_STRING_CASES = (
     ("2", 2),
     ("maybe", 1),
 )
-
-
-def test_rcx_step_config_uses_top_module_for_spef_paths(tmp_path):
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    db_config = config_dir / "db.json"
-    rcx_config = config_dir / "rcx.json"
-    json_write(db_config, {"INPUT": {}, "OUTPUT": {}})
-    json_write(
-        rcx_config,
-        {"corners": [{"name": "Cworst", "temperature": [125]}]},
-    )
-    workspace = Workspace(
-        directory=tmp_path,
-        design=OriginDesign(name="project_gcd_ws_0002", top_module="gcd"),
-        config={"db": db_config, StepEnum.RCX.value: rcx_config},
-    )
-    step = WorkspaceStep(
-        name=StepEnum.RCX.value,
-        input=StepInput(def_=None, verilog=None),
-        output=OutputPaths(dir=tmp_path / "RCX_ecc" / "output"),
-    )
-
-    update_step_config(workspace, step)
-
-    assert json_read(rcx_config)["corners"][0]["spef_file"] == [
-        {"125": str(tmp_path / "RCX_ecc" / "output" / "gcd_Cworst_125C.spef")}
-    ]
 
 
 def _create_loaded_ics55_workspace(


### PR DESCRIPTION
## What Changed

- build: remove standalone geometry snapshot tool。
- modify rcx process data path

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [x] Native toolchain or wrapper behavior changed
- [x] `ecc-tools` or `ecc-dreamplace` dependency changed
- [x] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
