### PR TITLE
fix: strip symbols of elf files in the bundle

### DIFF
--- a/.github/actions/build-pyinstaller-bundle/action.yml
+++ b/.github/actions/build-pyinstaller-bundle/action.yml
@@ -31,6 +31,17 @@ runs:
             ;;
         esac
 
+    # The manylinux_2_34 image's binutils 2.41 breaks ELF alignment when
+    # stripping .so files (https://sourceware.org/bugzilla/show_bug.cgi?id=31208);
+    # install a fixed strip (>= 2.43) from conda-forge.
+    - name: Install fixed binutils (strip >= 2.43)
+      shell: bash
+      run: |
+        mkdir -p /tmp/micromamba
+        curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xj -C /tmp/micromamba
+        /tmp/micromamba/bin/micromamba create -y -p /opt/bf -c conda-forge binutils=2.44
+        echo "/opt/bf/bin" >> "$GITHUB_PATH"
+
     - name: Build PyInstaller bundle
       shell: bash
       run: |

--- a/ecc.spec
+++ b/ecc.spec
@@ -24,6 +24,7 @@ ECC_DIR = Path(SPECPATH)
 HOOKS_DIR = ECC_DIR / "hooks"
 CODESIGN_IDENTITY = os.environ.get("APPLE_SIGNING_IDENTITY")
 BUNDLE_MODE = os.environ.get("ECOS_PYINSTALLER_MODE", "onedir").strip().lower()
+STRIP_BINARIES = sys.platform.startswith("linux")
 
 if BUNDLE_MODE not in {"onedir", "onefile"}:
     raise SystemExit(f"Unsupported ECOS_PYINSTALLER_MODE={BUNDLE_MODE!r}; use onedir or onefile.")
@@ -262,7 +263,7 @@ if BUNDLE_MODE == "onedir":
         [],
         exclude_binaries=True,
         name="ecc",
-        strip=False,
+        strip=STRIP_BINARIES,
         upx=False,
         console=True,
         codesign_identity=CODESIGN_IDENTITY,
@@ -273,7 +274,7 @@ if BUNDLE_MODE == "onedir":
         a.binaries,
         a.zipfiles,
         a.datas,
-        strip=False,
+        strip=STRIP_BINARIES,
         upx=False,
         name="ecc",
     )
@@ -286,7 +287,7 @@ else:
         a.datas,
         [],
         name="ecc",
-        strip=False,
+        strip=STRIP_BINARIES,
         upx=True,
         console=True,
         codesign_identity=CODESIGN_IDENTITY,


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
