### PR TITLE
fix: update floorplan config schema

### DIFF
--- a/chipcompiler/data/workspace/__init__.py
+++ b/chipcompiler/data/workspace/__init__.py
@@ -472,16 +472,21 @@ def _load_default_floorplan_config() -> dict:
 
 
 def _has_new_floorplan_schema(config: dict) -> bool:
-    return all(
-        key in config
-        for key in (
-            "ifp",
-            "macro_placer",
-            "die_builder",
-            "io_placer",
-            "phy_placer",
-            "pdn_generator",
+    die_builder = config.get("die_builder")
+    return (
+        all(
+            key in config
+            for key in (
+                "ifp",
+                "macro_placer",
+                "die_builder",
+                "io_placer",
+                "phy_placer",
+                "pdn_generator",
+            )
         )
+        and isinstance(die_builder, dict)
+        and all(key in die_builder for key in ("mode", "margin", "die_util", "die_size"))
     )
 
 
@@ -505,37 +510,62 @@ def _refresh_floorplan_config(workspace: Workspace, step: WorkspaceStep | None =
     if not config_path:
         return
 
+    default_floorplan = _load_default_floorplan_config()
     floorplan = json_read(config_path) if Path(config_path).exists() else {}
     if not _has_new_floorplan_schema(floorplan):
-        floorplan = _load_default_floorplan_config()
+        floorplan = default_floorplan
 
     ifp = floorplan.setdefault("ifp", {})
-    ifp.setdefault("thread_number", 16)
+    default_ifp = default_floorplan.get("ifp", {})
+    ifp.setdefault("thread_number", default_ifp.get("thread_number", 16))
     if step is not None:
         workdir = step.data.workdir_for(StepEnum.FLOORPLAN.value)
         if workdir:
             ifp["temp_directory_path"] = path_text(workdir)
 
+    default_die_builder = default_floorplan.get("die_builder", {})
+    die_builder = floorplan.setdefault("die_builder", {})
+    die_builder.setdefault("mode", default_die_builder.get("mode", "die_util"))
+    die_builder["site_name"] = workspace.pdk.site_core or die_builder.get(
+        "site_name", default_die_builder.get("site_name", "")
+    )
+
+    default_margin = default_die_builder.get("margin", {})
+    margin_config = die_builder.setdefault("margin", {})
     core = workspace.parameters.data.get("Core", {})
     margin = core.get("Margin", [])
     if len(margin) < 2:
         margin = [
-            floorplan.get("die_builder", {}).get("left_margin_micron", 10.0),
-            floorplan.get("die_builder", {}).get("bottom_margin_micron", 10.0),
+            margin_config.get("left_micron", default_margin.get("left_micron", 10.0)),
+            margin_config.get("bottom_micron", default_margin.get("bottom_micron", 10.0)),
         ]
+    margin_config["left_micron"] = margin[0]
+    margin_config["right_micron"] = margin[0]
+    margin_config["top_micron"] = margin[1]
+    margin_config["bottom_micron"] = margin[1]
 
-    die_builder = floorplan.setdefault("die_builder", {})
-    die_builder["site_name"] = workspace.pdk.site_core or die_builder.get("site_name", "")
-    die_builder["core_width_to_height_ratio"] = core.get(
-        "Aspect ratio", die_builder.get("core_width_to_height_ratio", 1.0)
+    default_die_util = default_die_builder.get("die_util", {})
+    die_util = die_builder.setdefault("die_util", {})
+    die_util["aspect_ratio"] = core.get(
+        "Aspect ratio", die_util.get("aspect_ratio", default_die_util.get("aspect_ratio", 1.0))
     )
-    die_builder["core_utilization"] = core.get(
-        "Utilitization", die_builder.get("core_utilization", 0.5)
+    die_util["utilization"] = core.get(
+        "Utilitization", die_util.get("utilization", default_die_util.get("utilization", 0.5))
     )
-    die_builder["left_margin_micron"] = margin[0]
-    die_builder["right_margin_micron"] = margin[0]
-    die_builder["top_margin_micron"] = margin[1]
-    die_builder["bottom_margin_micron"] = margin[1]
+
+    default_die_size = default_die_builder.get("die_size", {})
+    die_size = die_builder.setdefault("die_size", {})
+    die_size.setdefault("width_micron", default_die_size.get("width_micron", 100.1))
+    die_size.setdefault("height_micron", default_die_size.get("height_micron", 246.6))
+    for legacy_key in (
+        "core_width_to_height_ratio",
+        "core_utilization",
+        "left_margin_micron",
+        "right_margin_micron",
+        "top_margin_micron",
+        "bottom_margin_micron",
+    ):
+        die_builder.pop(legacy_key, None)
 
     phy_placer = floorplan.setdefault("phy_placer", {})
     well_tap = phy_placer.setdefault("well_tap", {})

--- a/chipcompiler/tools/ecc/configs/fp_default_config.json
+++ b/chipcompiler/tools/ecc/configs/fp_default_config.json
@@ -9,13 +9,22 @@
         "macro_location_path": "macro_locations.txt"
     },
     "die_builder": {
+        "mode": "die_util",
         "site_name": "core7",
-        "core_width_to_height_ratio": 1.0,
-        "core_utilization": 0.3,
-        "left_margin_micron": 2.0,
-        "right_margin_micron": 2.0,
-        "top_margin_micron": 2.0,
-        "bottom_margin_micron": 2.0
+        "margin": {
+            "left_micron": 2.0,
+            "right_micron": 2.0,
+            "top_micron": 2.0,
+            "bottom_micron": 2.0
+        },
+        "die_util": {
+            "aspect_ratio": 1.0,
+            "utilization": 0.5
+        },
+        "die_size": {
+            "width_micron": 100.1,
+            "height_micron": 246.6
+        }
     },
     "io_placer": {
         "io_layer_list": [
@@ -23,7 +32,7 @@
             "MET4"
         ],
         "width_micron": 0.1,
-        "depth_micron": 0.7
+        "depth_micron": 0.6
     },
     "phy_placer": {
         "well_tap": {

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -684,6 +684,7 @@ def test_refresh_workspace_config_updates_all_parameter_derived_fields(
     fixfanout = json_read(workspace.config["fixFanout"])
     placement = json_read(workspace.config["place"])
     db = json_read(workspace.config["db"])
+    floorplan = json_read(workspace.config[StepEnum.FLOORPLAN.value])
     routing = json_read(workspace.config["route"])
     dreamplace = json_read(workspace.config["dreamplace"])
 
@@ -696,6 +697,19 @@ def test_refresh_workspace_config_updates_all_parameter_derived_fields(
     assert dreamplace["stop_overflow"] == 0.07
     assert dreamplace["cell_padding_x"] == 444
     assert dreamplace["routability_opt_flag"] == 0
+    assert floorplan["die_builder"] == {
+        "mode": "die_util",
+        "site_name": "core7",
+        "margin": {
+            "left_micron": 2,
+            "right_micron": 2,
+            "top_micron": 2,
+            "bottom_micron": 2,
+        },
+        "die_util": {"aspect_ratio": 1, "utilization": 0.4},
+        "die_size": {"width_micron": 100.1, "height_micron": 246.6},
+    }
+    assert floorplan["io_placer"]["depth_micron"] == 0.6
 
 
 def test_refresh_workspace_config_preserves_routability_flag_string_coercion(


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
