### PR TITLE
fix: accept filelist and SystemVerilog inputs in signoff Initial RTL check

### DIFF
--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -2,9 +2,9 @@ import os
 import tomllib
 from dataclasses import dataclass, field
 
+from chipcompiler.utility.filelist import FILELIST_SUFFIXES, RTL_SUFFIXES
+
 SUPPORTED_PDK_NAMES = {"ics55"}
-FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
-RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}
 
 
 class InvalidFlowRun:

--- a/chipcompiler/tools/ecc/signoff_checklist.py
+++ b/chipcompiler/tools/ecc/signoff_checklist.py
@@ -20,6 +20,7 @@ from chipcompiler.tools.ecc.sta_qor import (
     read_sta_timing_paths,
 )
 from chipcompiler.utility import json_read
+from chipcompiler.utility.filelist import FILELIST_SUFFIXES, RTL_SUFFIXES
 
 _STEP_DIRECTORIES = {
     StepEnum.SYNTHESIS.value: "Synthesis_yosys",
@@ -488,6 +489,33 @@ def _flow_items(workspace: Workspace) -> list[dict]:
     return items
 
 
+def _initial_rtl_path(design, origin_directory: Path) -> Path | None:
+    """Resolve the initial RTL input: filelist first, then a single RTL file.
+
+    Mirrors the synthesis input priority (input_filelist over origin_verilog).
+    Configured paths win when they exist; otherwise glob the origin directory
+    by suffix, since load_workspace drops these attributes for .sv and
+    filelist inputs. A configured path missing on disk is returned last so
+    the item reports it as failed.
+    """
+    configured = (
+        getattr(design, "input_filelist", None),
+        getattr(design, "origin_verilog", None),
+    )
+    for candidate in configured:
+        if candidate and Path(candidate).is_file():
+            return Path(candidate)
+    files = sorted(path for path in origin_directory.glob("*") if path.is_file())
+    for suffixes in (FILELIST_SUFFIXES, RTL_SUFFIXES):
+        match = next((path for path in files if path.suffix.lower() in suffixes), None)
+        if match:
+            return match
+    match = next((path for path in files if path.name.endswith(".v.gz")), None)
+    if match:
+        return match
+    return next((Path(candidate) for candidate in configured if candidate), None)
+
+
 def _workspace_items(workspace: Workspace) -> list[dict]:
     workspace_directory = Path(workspace.directory)
     origin_directory = workspace_directory / "origin"
@@ -495,15 +523,12 @@ def _workspace_items(workspace: Workspace) -> list[dict]:
     pdk = getattr(workspace, "pdk", None)
     config = getattr(workspace, "config", {})
     config = config if isinstance(config, dict) else {}
-    origin_verilog = getattr(design, "origin_verilog", None)
-    if not origin_verilog:
-        origin_verilog = next(iter(sorted(origin_directory.glob("*.v*"))), None)
     origin_sdc = getattr(pdk, "sdc", None)
     if not origin_sdc:
         origin_sdc = next(iter(sorted(origin_directory.glob("*.sdc"))), None)
     config_keys = ("flow", "db", StepEnum.RCX.value, StepEnum.STA.value)
     inputs = (
-        ("provenance.initial.rtl", "Initial RTL", origin_verilog),
+        ("provenance.initial.rtl", "Initial RTL", _initial_rtl_path(design, origin_directory)),
         ("provenance.initial.sdc", "Initial SDC", origin_sdc),
         *(
             (

--- a/chipcompiler/utility/filelist.py
+++ b/chipcompiler/utility/filelist.py
@@ -24,6 +24,9 @@ Example filelist content:
 
 import os
 
+FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
+RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}
+
 UNSUPPORTED_OPTIONS = {
     "-f": "Recursive filelist files",
     "-v": "Library files",

--- a/test/tools/ecc/test_signoff_checklist.py
+++ b/test/tools/ecc/test_signoff_checklist.py
@@ -14,7 +14,7 @@ from chipcompiler.data import (
     WorkspaceStep,
 )
 from chipcompiler.tools.ecc.metrics import _quality_gates, build_qor_summary_payload
-from chipcompiler.tools.ecc.signoff_checklist import refresh_step_checklist
+from chipcompiler.tools.ecc.signoff_checklist import _workspace_items, refresh_step_checklist
 
 
 def _record(metric_id, value, path="feature/step.json"):
@@ -400,3 +400,113 @@ def test_harden_checklist_blocks_on_failed_mpc_area_gate_and_keeps_route_evidenc
     assert items["quality.mpc.maximum_area"]["evidence"] == [
         {"kind": "feature", "path": "route_ecc/feature/route.db.json"}
     ]
+
+
+def _rtl_item(workspace):
+    return next(
+        item for item in _workspace_items(workspace) if item["id"] == "provenance.initial.rtl"
+    )
+
+
+def _passing_rtl_item(path):
+    return {
+        "id": "provenance.initial.rtl",
+        "step": "workspace",
+        "category": "provenance",
+        "owner": "checklist",
+        "policy": "block",
+        "state": "pass",
+        "blocked": False,
+        "title": "Initial RTL",
+        "summary": "Current output is present and non-empty.",
+        "source": {"kind": "provenance", "path": path},
+        "evidence": [{"kind": "provenance", "path": path}],
+    }
+
+
+def test_initial_rtl_prefers_configured_filelist_over_verilog_placeholder(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    (origin / "gcd.f").write_text("gcd.sv\n", encoding="utf-8")
+    (origin / "gcd.sv").write_text("module gcd; endmodule\n", encoding="utf-8")
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(
+            name="gcd",
+            # Workspace creation always sets origin_verilog, a placeholder
+            # that never exists for filelist inputs.
+            origin_verilog=origin / "gcd.v",
+            input_filelist=origin / "gcd.f",
+        ),
+    )
+
+    assert _rtl_item(workspace) == _passing_rtl_item("origin/gcd.f")
+
+
+def test_initial_rtl_globs_filelist_when_attributes_missing(tmp_path):
+    # load_workspace restores neither input_filelist nor .sv sources, so the
+    # checklist must rediscover the filelist ahead of any RTL sources.
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    (origin / "gcd.f").write_text("gcd.sv\n", encoding="utf-8")
+    (origin / "gcd.sv").write_text("module gcd; endmodule\n", encoding="utf-8")
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd"))
+
+    assert _rtl_item(workspace) == _passing_rtl_item("origin/gcd.f")
+
+
+def test_initial_rtl_globs_systemverilog_when_attributes_missing(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    (origin / "gcd.sv").write_text("module gcd; endmodule\n", encoding="utf-8")
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd"))
+
+    assert _rtl_item(workspace) == _passing_rtl_item("origin/gcd.sv")
+
+
+def test_initial_rtl_accepts_plain_verilog(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    (origin / "gcd.v").write_text("module gcd; endmodule\n", encoding="utf-8")
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", origin_verilog=origin / "gcd.v"),
+    )
+
+    assert _rtl_item(workspace) == _passing_rtl_item("origin/gcd.v")
+
+
+def test_initial_rtl_accepts_gzipped_verilog(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    (origin / "gcd.v.gz").write_bytes(b"\x1f\x8bfake")
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd"))
+
+    assert _rtl_item(workspace) == _passing_rtl_item("origin/gcd.v.gz")
+
+
+def test_initial_rtl_reports_configured_file_missing(tmp_path):
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(
+            name="gcd",
+            origin_verilog=origin / "gcd.v",
+            input_filelist=origin / "gcd.f",
+        ),
+    )
+
+    assert _rtl_item(workspace) == {
+        "id": "provenance.initial.rtl",
+        "step": "workspace",
+        "category": "provenance",
+        "owner": "checklist",
+        "policy": "block",
+        "state": "failed",
+        "blocked": True,
+        "title": "Initial RTL",
+        "summary": "Required file is missing.",
+        "source": {"kind": "provenance", "path": "origin/gcd.f"},
+        "evidence": [{"kind": "provenance", "path": "origin/gcd.f"}],
+    }


### PR DESCRIPTION
The provenance check only looked at design.origin_verilog and a *.v* glob, so it failed for filelist-based workspaces (whose origin_verilog is a placeholder that never exists) and for .sv inputs after load_workspace drops the attributes on reload.

Resolve the configured input_filelist/origin_verilog first, mirroring the synthesis input priority, and fall back to a suffix glob of the origin directory. Move FILELIST_SUFFIXES/RTL_SUFFIXES to utility/filelist.py so cli project config and the checklist share one definition.

## What Changed

-

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
