### PR TITLE
feat: add post-synthesis power report to synthesis QoR metrics

### DIFF
--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from chipcompiler.data import StateEnum, StepEnum, Workspace
 from chipcompiler.tools.ecc.sta_qor import (
+    STA_POWER_REPORT_FILENAME,
     STA_QOR_SUMMARY_FILENAME,
     STA_REPORT_FILENAMES,
     STA_TIMING_PATHS_FILENAME,
@@ -314,6 +315,13 @@ class SignoffPackageCollector:
                     destination=f"{report_dest}/{report_name}",
                     required=True,
                 )
+            # Optional: workspaces whose STA ran before power collection have
+            # no per-corner power report; package it when present.
+            add_file(
+                role="final.sta_report",
+                source=report_dir / STA_POWER_REPORT_FILENAME,
+                destination=f"{report_dest}/{STA_POWER_REPORT_FILENAME}",
+            )
             item["report"] = f"{report_dest}/qor_summary.rpt"
             feature_dest = report_dest.removesuffix("/report") + "/feature"
             add_file(

--- a/chipcompiler/tools/ecc/metrics.py
+++ b/chipcompiler/tools/ecc/metrics.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from chipcompiler.data import EccStep, StateEnum, StepEnum, StepMetrics, Workspace, WorkspaceStep
 from chipcompiler.tools.ecc.sta_qor import (
+    POST_SYNTHESIS_STA_CORNER,
+    STA_POWER_SUMMARY_FILENAME,
     STA_QOR_SUMMARY_FILENAME,
     read_sta_qor_summary,
     read_sta_timing_paths,
@@ -44,6 +46,41 @@ QOR_METRIC_MAP = {
         "unit": "count",
         "dimension": "routability_physical",
         "polarity": "trend_only",
+    },
+    # iSTA runs without VCD activity here: non-clock inputs use the default
+    # transition density and static probability, so all four values are
+    # estimates and stay trend-only until activity provenance is supplied.
+    "Power internal [uW]": {
+        "name": "synthesis_power_internal_uw",
+        "display_name": "Synthesis Internal Power",
+        "unit": "uW",
+        "dimension": "power",
+        "polarity": "trend_only",
+        "confidence": "medium",
+    },
+    "Power switching [uW]": {
+        "name": "synthesis_power_switching_uw",
+        "display_name": "Synthesis Switching Power",
+        "unit": "uW",
+        "dimension": "power",
+        "polarity": "trend_only",
+        "confidence": "medium",
+    },
+    "Power dynamic [uW]": {
+        "name": "synthesis_power_dynamic_uw",
+        "display_name": "Synthesis Dynamic Power",
+        "unit": "uW",
+        "dimension": "power",
+        "polarity": "trend_only",
+        "confidence": "medium",
+    },
+    "Power leakage [uW]": {
+        "name": "synthesis_power_leakage_uw",
+        "display_name": "Synthesis Leakage Power",
+        "unit": "uW",
+        "dimension": "power",
+        "polarity": "trend_only",
+        "confidence": "medium",
     },
     "Die area [μm^2]": {
         "name": "die_area",
@@ -518,6 +555,10 @@ QOR_EXPECTED_METRICS_BY_STEP = {
         "synthesis_cell_count",
         "synthesis_wire_count",
         "synthesis_port_count",
+        "synthesis_power_internal_uw",
+        "synthesis_power_switching_uw",
+        "synthesis_power_dynamic_uw",
+        "synthesis_power_leakage_uw",
     ],
     StepEnum.FLOORPLAN.value: [
         "die_area",
@@ -1928,7 +1969,20 @@ def _metric_feature_source(
     feature_path = None
     selector = ""
 
-    if metric_id.startswith("synthesis_"):
+    if metric_id.startswith("synthesis_power_"):
+        feature_dir = getattr(step.feature, "dir", None)
+        feature_path = (
+            Path(feature_dir) / POST_SYNTHESIS_STA_CORNER / STA_POWER_SUMMARY_FILENAME
+            if feature_dir
+            else None
+        )
+        selector = {
+            "synthesis_power_internal_uw": "/internal_uw",
+            "synthesis_power_switching_uw": "/switching_uw",
+            "synthesis_power_dynamic_uw": "/dynamic_uw",
+            "synthesis_power_leakage_uw": "/leakage_uw",
+        }.get(metric_id, "")
+    elif metric_id.startswith("synthesis_"):
         feature_path = getattr(step.feature, "stat", None)
         selector = {
             "synthesis_cell_area": "/design/area",

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -7,7 +7,7 @@ from typing import TypeAlias
 
 from numpy import double
 
-from chipcompiler.tools.ecc.sta_artifacts import clear_published_sdf, publish_sta_artifacts
+from chipcompiler.tools.ecc.sta_artifacts import discard_sta_run_outputs, publish_sta_artifacts
 from chipcompiler.utility.path import path_text, path_texts
 
 # Path arguments to the native-wrapper methods are normalized via path_text(),
@@ -667,8 +667,7 @@ class ECCToolsModule:
         if "structured" in modes and not feature_dir:
             raise ValueError("STA feature_dir is required when structured output is requested")
 
-        if "report" in modes:
-            clear_published_sdf(report_dir or "")
+        discard_sta_run_outputs(work_dir, report_dir, feature_dir, modes)
 
         self.ecc.lib_init(lib_paths=path_texts(lib_paths))
         self.ecc.sdc_init(path_text(sdc_path))

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -12,7 +12,11 @@ from chipcompiler.tools.ecc.metrics import (
 )
 from chipcompiler.tools.ecc.module import ECCToolsModule
 from chipcompiler.tools.ecc.plot import ECCToolsPlot
-from chipcompiler.tools.ecc.sta_qor import sta_artifact_directory
+from chipcompiler.tools.ecc.sta_artifacts import discard_sta_outputs
+from chipcompiler.tools.ecc.sta_qor import (
+    POST_SYNTHESIS_STA_CORNER,
+    sta_artifact_directory,
+)
 from chipcompiler.tools.ecc.subflow import EccSubFlow, EccSubFlowEnum
 from chipcompiler.tools.ecc.utility import is_eda_exist
 from chipcompiler.utility import json_read
@@ -272,6 +276,13 @@ def run_sta_without_spef(
     STA is supplemental to synthesis, so callers can retain a successful
     synthesis result when this function returns ``False``.
     """
+    # A rerun keeps the step directory, so drop the previously published STA
+    # artifacts first; a failed STA rerun must not leave stale reports or
+    # power summaries visible as current outputs.
+    for root in (step.feature.dir, step.report.dir):
+        if root:
+            discard_sta_outputs(Path(root) / POST_SYNTHESIS_STA_CORNER)
+
     try:
         netlist_path = step.output.verilog or ""
         liberty_paths = workspace.pdk.libs
@@ -298,7 +309,7 @@ def run_sta_without_spef(
 
         work_dir = Path(data_dir) / "sta"
         work_dir.mkdir(parents=True, exist_ok=True)
-        corner = "post_synthesis"
+        corner = POST_SYNTHESIS_STA_CORNER
         report_dir = Path(report_root) / corner
         feature_dir = Path(feature_root) / corner
 

--- a/chipcompiler/tools/ecc/sta_artifacts.py
+++ b/chipcompiler/tools/ecc/sta_artifacts.py
@@ -1,12 +1,21 @@
 """Publication policy for iSTA run artifacts.
 
-iSTA writes timing reports to ``<work_dir>/timing_reporter`` and the SDF to
+iSTA writes timing reports to ``<work_dir>/timing_reporter``, the power
+report to ``<work_dir>/power_reporter`` and the SDF to
 ``<work_dir>/sdf_writer``. This module validates those outputs and publishes
 them to the per-corner report/feature directories.
 """
 
 import shutil
 from pathlib import Path
+
+from chipcompiler.tools.ecc.sta_qor import (
+    STA_POWER_REPORT_FILENAME,
+    STA_POWER_SUMMARY_FILENAME,
+    read_sta_power_summary,
+    sta_power_summary_payload,
+)
+from chipcompiler.utility import json_write
 
 STA_REQUIRED_STRUCTURED_FILENAMES = ("qor_summary.json",)
 
@@ -19,10 +28,37 @@ def copy_sta_artifact(source_path: Path, destination_dir: Path) -> None:
     temporary_path.replace(target_path)
 
 
-def clear_published_sdf(report_dir: str | Path) -> None:
-    """Drop previously published SDF files so a failed rerun cannot expose them as current."""
-    for stale_sdf in Path(report_dir).glob("*.sdf"):
-        stale_sdf.unlink()
+def discard_sta_outputs(directory) -> None:
+    # Remove every artifact an STA run publishes into a destination directory,
+    # so a failed rerun cannot leave previous outputs visible as current.
+    # Report names vary with iSTA's start_end_type config, hence the glob.
+    root = Path(directory) if directory else None
+    if root is None or not root.is_dir():
+        return
+    for pattern in ("*.rpt", "*.json", "*.sdf"):
+        for stale_path in root.glob(pattern):
+            if stale_path.is_file():
+                stale_path.unlink()
+
+
+def discard_sta_run_outputs(work_dir, report_dir, feature_dir, modes) -> None:
+    # Invalidate every artifact the STA run can republish: stale temp outputs
+    # must not mask a failed native run, and previously published copies must
+    # not survive a failed rerun. Only destinations whose mode was requested
+    # are cleared; unrequested modes are not republished and keep their copies.
+    work_root = Path(work_dir)
+    power_report_path = work_root / "power_reporter" / STA_POWER_REPORT_FILENAME
+    power_report_path.unlink(missing_ok=True)
+    for temp_subdirectory in ("timing_reporter", "sdf_writer"):
+        temp_dir = work_root / temp_subdirectory
+        if temp_dir.is_dir():
+            for stale_path in temp_dir.iterdir():
+                if stale_path.is_file():
+                    stale_path.unlink()
+    if "report" in modes:
+        discard_sta_outputs(report_dir)
+    if "structured" in modes:
+        discard_sta_outputs(feature_dir)
 
 
 def publish_sta_artifacts(
@@ -60,14 +96,39 @@ def publish_sta_artifacts(
             raise FileNotFoundError(
                 f"iSTA did not produce requested structured artifacts: {', '.join(missing)}"
             )
-
-    if "report" in modes:
-        report_root = Path(report_dir)
-        for source_path in report_paths:
-            copy_sta_artifact(source_path, report_root)
-        for sdf_path in sdf_paths:
-            copy_sta_artifact(sdf_path, report_root)
+    power_report_path = Path(work_dir) / "power_reporter" / STA_POWER_REPORT_FILENAME
+    if not power_report_path.is_file():
+        raise FileNotFoundError(f"iSTA power report does not exist: {power_report_path}")
+    # The structured destination holds machine-readable artifacts only, so the
+    # plaintext power report is converted to a JSON summary. Parse before
+    # publishing anything: the artifact set publishes all at once.
+    power_summary_payload = None
     if "structured" in modes:
-        feature_root = Path(feature_dir)
-        for source_path in structured_paths:
-            copy_sta_artifact(source_path, feature_root)
+        power_summary = read_sta_power_summary(power_report_path)
+        if power_summary is None:
+            raise ValueError(f"iSTA power report is not parseable: {power_report_path}")
+        power_summary_payload = sta_power_summary_payload(power_summary)
+
+    try:
+        if "report" in modes:
+            report_root = Path(report_dir)
+            for source_path in report_paths:
+                copy_sta_artifact(source_path, report_root)
+            for sdf_path in sdf_paths:
+                copy_sta_artifact(sdf_path, report_root)
+            copy_sta_artifact(power_report_path, report_root)
+        if "structured" in modes:
+            feature_root = Path(feature_dir)
+            for source_path in structured_paths:
+                copy_sta_artifact(source_path, feature_root)
+            power_summary_path = feature_root / STA_POWER_SUMMARY_FILENAME
+            if not json_write(power_summary_path, power_summary_payload):
+                raise OSError(f"Failed to write STA power summary: {power_summary_path}")
+    except Exception:
+        # Publication is all-or-nothing: a partial set left behind by a
+        # failed run must not remain visible as current artifacts.
+        if "report" in modes:
+            discard_sta_outputs(report_dir)
+        if "structured" in modes:
+            discard_sta_outputs(feature_dir)
+        raise

--- a/chipcompiler/tools/ecc/sta_qor.py
+++ b/chipcompiler/tools/ecc/sta_qor.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from math import isfinite
 from pathlib import Path
@@ -11,6 +12,12 @@ STA_REPORT_FILENAMES = (
 )
 STA_QOR_SUMMARY_FILENAME = "qor_summary.json"
 STA_TIMING_PATHS_FILENAME = "timing_paths.json"
+# power.rpt stays out of STA_REPORT_FILENAMES: that list drives required
+# artifacts, while signoff packaging adds the power report as an optional
+# file so workspaces completed before power collection existed still export.
+STA_POWER_REPORT_FILENAME = "power.rpt"
+STA_POWER_SUMMARY_FILENAME = "power_summary.json"
+POST_SYNTHESIS_STA_CORNER = "post_synthesis"
 
 
 @dataclass(frozen=True)
@@ -284,3 +291,100 @@ def read_sta_timing_paths(corner: str, path: Path) -> StaTimingPaths | None:
         path_limit=path_limit,
         paths=tuple(valid_paths),
     )
+
+
+@dataclass(frozen=True)
+class StaPowerSummary:
+    path: Path
+    internal_uw: float
+    switching_uw: float
+    dynamic_uw: float
+    leakage_uw: float
+
+
+# iSTA picks the unit by magnitude for each summary line (pW/nW/uW/mW/W).
+_POWER_UNIT_TO_UW = {
+    "pW": 1e-6,
+    "nW": 1e-3,
+    "uW": 1.0,
+    "mW": 1e3,
+    "W": 1e6,
+}
+
+_POWER_SUMMARY_PATTERN = re.compile(
+    r"^(Cell Internal Power|Net Switching Power|Total Dynamic Power|Cell Leakage Power)"
+    r"\s*=\s*(\S+)\s+(pW|nW|uW|mW|W)\s*$"
+)
+
+
+def _power_value_uw(number_text: str, unit: str) -> float | None:
+    try:
+        value = float(number_text)
+    except ValueError:
+        return None
+    if not isfinite(value) or value < 0:
+        return None
+    return value * _POWER_UNIT_TO_UW[unit]
+
+
+def read_sta_power_summary(path: Path) -> StaPowerSummary | None:
+    if not path.is_file() or path.stat().st_size <= 0:
+        return None
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError):
+        return None
+
+    values = {}
+    for line in lines:
+        match = _POWER_SUMMARY_PATTERN.match(line.strip())
+        if match is None:
+            continue
+        label, number_text, unit = match.groups()
+        value_uw = _power_value_uw(number_text, unit)
+        if value_uw is None or label in values:
+            return None
+        values[label] = value_uw
+
+    try:
+        return StaPowerSummary(
+            path=path,
+            internal_uw=values["Cell Internal Power"],
+            switching_uw=values["Net Switching Power"],
+            dynamic_uw=values["Total Dynamic Power"],
+            leakage_uw=values["Cell Leakage Power"],
+        )
+    except KeyError:
+        return None
+
+
+_STA_POWER_SUMMARY_FIELDS = ("internal_uw", "switching_uw", "dynamic_uw", "leakage_uw")
+
+
+def sta_power_summary_payload(summary: StaPowerSummary) -> dict:
+    return {
+        "schema_version": 1,
+        "internal_uw": summary.internal_uw,
+        "switching_uw": summary.switching_uw,
+        "dynamic_uw": summary.dynamic_uw,
+        "leakage_uw": summary.leakage_uw,
+    }
+
+
+def read_sta_power_summary_json(path: Path) -> StaPowerSummary | None:
+    if not path.is_file() or path.stat().st_size <= 0:
+        return None
+
+    data = json_read(path)
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        return None
+
+    values = {}
+    for field in _STA_POWER_SUMMARY_FIELDS:
+        value = _finite_number(data.get(field))
+        if value is None or value < 0:
+            return None
+        values[field] = value
+
+    return StaPowerSummary(path=path, **values)

--- a/chipcompiler/tools/yosys/metrics.py
+++ b/chipcompiler/tools/yosys/metrics.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
+from pathlib import Path
+
 from chipcompiler.data import StepMetrics, Workspace, YosysStep
 from chipcompiler.tools.ecc.metrics import save_step_metrics
+from chipcompiler.tools.ecc.sta_qor import (
+    POST_SYNTHESIS_STA_CORNER,
+    STA_POWER_SUMMARY_FILENAME,
+    read_sta_power_summary_json,
+)
 from chipcompiler.utility import dict_to_str, json_read
 
 
@@ -30,6 +37,23 @@ def build_step_metrics(workspace: Workspace, step: YosysStep) -> StepMetrics:
         "Wire number": design_data.get("num_wires", 0),
         "Port number": design_data.get("num_port_bits", 0),
     }
+
+    power_summary = (
+        read_sta_power_summary_json(
+            Path(step.feature.dir) / POST_SYNTHESIS_STA_CORNER / STA_POWER_SUMMARY_FILENAME
+        )
+        if step.feature.dir
+        else None
+    )
+    if power_summary is not None:
+        metrics.update(
+            {
+                "Power internal [uW]": power_summary.internal_uw,
+                "Power switching [uW]": power_summary.switching_uw,
+                "Power dynamic [uW]": power_summary.dynamic_uw,
+                "Power leakage [uW]": power_summary.leakage_uw,
+            }
+        )
 
     step_metrics.data = metrics
 

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -8,6 +8,7 @@ from chipcompiler.engine.signoff import SignoffPackageOptions
 STA_REPORT_NAMES = (
     "qor_summary.rpt",
     "timing_max.rpt",
+    "power.rpt",
 )
 
 
@@ -221,6 +222,21 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
         "final/timing/sta/MAX_125/RCworst/feature/timing_paths.json",
     }.issubset(destinations)
     assert all(".tsv" not in destination for destination in destinations)
+
+
+def test_collect_signoff_package_tolerates_missing_sta_power_report(tmp_path):
+    # Workspaces completed before power collection have no per-corner power.rpt;
+    # it is packaged when present but must not be required for export.
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "sta_ecc" / "report" / "MAX_125" / "RCworst" / "power.rpt").unlink()
+    engine_flow = _make_engine_flow(workspace_dir)
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is True
+    manifest = json.loads((Path(result.package_dir) / "manifest.json").read_text())
+    destinations = {item["destination"] for item in manifest["files"]}
+    assert "final/timing/sta/MAX_125/RCworst/report/power.rpt" not in destinations
 
 
 def test_collect_signoff_package_uses_top_module_for_rcx_spef(tmp_path):

--- a/test/tools/ecc/test_module_timing.py
+++ b/test/tools/ecc/test_module_timing.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import shutil
 from pathlib import Path
 
@@ -16,6 +17,7 @@ class FakeStaEcc:
             "timing_paths.json",
         )
         self.emit_sdf = True
+        self.emit_power_report = True
 
     def lib_init(self, **kwargs):
         self.calls.append(("lib_init", kwargs))
@@ -55,6 +57,16 @@ class FakeStaEcc:
             sdf_dir = Path(config_dict["-temp_directory_path"]) / "sdf_writer"
             sdf_dir.mkdir(parents=True, exist_ok=True)
             (sdf_dir / "gcd.sdf").write_text("(DELAYFILE\n)\n", encoding="utf-8")
+        if self.emit_power_report:
+            power_dir = Path(config_dict["-temp_directory_path"]) / "power_reporter"
+            power_dir.mkdir(parents=True, exist_ok=True)
+            (power_dir / "power.rpt").write_text(
+                "Cell Internal Power  =   51.2062 uW\n"
+                "Net Switching Power  =   11.5906 uW\n"
+                "Total Dynamic Power  =   62.7968 uW\n"
+                "Cell Leakage Power   =    1.7151 uW\n",
+                encoding="utf-8",
+            )
         return True
 
     def destroy_sta(self):
@@ -84,8 +96,17 @@ def test_run_timing_splits_text_reports_and_structured_artifacts(tmp_path):
 
     assert (report_dir / "qor_summary.rpt").is_file()
     assert (report_dir / "timing_max.rpt").is_file()
+    assert (report_dir / "power.rpt").is_file()
     assert (feature_dir / "qor_summary.json").is_file()
     assert (feature_dir / "timing_paths.json").is_file()
+    assert not (feature_dir / "power.rpt").exists()
+    assert json.loads((feature_dir / "power_summary.json").read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "internal_uw": 51.2062,
+        "switching_uw": 11.5906,
+        "dynamic_uw": 62.7968,
+        "leakage_uw": 1.7151,
+    }
     init_config = next(
         call[1] for call in module.ecc.calls if len(call) == 2 and call[0] == "init_sta"
     )
@@ -112,6 +133,39 @@ def test_run_timing_accepts_qor_summary_without_timing_paths(tmp_path):
 
     assert (feature_dir / "qor_summary.json").is_file()
     assert not (feature_dir / "timing_paths.json").exists()
+    assert (feature_dir / "power_summary.json").is_file()
+
+
+def test_run_timing_publishes_nothing_when_power_report_missing(tmp_path):
+    module = make_module()
+    module.ecc.emit_power_report = False
+    report_dir = tmp_path / "report" / "post_synthesis"
+    feature_dir = tmp_path / "feature" / "post_synthesis"
+    report_dir.mkdir(parents=True)
+    feature_dir.mkdir(parents=True)
+    # Stale artifacts from a previous successful run: the failed rerun must
+    # not leave any of them visible as current outputs. timing_max.rpt is
+    # emitted when iSTA reports with start_end_type=all, and notes.txt is
+    # not owned by run_timing and must survive.
+    (report_dir / "qor_summary.rpt").write_text("stale\n", encoding="utf-8")
+    (report_dir / "timing_max.rpt").write_text("stale\n", encoding="utf-8")
+    (report_dir / "power.rpt").write_text("stale\n", encoding="utf-8")
+    (report_dir / "gcd.sdf").write_text("stale\n", encoding="utf-8")
+    (report_dir / "notes.txt").write_text("keep\n", encoding="utf-8")
+    (feature_dir / "qor_summary.json").write_text("stale\n", encoding="utf-8")
+    (feature_dir / "timing_paths.json").write_text("stale\n", encoding="utf-8")
+    (feature_dir / "power_summary.json").write_text("stale\n", encoding="utf-8")
+    (feature_dir / "power.rpt").write_text("stale\n", encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="power report"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            report_dir=report_dir,
+            feature_dir=feature_dir,
+        )
+
+    assert [path.name for path in report_dir.iterdir()] == ["notes.txt"]
+    assert not any(feature_dir.iterdir())
 
 
 def test_run_timing_rejects_invalid_output_modes(tmp_path):
@@ -140,6 +194,7 @@ def test_run_timing_publishes_sdf_alongside_text_reports(tmp_path):
 
     assert sorted(path.name for path in report_dir.iterdir()) == [
         "gcd.sdf",
+        "power.rpt",
         "qor_summary.rpt",
         "timing_max.rpt",
     ]

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -327,6 +327,35 @@ def test_run_sta_without_spef_warns_when_sdc_is_missing(tmp_path):
     assert logger.warnings[0][0] == "Post-synthesis STA failed; synthesis result is kept: %s"
 
 
+def test_run_sta_without_spef_removes_stale_power_report_on_failure(tmp_path):
+    netlist = tmp_path / "output" / "gcd.v"
+    liberty = tmp_path / "pdk" / "std.lib"
+    stale_reports = [
+        tmp_path / "Synthesis_yosys" / "feature" / "post_synthesis" / "power_summary.json",
+        tmp_path / "Synthesis_yosys" / "report" / "post_synthesis" / "power.rpt",
+    ]
+    for path in (netlist, liberty, *stale_reports):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("", encoding="utf-8")
+
+    logger = FakeLogger()
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+        pdk=PDK(libs=[liberty], sdc=tmp_path / "missing.sdc"),
+        logger=logger,
+    )
+    step = EccStep(
+        output=EccOutput(verilog=netlist),
+        data=EccData(dir=tmp_path / "Synthesis_yosys" / "data"),
+        feature=EccFeature(dir=tmp_path / "Synthesis_yosys" / "feature"),
+        report=EccReport(dir=tmp_path / "Synthesis_yosys" / "report"),
+    )
+
+    assert ecc_runner.run_sta_without_spef(workspace, step) is False
+    assert not any(path.exists() for path in stale_reports)
+
+
 def test_sta_signoff_items_use_top_module_for_rcx_spef(tmp_path):
     config_dir = tmp_path / "config"
     config_dir.mkdir()

--- a/test/tools/ecc/test_sta_artifacts.py
+++ b/test/tools/ecc/test_sta_artifacts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chipcompiler.tools.ecc.sta_artifacts import (
+    discard_sta_run_outputs,
+    publish_sta_artifacts,
+)
+
+POWER_REPORT = (
+    "Cell Internal Power  =   51.2062 uW\n"
+    "Net Switching Power  =   11.5906 uW\n"
+    "Total Dynamic Power  =   62.7968 uW\n"
+    "Cell Leakage Power   =    1.7151 uW\n"
+)
+
+
+def _seed_sta_temp_outputs(work_dir: Path, power_contents: str | None = POWER_REPORT) -> None:
+    timing_dir = work_dir / "timing_reporter"
+    timing_dir.mkdir(parents=True)
+    (timing_dir / "qor_summary.rpt").write_text("report\n", encoding="utf-8")
+    (timing_dir / "qor_summary.json").write_text("{}\n", encoding="utf-8")
+    sdf_dir = work_dir / "sdf_writer"
+    sdf_dir.mkdir(parents=True)
+    (sdf_dir / "gcd.sdf").write_text("(DELAYFILE\n)\n", encoding="utf-8")
+    if power_contents is not None:
+        power_dir = work_dir / "power_reporter"
+        power_dir.mkdir(parents=True)
+        (power_dir / "power.rpt").write_text(power_contents, encoding="utf-8")
+
+
+def test_discard_sta_run_outputs_clears_only_requested_modes(tmp_path):
+    work_dir = tmp_path / "data" / "sta"
+    _seed_sta_temp_outputs(work_dir)
+    report_dir = tmp_path / "report"
+    feature_dir = tmp_path / "feature"
+    report_dir.mkdir()
+    feature_dir.mkdir()
+    stale_report = report_dir / "power.rpt"
+    stale_report.write_text("previous report\n", encoding="utf-8")
+    stale_sdf = report_dir / "gcd.sdf"
+    stale_sdf.write_text("previous sdf\n", encoding="utf-8")
+    (feature_dir / "qor_summary.json").write_text("stale\n", encoding="utf-8")
+    (feature_dir / "power_summary.json").write_text("stale\n", encoding="utf-8")
+
+    discard_sta_run_outputs(work_dir, report_dir, feature_dir, ("structured",))
+
+    assert stale_report.read_text(encoding="utf-8") == "previous report\n"
+    assert stale_sdf.read_text(encoding="utf-8") == "previous sdf\n"
+    assert not any(feature_dir.iterdir())
+    assert not any((work_dir / "timing_reporter").iterdir())
+    assert not any((work_dir / "sdf_writer").iterdir())
+    assert not (work_dir / "power_reporter" / "power.rpt").exists()
+
+
+def test_publish_sta_artifacts_splits_report_and_structured_artifacts(tmp_path):
+    work_dir = tmp_path / "data" / "sta"
+    _seed_sta_temp_outputs(work_dir)
+    report_dir = tmp_path / "report"
+    feature_dir = tmp_path / "feature"
+
+    publish_sta_artifacts(work_dir, report_dir, feature_dir, ("report", "structured"))
+
+    assert sorted(path.name for path in report_dir.iterdir()) == [
+        "gcd.sdf",
+        "power.rpt",
+        "qor_summary.rpt",
+    ]
+    assert (feature_dir / "qor_summary.json").is_file()
+    assert not (feature_dir / "power.rpt").exists()
+    assert json.loads((feature_dir / "power_summary.json").read_text(encoding="utf-8")) == {
+        "schema_version": 1,
+        "internal_uw": 51.2062,
+        "switching_uw": 11.5906,
+        "dynamic_uw": 62.7968,
+        "leakage_uw": 1.7151,
+    }
+
+
+def test_publish_sta_artifacts_requires_power_report(tmp_path):
+    work_dir = tmp_path / "data" / "sta"
+    report_dir = tmp_path / "report"
+    feature_dir = tmp_path / "feature"
+    report_dir.mkdir(parents=True)
+    feature_dir.mkdir()
+    (report_dir / "power.rpt").write_text("stale\n", encoding="utf-8")
+    # A rerun invalidates previous outputs before the native run; the native
+    # run then produces timing reports but no power report.
+    discard_sta_run_outputs(work_dir, report_dir, feature_dir, ("report", "structured"))
+    _seed_sta_temp_outputs(work_dir, power_contents=None)
+
+    with pytest.raises(FileNotFoundError, match="power report"):
+        publish_sta_artifacts(work_dir, report_dir, feature_dir, ("report", "structured"))
+
+    assert not any(report_dir.iterdir())
+    assert not any(feature_dir.iterdir())
+
+
+def test_publish_sta_artifacts_rejects_unparseable_power_report(tmp_path):
+    work_dir = tmp_path / "data" / "sta"
+    _seed_sta_temp_outputs(work_dir, power_contents="power estimate unavailable\n")
+
+    with pytest.raises(ValueError, match="power report is not parseable"):
+        publish_sta_artifacts(
+            work_dir, tmp_path / "report", tmp_path / "feature", ("report", "structured")
+        )
+
+    assert not (tmp_path / "report").exists()
+    assert not (tmp_path / "feature").exists()
+
+
+def test_publish_sta_artifacts_rolls_back_when_publication_fails(tmp_path, monkeypatch):
+    work_dir = tmp_path / "data" / "sta"
+    _seed_sta_temp_outputs(work_dir)
+    report_dir = tmp_path / "report"
+    feature_dir = tmp_path / "feature"
+    monkeypatch.setattr("chipcompiler.tools.ecc.sta_artifacts.json_write", lambda *args: False)
+
+    with pytest.raises(OSError, match="power summary"):
+        publish_sta_artifacts(work_dir, report_dir, feature_dir, ("report", "structured"))
+
+    assert not any(report_dir.iterdir())
+    assert not any(feature_dir.iterdir())

--- a/test/tools/ecc/test_sta_qor.py
+++ b/test/tools/ecc/test_sta_qor.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+
+import json
+
+from chipcompiler.tools.ecc.sta_qor import (
+    StaPowerSummary,
+    read_sta_power_summary,
+    read_sta_power_summary_json,
+    sta_power_summary_payload,
+)
+
+REAL_POWER_REPORT = """Design : gcd
+Operating Conditions: ICS_N55_H7BR_ss_mos_RCworst_1.08_125
+Analysis Effort : low
+Wire Load Model : ZeroWireload
+Global Operating Voltage = 1.08
+
+Dynamic Power Units = 1mW
+Leakage Power Units = 1nW
+
+Cell Internal Power  =   51.2062 uW
+Net Switching Power  =   11.5906 uW
+Total Dynamic Power  =   62.7968 uW
+Cell Leakage Power   =    1.7151 uW
+
+                 Internal         Switching           Leakage            Total
+Power Group      Power            Power               Power              Power   (   %    )  Attrs
+--------------------------------------------------------------------------------------------------
+register       3.6408e-02        2.5064e-03          364.6992        3.9279e-02  (  60.89%)
+combinational  1.4798e-02        9.0842e-03         1350.4076        2.5233e-02  (  39.11%)
+--------------------------------------------------------------------------------------------------
+Total          5.1206e-02 mW     1.1591e-02 mW      1715.1068 nW     6.4512e-02 mW
+"""
+
+
+def test_read_sta_power_summary_parses_real_report(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text(REAL_POWER_REPORT, encoding="utf-8")
+
+    assert read_sta_power_summary(report_path) == StaPowerSummary(
+        path=report_path,
+        internal_uw=51.2062,
+        switching_uw=11.5906,
+        dynamic_uw=62.7968,
+        leakage_uw=1.7151,
+    )
+
+
+def test_read_sta_power_summary_normalizes_units(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text(
+        "Cell Internal Power  =  1.5 mW\n"
+        "Net Switching Power  =  200 nW\n"
+        "Total Dynamic Power  =  2.5e-03 W\n"
+        "Cell Leakage Power   =  3000 pW\n",
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary(report_path) == StaPowerSummary(
+        path=report_path,
+        internal_uw=1500.0,
+        switching_uw=0.2,
+        dynamic_uw=2500.0,
+        leakage_uw=0.003,
+    )
+
+
+def test_read_sta_power_summary_returns_none_for_missing_file(tmp_path):
+    assert read_sta_power_summary(tmp_path / "power.rpt") is None
+
+
+def test_read_sta_power_summary_returns_none_for_empty_file(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text("", encoding="utf-8")
+
+    assert read_sta_power_summary(report_path) is None
+
+
+def test_read_sta_power_summary_returns_none_when_summary_line_missing(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text(
+        "Cell Internal Power  =  51.2062 uW\n"
+        "Net Switching Power  =  11.5906 uW\n"
+        "Total Dynamic Power  =  62.7968 uW\n",
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary(report_path) is None
+
+
+def test_read_sta_power_summary_returns_none_for_invalid_number(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text(
+        "Cell Internal Power  =  unknown uW\n"
+        "Net Switching Power  =  11.5906 uW\n"
+        "Total Dynamic Power  =  62.7968 uW\n"
+        "Cell Leakage Power   =  1.7151 uW\n",
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary(report_path) is None
+
+
+def test_read_sta_power_summary_returns_none_for_duplicate_summary_line(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_text(
+        "Cell Internal Power  =  51.2062 uW\n"
+        "Cell Internal Power  =  51.2062 uW\n"
+        "Net Switching Power  =  11.5906 uW\n"
+        "Total Dynamic Power  =  62.7968 uW\n"
+        "Cell Leakage Power   =  1.7151 uW\n",
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary(report_path) is None
+
+
+def test_read_sta_power_summary_returns_none_for_non_utf8_content(tmp_path):
+    report_path = tmp_path / "power.rpt"
+    report_path.write_bytes(b"Cell Internal Power  =  51.2062 uW\n\xff\xfe\r\x00")
+
+    assert read_sta_power_summary(report_path) is None
+
+
+def test_sta_power_summary_json_round_trip(tmp_path):
+    summary_path = tmp_path / "power_summary.json"
+    summary = StaPowerSummary(
+        path=tmp_path / "power.rpt",
+        internal_uw=51.2062,
+        switching_uw=11.5906,
+        dynamic_uw=62.7968,
+        leakage_uw=1.7151,
+    )
+    summary_path.write_text(json.dumps(sta_power_summary_payload(summary)), encoding="utf-8")
+
+    assert read_sta_power_summary_json(summary_path) == StaPowerSummary(
+        path=summary_path,
+        internal_uw=51.2062,
+        switching_uw=11.5906,
+        dynamic_uw=62.7968,
+        leakage_uw=1.7151,
+    )
+
+
+def test_read_sta_power_summary_json_returns_none_for_wrong_schema_version(tmp_path):
+    summary_path = tmp_path / "power_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "internal_uw": 51.2062,
+                "switching_uw": 11.5906,
+                "dynamic_uw": 62.7968,
+                "leakage_uw": 1.7151,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary_json(summary_path) is None
+
+
+def test_read_sta_power_summary_json_returns_none_when_field_missing(tmp_path):
+    summary_path = tmp_path / "power_summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "internal_uw": 51.2062,
+                "switching_uw": 11.5906,
+                "dynamic_uw": 62.7968,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_sta_power_summary_json(summary_path) is None
+
+
+def test_read_sta_power_summary_json_returns_none_for_malformed_json(tmp_path):
+    summary_path = tmp_path / "power_summary.json"
+    summary_path.write_text("{not json\n", encoding="utf-8")
+
+    assert read_sta_power_summary_json(summary_path) is None

--- a/test/tools/yosys/test_metrics.py
+++ b/test/tools/yosys/test_metrics.py
@@ -51,6 +51,20 @@ def test_synthesis_metrics_write_v2_qor_files_without_legacy_metrics(tmp_path):
         ),
         encoding="utf-8",
     )
+    power_dir = step.feature.dir / "post_synthesis"
+    power_dir.mkdir(parents=True)
+    (power_dir / "power_summary.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "internal_uw": 51.2062,
+                "switching_uw": 11.5906,
+                "dynamic_uw": 62.7968,
+                "leakage_uw": 1.7151,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     metrics = build_step_metrics(workspace, step)
 
@@ -79,6 +93,34 @@ def test_synthesis_metrics_write_v2_qor_files_without_legacy_metrics(tmp_path):
         "path": "feature/Synthesis_stat.json",
         "selector": "/design/area",
     }
+    assert records["synthesis_power_dynamic_uw"] == {
+        "id": "synthesis_power_dynamic_uw",
+        "display_name": "Synthesis Dynamic Power",
+        "value": 62.7968,
+        "unit": "uW",
+        "category": "power",
+        "direction": "trend_only",
+        "scope": "synthesis",
+        "corner": None,
+        "project_role": "trend",
+        "step_role": "primary",
+        "analysis_group": "synthesis_metrics",
+        "rating": {"gate": False, "score": False, "trend": True},
+        "confidence": "medium",
+        "source": {
+            "kind": "feature",
+            "path": "feature/post_synthesis/power_summary.json",
+            "selector": "/dynamic_uw",
+        },
+    }
+    assert records["synthesis_power_internal_uw"]["value"] == 51.2062
+    assert records["synthesis_power_internal_uw"]["rating"] == {
+        "gate": False,
+        "score": False,
+        "trend": True,
+    }
+    assert records["synthesis_power_switching_uw"]["value"] == 11.5906
+    assert records["synthesis_power_leakage_uw"]["value"] == 1.7151
     assert records["runtime_seconds"] == {
         "id": "runtime_seconds",
         "display_name": "Step Runtime",
@@ -118,3 +160,85 @@ def test_synthesis_metrics_write_v2_qor_files_without_legacy_metrics(tmp_path):
     assert summary["quality_status"] == "pass"
     assert summary["gates"] == []
     assert summary["missing_metrics"] == []
+
+
+def test_synthesis_metrics_list_power_missing_when_sta_report_absent(tmp_path):
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+    )
+    step = build_step(
+        workspace=workspace,
+        step_name=StepEnum.SYNTHESIS.value,
+        input_def=None,
+        input_verilog=tmp_path / "gcd.v",
+    )
+    build_step_space(step)
+    step.feature.stat.write_text(
+        json.dumps(
+            {
+                "design": {
+                    "num_cells": 123,
+                    "area": 456.789,
+                    "num_wires": 87,
+                    "num_port_bits": 10,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    metrics = build_step_metrics(workspace, step)
+
+    assert metrics is not None
+    qor_metrics = json.loads(step.analysis.qor_metrics.read_text(encoding="utf-8"))
+    records = {record["id"]: record for record in qor_metrics["metrics"]}
+    assert "synthesis_power_dynamic_uw" not in records
+    assert "synthesis_power_leakage_uw" not in records
+
+    summary = json.loads(step.analysis.qor_summary.read_text(encoding="utf-8"))
+    assert summary["analysis_status"] == "incomplete"
+    assert summary["quality_status"] == "pass"
+    missing_ids = {record["metric_id"] for record in summary["missing_metrics"]}
+    assert missing_ids == {
+        "synthesis_power_internal_uw",
+        "synthesis_power_switching_uw",
+        "synthesis_power_dynamic_uw",
+        "synthesis_power_leakage_uw",
+    }
+
+
+def test_synthesis_metrics_tolerate_unset_feature_dir(tmp_path):
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+    )
+    step = build_step(
+        workspace=workspace,
+        step_name=StepEnum.SYNTHESIS.value,
+        input_def=None,
+        input_verilog=tmp_path / "gcd.v",
+    )
+    build_step_space(step)
+    step.feature.stat.write_text(
+        json.dumps(
+            {
+                "design": {
+                    "num_cells": 123,
+                    "area": 456.789,
+                    "num_wires": 87,
+                    "num_port_bits": 10,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    step.feature.dir = None
+
+    metrics = build_step_metrics(workspace, step)
+
+    assert metrics is not None
+    qor_metrics = json.loads(step.analysis.qor_metrics.read_text(encoding="utf-8"))
+    records = {record["id"]: record for record in qor_metrics["metrics"]}
+    assert records["synthesis_cell_area"]["value"] == 456.79
+    assert "synthesis_power_dynamic_uw" not in records


### PR DESCRIPTION
iSTA run_sta() always emits power.rpt under the STA temp directory, but run_timing only collected the timing_reporter artifacts, so the power report never left data/sta/power_reporter/.

- run_timing now copies power.rpt into the step report dir (readable report) and feature dir (QoR source), failing loudly when iSTA did not produce it
- add read_sta_power_summary() to parse the four summary lines (internal/switching/dynamic/leakage) with pW/nW/uW/mW/W unit normalization to uW
- synthesis step metrics surface the four values as synthesis_power_*_uw QoR records and list them as expected metrics, so a missing power report shows up in qor_summary missing_metrics without blocking the flow

Signoff STA corners share the same run_timing path and therefore also collect per-corner power.rpt; wiring those into QoR is left for later.

## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
