### PR TITLE
fix(iFP): align via enclosures with PG lines support die sizing modes

### DIFF
--- a/chipcompiler/tools/ecc/configs/fp_default_config.json
+++ b/chipcompiler/tools/ecc/configs/fp_default_config.json
@@ -10,12 +10,21 @@
     },
     "die_builder": {
         "site_name": "core7",
-        "core_width_to_height_ratio": 1.0,
-        "core_utilization": 0.3,
-        "left_margin_micron": 2.0,
-        "right_margin_micron": 2.0,
-        "top_margin_micron": 2.0,
-        "bottom_margin_micron": 2.0
+        "mode": "die_util",
+        "margin": {
+            "left_micron": 2.0,
+            "right_micron": 2.0,
+            "top_micron": 2.0,
+            "bottom_micron": 2.0
+        },
+        "die_util": {
+            "aspect_ratio": 1.0,
+            "utilization": 0.5
+        },
+        "die_size": {
+            "width_micron": 100.1,
+            "height_micron": 246.6
+        }
     },
     "io_placer": {
         "io_layer_list": [
@@ -23,7 +32,7 @@
             "MET4"
         ],
         "width_micron": 0.1,
-        "depth_micron": 0.7
+        "depth_micron": 0.6
     },
     "phy_placer": {
         "well_tap": {


### PR DESCRIPTION
## What Changed

- https://github.com/openecos-projects/ecc-tools/commit/735efd2a01f3fc97ef2972e69192ae7ab1576fb4

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
