### PR TITLE
fix(sizer): tolerate steps whose tool lacks build_step_metrics, set geometry to None 

### DIFF
--- a/chipcompiler/tools/ecc_sizer/builder.py
+++ b/chipcompiler/tools/ecc_sizer/builder.py
@@ -44,6 +44,10 @@ def build_step(
         step_directory=step_directory,
     )
     step.output.db = ""
+    # Sizer produces no geometry snapshot; leave the destination undeclared so
+    # it is not part of this step's success contract (see EngineFlow.check_step_result).
+    step.output.geometry = None
+    step.output.geometry_manifest = None
     script_dir = step.script.dir or step_directory / "script"
     step.script.sizer_env = script_dir / f"{workspace.design.name}.env_file"
     step.script.sizer_cmd = script_dir / f"{workspace.design.name}.cmd_file"

--- a/chipcompiler/tools/eda.py
+++ b/chipcompiler/tools/eda.py
@@ -129,10 +129,11 @@ def build_step_metrics(workspace: Workspace, step: WorkspaceStep) -> StepMetrics
     build step metrics
     """
     eda_module = load_eda_module(step.tool)
-    if eda_module is None:
+    build_metrics = getattr(eda_module, "build_step_metrics", None)
+    if build_metrics is None:
         return None
 
-    metrics = eda_module.build_step_metrics(workspace=workspace, step=step)
+    metrics = build_metrics(workspace=workspace, step=step)
 
     return metrics
 

--- a/chipcompiler/utility/log.py
+++ b/chipcompiler/utility/log.py
@@ -148,6 +148,9 @@ class Logger:
     def error(self, msg: str, *args, **kwargs):
         self.logger.error(msg, *args, **kwargs)
 
+    def exception(self, msg: str, *args, **kwargs):
+        self.logger.exception(msg, *args, **kwargs)
+
     def critical(self, msg: str, *args, **kwargs):
         self.logger.critical(msg, *args, **kwargs)
 


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [x] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
