### PR TITLE
fix(ci): restore to latest ics55 pdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,8 @@ jobs:
 
       - name: Setup PDK
         run: |
-          git clone --depth 10 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
-          cd chipcompiler/thirdparty/icsprout55-pdk
-          git checkout 7517041c8ae80ce99b44ff1ad4ebca6de5ee3c53 # Pin for ecc-dreamplace error on latest pdk, remove this after upstream fix.
-          curl -fsSL https://github.com/Emin017/icsprout55-pdk/commit/9a4df8c336158a78947cbcbe6b18d19cae5bab3c.patch | git apply --verbose
-          grep -q 'RELEASE_TAG ?= latest' Makefile || { echo "Patch failed to apply"; exit 1; }
-          make unzip RELEASE_TAG=v1.10.100
+          git clone --depth 1 https://github.com/openecos-projects/icsprout55-pdk.git chipcompiler/thirdparty/icsprout55-pdk
+          cd chipcompiler/thirdparty/icsprout55-pdk && make unzip
 
       - name: Setup OSS CAD Suite
         uses: YosysHQ/setup-oss-cad-suite@v4


### PR DESCRIPTION
## What Changed

- ecc-tools: https://github.com/openecos-projects/ecc-tools/commit/ffa44bcb6c90bade58e74ceeffd1115386e0d851

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.