### PR TITLE
refactor: remove unused fixed netlist from synthesis output

### DIFF
--- a/chipcompiler/data/workspace/layout.py
+++ b/chipcompiler/data/workspace/layout.py
@@ -45,7 +45,6 @@ class OutputPaths:
 @dataclass
 class YosysOutput(OutputPaths):
     sim_verilog: Path | None = None
-    fixed_verilog: Path | None = None
     report: Path | None = None
 
 

--- a/chipcompiler/tools/yosys/builder.py
+++ b/chipcompiler/tools/yosys/builder.py
@@ -261,7 +261,6 @@ def build_step(
                 else output_dir / f"{design}_{step_name}.v.gz"
             ),
             sim_verilog=output_dir / f"{design}_{step_name}_sim.v.gz",
-            fixed_verilog=output_dir / f"{design}_{step_name}_fixed.v.gz",
             json=output_dir / f"{design}_{step_name}.json",
             report=output_dir / f"{design}_{step_name}.rpt",
             image=output_dir / f"{design}_{step_name}.png",

--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -1,56 +1,12 @@
 #!/usr/bin/env python
 import os
 import subprocess
-from pathlib import Path
 
 from chipcompiler.data import StateEnum, Workspace, YosysStep
 from chipcompiler.tools.yosys.checklist import YosysChecklist
 from chipcompiler.tools.yosys.metrics import build_step_metrics
 from chipcompiler.tools.yosys.subflow import YosysSubFlow
 from chipcompiler.tools.yosys.utility import check_slang_plugin, get_yosys_runtime
-from chipcompiler.utility.gzip import read_text_maybe_gzip, write_text_maybe_gzip
-
-
-def _remove_parameter_overrides(text: str) -> str:
-    """Remove Verilog parameter override blocks of the form #( ... )."""
-    out = []
-    i = 0
-    length = len(text)
-
-    while i < length:
-        if text[i] == "#" and i + 1 < length and text[i + 1] == "(":
-            depth = 0
-            j = i + 1
-            while j < length:
-                if text[j] == "(":
-                    depth += 1
-                elif text[j] == ")":
-                    depth -= 1
-                    if depth == 0:
-                        j += 1
-                        break
-                j += 1
-
-            if depth == 0:
-                i = j
-                continue
-
-        out.append(text[i])
-        i += 1
-
-    return "".join(out)
-
-
-def _write_fixed_netlist(src_path: str | Path, dst_path: str | Path) -> bool:
-    """Write an extra netlist with parameter override blocks removed."""
-    if not src_path or not dst_path or not os.path.exists(src_path):
-        return False
-
-    text = read_text_maybe_gzip(src_path)
-    fixed = _remove_parameter_overrides(text)
-    write_text_maybe_gzip(dst_path, fixed)
-
-    return True
 
 
 def _run_ecc_synthesis_sta(workspace: Workspace, step: YosysStep, ecc_module=None) -> bool:
@@ -138,10 +94,6 @@ def run_step(workspace: Workspace, step: YosysStep, ecc_module=None) -> bool:
 
         if os.path.exists(step.output.verilog or ""):
             sub_flow.update_step(step_name="run yosys", state=StateEnum.Success)
-
-            fixed_netlist = step.output.fixed_verilog or ""
-            if fixed_netlist:
-                _write_fixed_netlist(step.output.verilog or "", fixed_netlist)
 
             _run_ecc_synthesis_sta(
                 workspace=workspace,

--- a/test/data/test_workspace_layout.py
+++ b/test/data/test_workspace_layout.py
@@ -158,7 +158,7 @@ def test_log_projection_yosys_shape_has_no_foreign_keys(tmp_path):
     step = yosys_builder.build_step(workspace, "Synthesis", None, tmp_path / "in.v")
     keys = _shape_keys(step)
     assert keys["output"] == sorted(
-        ["dir", "def", "verilog", "fixed_verilog", "sim_verilog", "json", "report", "image"]
+        ["dir", "def", "verilog", "sim_verilog", "json", "report", "image"]
     )
     assert keys["data"] == sorted(["dir", "tmp"])
     assert keys["feature"] == sorted(["dir", "step", "generic_stat", "stat"])

--- a/test/tools/yosys/test_global_var_builder.py
+++ b/test/tools/yosys/test_global_var_builder.py
@@ -103,7 +103,6 @@ def test_yosys_builder_constructs_path_objects_and_creates_dirs(tmp_path):
     assert isinstance(step.directory, Path)
     assert step.input.verilog == rtl_file
     assert step.output.dir == expected_step_dir / "output"
-    assert step.output.fixed_verilog == expected_step_dir / "output" / "top_Synthesis_fixed.v.gz"
     assert step.script.main == expected_step_dir / "script" / "Synthesis_main.tcl"
 
     yosys_builder.build_step_space(step)

--- a/test/tools/yosys/test_runner.py
+++ b/test/tools/yosys/test_runner.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import gzip
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -227,19 +226,3 @@ def test_run_step_marks_invalid_when_yosys_is_missing(tmp_path, monkeypatch):
     assert result is False
     assert ("run yosys", StateEnum.Invalid) in updates
     assert "yosys is not available" in log_file.read_text()
-
-
-def test_write_fixed_netlist_handles_gzip_paths(tmp_path):
-    source = tmp_path / "source.v.gz"
-    destination = tmp_path / "fixed.v.gz"
-    with gzip.open(source, "wt", encoding="utf-8") as file:
-        file.write("module top;\n  CELL #(.WIDTH(1)) u0();\nendmodule\n")
-
-    assert runner._write_fixed_netlist(str(source), str(destination)) is True
-
-    with gzip.open(destination, "rt", encoding="utf-8") as file:
-        fixed = file.read()
-
-    assert "module top" in fixed
-    assert "#(" not in fixed
-    assert "endmodule" in fixed


### PR DESCRIPTION
## What Changed

- Remove unused fixed netlist (Introduced in #77)

After Yosys reads in the Verilog of a macro, it generates module parameter syntax, which can cause backend tools to report errors. After the macro’s Liberty file is read in, Yosys automatically treats it as a blackbox; therefore, once the Liberty file has been read normally, no additional fix is needed.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- x ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
