### PR TITLE
fix: support typed candidate rerun steps

### DIFF
--- a/chipcompiler/data/candidate_input_binding.py
+++ b/chipcompiler/data/candidate_input_binding.py
@@ -51,7 +51,7 @@ def bind_candidate_input(
     inputs = _source_inputs(workspace, engine_flow, source_step)
     receipt = _build_receipt(workspace, target_step, source_step, candidate_id, inputs)
     write_json_atomic(_receipt_path(workspace), receipt)
-    target.input = dict(inputs)
+    _set_target_inputs(target, inputs)
     return receipt
 
 
@@ -79,7 +79,7 @@ def reapply_candidate_input_binding(
     )
     if receipt != actual:
         raise CandidateInputBindingError("candidate input binding source artifacts are stale")
-    target.input = dict(inputs)
+    _set_target_inputs(target, inputs)
     return actual
 
 
@@ -107,9 +107,23 @@ def _source_inputs(workspace: Any, engine_flow: Any, source_step: str) -> dict[s
         }
     else:
         source = _step_or_error(engine_flow, source_step, "source").output
-    inputs = {key: _path_or_none(source.get(key)) for key in ("def", "verilog", "db")}
+    inputs = {key: _path_or_none(_group_value(source, key)) for key in ("def", "verilog", "db")}
     _validate_source_inputs(source_step, inputs)
     return inputs
+
+
+def _group_value(group: Any, key: str) -> Any:
+    if isinstance(group, dict):
+        return group.get(key)
+    return getattr(group, "def_" if key == "def" else key, None)
+
+
+def _set_target_inputs(target: Any, inputs: dict[str, Path | None]) -> None:
+    if isinstance(target.input, dict):
+        target.input = dict(inputs)
+        return
+    for key, value in inputs.items():
+        setattr(target.input, "def_" if key == "def" else key, value)
 
 
 def _path_or_none(value: Any) -> Path | None:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -940,7 +940,7 @@ class WorkspaceRuntimeApi:
         directories: list[Path] = []
         for field in ("output", "data", "feature", "analysis", "report", "log"):
             value = getattr(step, field, {})
-            directory = value.get("dir") if isinstance(value, dict) else None
+            directory = value.get("dir") if isinstance(value, dict) else getattr(value, "dir", None)
             if directory:
                 directories.append(Path(directory))
         return tuple(dict.fromkeys(directories))

--- a/test/data/test_candidate_input_binding.py
+++ b/test/data/test_candidate_input_binding.py
@@ -10,6 +10,7 @@ from chipcompiler.data.candidate_input_binding import (
     bind_candidate_input,
     reapply_candidate_input_binding,
 )
+from chipcompiler.data.workspace.layout import EccOutput, EccStep, StepInput
 
 
 def _sha256(path: Path) -> str:
@@ -77,6 +78,33 @@ def test_bind_and_reapply_cts_from_legalization_uses_checkpoint_outputs(tmp_path
 
     assert applied["inputs"]["def"]["sha256"] == _sha256(legalization.output["def"])
     assert cts.input == legalization.output
+
+
+def test_bind_candidate_input_reads_typed_ecc_output_paths(tmp_path):
+    cts = EccStep(name="CTS", input=StepInput())
+    legalization_output = _step(tmp_path, "legalization").output
+    legalization = EccStep(
+        name="legalization",
+        output=EccOutput(
+            dir=legalization_output["db"],
+            def_=legalization_output["def"],
+            verilog=legalization_output["verilog"],
+            db=legalization_output["db"],
+        ),
+    )
+    workspace = SimpleNamespace(directory=str(tmp_path), design=SimpleNamespace())
+
+    bind_candidate_input(
+        workspace,
+        _Flow(cts, legalization),
+        "CTS",
+        "legalization",
+        candidate_id="cts-rerun-typed-output",
+    )
+
+    assert cts.input.def_ == legalization_output["def"]
+    assert cts.input.verilog == legalization_output["verilog"]
+    assert cts.input.db == legalization_output["db"]
 
 
 @pytest.mark.parametrize(

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from chipcompiler.data import StateEnum
+from chipcompiler.data.workspace.layout import EccOutput
 from chipcompiler.runtime.requests import (
     CandidateBindInputRequest,
     CandidateMaterializeRequest,
@@ -1294,7 +1295,7 @@ def test_candidate_rerun_rebuilds_the_requested_scope(
         {
             "name": "place",
             "tool": "dreamplace",
-            "output": {"dir": ws / "place_dreamplace/output"},
+            "output": EccOutput(dir=ws / "place_dreamplace/output"),
             "analysis": {"dir": ws / "place_dreamplace/analysis"},
         },
         {


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
