### PR TITLE
feat: publish SDF artifact in STA report output

### DIFF
--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 
 from numpy import double
 
+from chipcompiler.tools.ecc.sta_artifacts import clear_published_sdf, publish_sta_artifacts
 from chipcompiler.utility.path import path_text, path_texts
 
 # Path arguments to the native-wrapper methods are normalized via path_text(),
@@ -15,7 +16,6 @@ PathArg: TypeAlias = str | Path | None
 
 
 STA_OUTPUT_MODES = frozenset(("report", "structured"))
-STA_REQUIRED_STRUCTURED_FILENAMES = ("qor_summary.json",)
 
 
 def _normalize_sta_output_modes(output_modes) -> tuple[str, ...]:
@@ -31,14 +31,6 @@ def _normalize_sta_output_modes(output_modes) -> tuple[str, ...]:
     if invalid_modes:
         raise ValueError(f"Unsupported STA output modes: {sorted(invalid_modes)}")
     return modes
-
-
-def _copy_sta_artifact(source_path: Path, destination_dir: Path) -> None:
-    destination_dir.mkdir(parents=True, exist_ok=True)
-    target_path = destination_dir / source_path.name
-    temporary_path = target_path.with_name(f".{target_path.name}.tmp")
-    shutil.copy2(source_path, temporary_path)
-    temporary_path.replace(target_path)
 
 
 class ECCToolsModule:
@@ -675,6 +667,9 @@ class ECCToolsModule:
         if "structured" in modes and not feature_dir:
             raise ValueError("STA feature_dir is required when structured output is requested")
 
+        if "report" in modes:
+            clear_published_sdf(report_dir or "")
+
         self.ecc.lib_init(lib_paths=path_texts(lib_paths))
         self.ecc.sdc_init(path_text(sdc_path))
         self.ecc.spef_init(path_text(spef_path))
@@ -696,37 +691,12 @@ class ECCToolsModule:
         finally:
             self.ecc.destroy_sta()
 
-        timing_report_dir = Path(work_dir) / "timing_reporter"
-        if not timing_report_dir.is_dir():
-            raise FileNotFoundError(
-                f"iSTA timing reporter output directory does not exist: {timing_report_dir}"
-            )
-
-        source_paths = [path for path in timing_report_dir.iterdir() if path.is_file()]
-        report_paths = [path for path in source_paths if path.suffix != ".json"]
-        structured_paths = [path for path in source_paths if path.suffix == ".json"]
-        if "report" in modes:
-            if not report_paths:
-                raise FileNotFoundError("iSTA did not produce requested text reports")
-            sdf_paths = sorted((Path(work_dir) / "sdf_writer").glob("*.sdf"))
-            if not sdf_paths:
-                raise FileNotFoundError(
-                    f"iSTA did not produce an SDF file in {Path(work_dir) / 'sdf_writer'}"
-                )
-            report_root = Path(report_dir)
-            for source_path in report_paths:
-                _copy_sta_artifact(source_path, report_root)
-            for sdf_path in sdf_paths:
-                _copy_sta_artifact(sdf_path, report_root)
-        if "structured" in modes:
-            names = {path.name for path in structured_paths}
-            missing = [name for name in STA_REQUIRED_STRUCTURED_FILENAMES if name not in names]
-            if missing:
-                raise FileNotFoundError(
-                    f"iSTA did not produce requested structured artifacts: {', '.join(missing)}"
-                )
-            for source_path in structured_paths:
-                _copy_sta_artifact(source_path, Path(feature_dir))
+        publish_sta_artifacts(
+            work_dir=work_dir or "",
+            report_dir=report_dir or "",
+            feature_dir=feature_dir or "",
+            modes=modes,
+        )
 
     def run_sta(self, output_dir: str):
         return None

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -708,8 +708,16 @@ class ECCToolsModule:
         if "report" in modes:
             if not report_paths:
                 raise FileNotFoundError("iSTA did not produce requested text reports")
+            sdf_paths = sorted((Path(work_dir) / "sdf_writer").glob("*.sdf"))
+            if not sdf_paths:
+                raise FileNotFoundError(
+                    f"iSTA did not produce an SDF file in {Path(work_dir) / 'sdf_writer'}"
+                )
+            report_root = Path(report_dir)
             for source_path in report_paths:
-                _copy_sta_artifact(source_path, Path(report_dir))
+                _copy_sta_artifact(source_path, report_root)
+            for sdf_path in sdf_paths:
+                _copy_sta_artifact(sdf_path, report_root)
         if "structured" in modes:
             names = {path.name for path in structured_paths}
             missing = [name for name in STA_REQUIRED_STRUCTURED_FILENAMES if name not in names]

--- a/chipcompiler/tools/ecc/sta_artifacts.py
+++ b/chipcompiler/tools/ecc/sta_artifacts.py
@@ -41,6 +41,10 @@ def publish_sta_artifacts(
     source_paths = [path for path in timing_report_dir.iterdir() if path.is_file()]
     report_paths = [path for path in source_paths if path.suffix != ".json"]
     structured_paths = [path for path in source_paths if path.suffix == ".json"]
+
+    # Validate every requested mode before mutating any destination, so a
+    # failed run cannot leave a partially updated artifact set behind.
+    sdf_paths: list[Path] = []
     if "report" in modes:
         if not report_paths:
             raise FileNotFoundError("iSTA did not produce requested text reports")
@@ -49,11 +53,6 @@ def publish_sta_artifacts(
             raise FileNotFoundError(
                 f"iSTA did not produce an SDF file in {Path(work_dir) / 'sdf_writer'}"
             )
-        report_root = Path(report_dir)
-        for source_path in report_paths:
-            copy_sta_artifact(source_path, report_root)
-        for sdf_path in sdf_paths:
-            copy_sta_artifact(sdf_path, report_root)
     if "structured" in modes:
         names = {path.name for path in structured_paths}
         missing = [name for name in STA_REQUIRED_STRUCTURED_FILENAMES if name not in names]
@@ -61,6 +60,14 @@ def publish_sta_artifacts(
             raise FileNotFoundError(
                 f"iSTA did not produce requested structured artifacts: {', '.join(missing)}"
             )
+
+    if "report" in modes:
+        report_root = Path(report_dir)
+        for source_path in report_paths:
+            copy_sta_artifact(source_path, report_root)
+        for sdf_path in sdf_paths:
+            copy_sta_artifact(sdf_path, report_root)
+    if "structured" in modes:
         feature_root = Path(feature_dir)
         for source_path in structured_paths:
             copy_sta_artifact(source_path, feature_root)

--- a/chipcompiler/tools/ecc/sta_artifacts.py
+++ b/chipcompiler/tools/ecc/sta_artifacts.py
@@ -1,0 +1,66 @@
+"""Publication policy for iSTA run artifacts.
+
+iSTA writes timing reports to ``<work_dir>/timing_reporter`` and the SDF to
+``<work_dir>/sdf_writer``. This module validates those outputs and publishes
+them to the per-corner report/feature directories.
+"""
+
+import shutil
+from pathlib import Path
+
+STA_REQUIRED_STRUCTURED_FILENAMES = ("qor_summary.json",)
+
+
+def copy_sta_artifact(source_path: Path, destination_dir: Path) -> None:
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    target_path = destination_dir / source_path.name
+    temporary_path = target_path.with_name(f".{target_path.name}.tmp")
+    shutil.copy2(source_path, temporary_path)
+    temporary_path.replace(target_path)
+
+
+def clear_published_sdf(report_dir: str | Path) -> None:
+    """Drop previously published SDF files so a failed rerun cannot expose them as current."""
+    for stale_sdf in Path(report_dir).glob("*.sdf"):
+        stale_sdf.unlink()
+
+
+def publish_sta_artifacts(
+    work_dir: str | Path,
+    report_dir: str | Path,
+    feature_dir: str | Path,
+    modes: tuple[str, ...],
+) -> None:
+    """Validate iSTA outputs under work_dir and copy them to the corner directories."""
+    timing_report_dir = Path(work_dir) / "timing_reporter"
+    if not timing_report_dir.is_dir():
+        raise FileNotFoundError(
+            f"iSTA timing reporter output directory does not exist: {timing_report_dir}"
+        )
+
+    source_paths = [path for path in timing_report_dir.iterdir() if path.is_file()]
+    report_paths = [path for path in source_paths if path.suffix != ".json"]
+    structured_paths = [path for path in source_paths if path.suffix == ".json"]
+    if "report" in modes:
+        if not report_paths:
+            raise FileNotFoundError("iSTA did not produce requested text reports")
+        sdf_paths = sorted((Path(work_dir) / "sdf_writer").glob("*.sdf"))
+        if not sdf_paths:
+            raise FileNotFoundError(
+                f"iSTA did not produce an SDF file in {Path(work_dir) / 'sdf_writer'}"
+            )
+        report_root = Path(report_dir)
+        for source_path in report_paths:
+            copy_sta_artifact(source_path, report_root)
+        for sdf_path in sdf_paths:
+            copy_sta_artifact(sdf_path, report_root)
+    if "structured" in modes:
+        names = {path.name for path in structured_paths}
+        missing = [name for name in STA_REQUIRED_STRUCTURED_FILENAMES if name not in names]
+        if missing:
+            raise FileNotFoundError(
+                f"iSTA did not produce requested structured artifacts: {', '.join(missing)}"
+            )
+        feature_root = Path(feature_dir)
+        for source_path in structured_paths:
+            copy_sta_artifact(source_path, feature_root)

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -33,6 +33,7 @@ class FakeEcc:
             "qor_summary.json",
             "timing_paths.json",
         )
+        self.emit_sdf = True
 
     def flow_init(self, **kwargs):
         self.calls.append(("flow_init", kwargs))
@@ -74,6 +75,10 @@ class FakeEcc:
         if config_dict.get("-output_timing_features") == "1":
             for filename in self.structured_timing_filenames:
                 (report_dir / filename).write_text("{}\n", encoding="utf-8")
+        if self.emit_sdf:
+            sdf_dir = Path(config_dict["-temp_directory_path"]) / "sdf_writer"
+            sdf_dir.mkdir(parents=True, exist_ok=True)
+            (sdf_dir / "gcd.sdf").write_text("(DELAYFILE\n)\n", encoding="utf-8")
         return True
 
     def cts_timing_feature(self):

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -4,8 +4,6 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
-
 import chipcompiler.utility as chipcompiler_utility
 from chipcompiler.data import OriginDesign, StepEnum, Workspace
 from chipcompiler.tools.ecc import metrics as ecc_metrics
@@ -414,120 +412,6 @@ def test_ecc_binding_wrappers_stringify_path_arguments(tmp_path):
         ("run_sta", (), {}),
         ("destroy_sta", (), {}),
     ]
-
-
-def test_run_timing_splits_text_reports_and_structured_artifacts(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
-    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
-
-    module.run_timing(
-        work_dir=tmp_path / "data" / "sta",
-        report_dir=report_dir,
-        feature_dir=feature_dir,
-        output_modes=("structured", "report"),
-        max_paths_per_analysis=7,
-        corner="MAX_125/RCworst",
-    )
-
-    assert (report_dir / "qor_summary.rpt").is_file()
-    assert (report_dir / "timing_max.rpt").is_file()
-    assert (feature_dir / "qor_summary.json").is_file()
-    assert (feature_dir / "timing_paths.json").is_file()
-    init_config = next(
-        call[1] for call in module.ecc.calls if len(call) == 2 and call[0] == "init_sta"
-    )
-    assert init_config["config_dict"] == {
-        "-temp_directory_path": str(tmp_path / "data" / "sta"),
-        "-output_timing_reports": "1",
-        "-output_timing_features": "1",
-        "-timing_path_limit": "7",
-        "-timing_corner": "MAX_125/RCworst",
-    }
-
-
-def test_run_timing_accepts_qor_summary_without_timing_paths(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-    module.ecc.structured_timing_filenames = ("qor_summary.json",)
-    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
-
-    module.run_timing(
-        work_dir=tmp_path / "data" / "sta",
-        feature_dir=feature_dir,
-        output_modes=("structured",),
-        corner="MAX_125/RCworst",
-    )
-
-    assert (feature_dir / "qor_summary.json").is_file()
-    assert not (feature_dir / "timing_paths.json").exists()
-
-
-def test_run_timing_rejects_invalid_output_modes(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-
-    with pytest.raises(ValueError, match="Unsupported STA output modes"):
-        module.run_timing(
-            work_dir=tmp_path / "data" / "sta",
-            feature_dir=tmp_path / "feature",
-            output_modes=("structured", "raw"),
-        )
-
-    assert module.ecc.calls == []
-
-
-def test_run_timing_publishes_sdf_alongside_text_reports(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
-
-    module.run_timing(
-        work_dir=tmp_path / "data" / "sta",
-        report_dir=report_dir,
-        output_modes=("report",),
-        corner="MAX_125/RCworst",
-    )
-
-    assert sorted(path.name for path in report_dir.iterdir()) == [
-        "gcd.sdf",
-        "qor_summary.rpt",
-        "timing_max.rpt",
-    ]
-
-
-def test_run_timing_raises_when_sdf_missing(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-    module.ecc.emit_sdf = False
-    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
-
-    with pytest.raises(FileNotFoundError, match="SDF"):
-        module.run_timing(
-            work_dir=tmp_path / "data" / "sta",
-            report_dir=report_dir,
-            output_modes=("report",),
-            corner="MAX_125/RCworst",
-        )
-
-    assert not report_dir.exists()
-
-
-def test_run_timing_structured_only_does_not_require_sdf(tmp_path):
-    module = ECCToolsModule.__new__(ECCToolsModule)
-    module.ecc = FakeEcc()
-    module.ecc.emit_sdf = False
-    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
-
-    module.run_timing(
-        work_dir=tmp_path / "data" / "sta",
-        feature_dir=feature_dir,
-        output_modes=("structured",),
-        corner="MAX_125/RCworst",
-    )
-
-    assert (feature_dir / "qor_summary.json").is_file()
 
 
 def test_ecc_runtime_wrappers_stringify_path_arguments(tmp_path):

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -478,6 +478,58 @@ def test_run_timing_rejects_invalid_output_modes(tmp_path):
     assert module.ecc.calls == []
 
 
+def test_run_timing_publishes_sdf_alongside_text_reports(tmp_path):
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        report_dir=report_dir,
+        output_modes=("report",),
+        corner="MAX_125/RCworst",
+    )
+
+    assert sorted(path.name for path in report_dir.iterdir()) == [
+        "gcd.sdf",
+        "qor_summary.rpt",
+        "timing_max.rpt",
+    ]
+
+
+def test_run_timing_raises_when_sdf_missing(tmp_path):
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+    module.ecc.emit_sdf = False
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+
+    with pytest.raises(FileNotFoundError, match="SDF"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            report_dir=report_dir,
+            output_modes=("report",),
+            corner="MAX_125/RCworst",
+        )
+
+    assert not report_dir.exists()
+
+
+def test_run_timing_structured_only_does_not_require_sdf(tmp_path):
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeEcc()
+    module.ecc.emit_sdf = False
+    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        feature_dir=feature_dir,
+        output_modes=("structured",),
+        corner="MAX_125/RCworst",
+    )
+
+    assert (feature_dir / "qor_summary.json").is_file()
+
+
 def test_ecc_runtime_wrappers_stringify_path_arguments(tmp_path):
     module = ECCToolsModule.__new__(ECCToolsModule)
     module.ecc = FakeEcc()

--- a/test/tools/ecc/test_module.py
+++ b/test/tools/ecc/test_module.py
@@ -27,11 +27,6 @@ class FakeEcc:
         self.calls = []
         self.generated_timing_lib_name = "gcd_max.lib"
         self.generated_timing_lib_contents = "library (gcd_max) {}\n"
-        self.structured_timing_filenames = (
-            "qor_summary.json",
-            "timing_paths.json",
-        )
-        self.emit_sdf = True
 
     def flow_init(self, **kwargs):
         self.calls.append(("flow_init", kwargs))
@@ -55,28 +50,6 @@ class FakeEcc:
 
     def init_sta(self, **kwargs):
         self.calls.append(("init_sta", kwargs))
-        return True
-
-    def run_sta(self):
-        self.calls.append(("run_sta", (), {}))
-        config_dict = None
-        for call in reversed(self.calls):
-            if len(call) == 2 and call[0] == "init_sta":
-                config_dict = call[1]["config_dict"]
-                break
-        assert config_dict is not None
-        report_dir = Path(config_dict["-temp_directory_path"]) / "timing_reporter"
-        report_dir.mkdir(parents=True, exist_ok=True)
-        if config_dict.get("-output_timing_reports") == "1":
-            (report_dir / "qor_summary.rpt").write_text("report\n", encoding="utf-8")
-            (report_dir / "timing_max.rpt").write_text("report\n", encoding="utf-8")
-        if config_dict.get("-output_timing_features") == "1":
-            for filename in self.structured_timing_filenames:
-                (report_dir / filename).write_text("{}\n", encoding="utf-8")
-        if self.emit_sdf:
-            sdf_dir = Path(config_dict["-temp_directory_path"]) / "sdf_writer"
-            sdf_dir.mkdir(parents=True, exist_ok=True)
-            (sdf_dir / "gcd.sdf").write_text("(DELAYFILE\n)\n", encoding="utf-8")
         return True
 
     def cts_timing_feature(self):
@@ -330,7 +303,7 @@ def test_geometry_edit_session_wrappers_forward_instance_name():
     ]
 
 
-def test_ecc_binding_wrappers_stringify_path_arguments(tmp_path):
+def test_ecc_binding_wrappers_stringify_path_arguments():
     module = ECCToolsModule.__new__(ECCToolsModule)
     module.ecc = FakeEcc()
 
@@ -352,16 +325,6 @@ def test_ecc_binding_wrappers_stringify_path_arguments(tmp_path):
         output_dir=Path("/ws/out"),
         lib_paths=[Path("/pdk/lib.lib")],
         sdc_path=Path("/ws/design.sdc"),
-    )
-    module.run_timing(
-        config=Path("/ws/config/sta.json"),
-        work_dir=tmp_path / "sta_work",
-        report_dir=tmp_path / "sta_report",
-        feature_dir=tmp_path / "sta_feature",
-        lib_paths=[Path("/pdk/lib.lib")],
-        sdc_path=Path("/ws/design.sdc"),
-        spef_path=Path("/ws/design.spef"),
-        corner="MAX_125/RCworst",
     )
 
     assert module.ecc.calls == [
@@ -393,24 +356,6 @@ def test_ecc_binding_wrappers_stringify_path_arguments(tmp_path):
                 "sdc_path": "/ws/design.sdc",
             },
         ),
-        ("lib_init", (), {"lib_paths": ["/pdk/lib.lib"]}),
-        ("sdc_init", ("/ws/design.sdc",), {}),
-        ("spef_init", ("/ws/design.spef",), {}),
-        (
-            "init_sta",
-            {
-                "config": "/ws/config/sta.json",
-                "config_dict": {
-                    "-temp_directory_path": str(tmp_path / "sta_work"),
-                    "-output_timing_reports": "1",
-                    "-output_timing_features": "1",
-                    "-timing_path_limit": "20",
-                    "-timing_corner": "MAX_125/RCworst",
-                },
-            },
-        ),
-        ("run_sta", (), {}),
-        ("destroy_sta", (), {}),
     ]
 
 

--- a/test/tools/ecc/test_module_timing.py
+++ b/test/tools/ecc/test_module_timing.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from chipcompiler.tools.ecc.module import ECCToolsModule
+
+
+class FakeStaEcc:
+    def __init__(self):
+        self.calls = []
+        self.structured_timing_filenames = (
+            "qor_summary.json",
+            "timing_paths.json",
+        )
+        self.emit_sdf = True
+
+    def lib_init(self, **kwargs):
+        self.calls.append(("lib_init", kwargs))
+        return True
+
+    def sdc_init(self, sdc_path):
+        self.calls.append(("sdc_init", sdc_path))
+        return True
+
+    def spef_init(self, spef_path):
+        self.calls.append(("spef_init", spef_path))
+        return True
+
+    def init_sta(self, **kwargs):
+        self.calls.append(("init_sta", kwargs))
+        # iSTA wipes the temp directory on init, like DataManager::input does.
+        shutil.rmtree(kwargs["config_dict"]["-temp_directory_path"], ignore_errors=True)
+        return True
+
+    def run_sta(self):
+        self.calls.append(("run_sta", (), {}))
+        config_dict = None
+        for call in reversed(self.calls):
+            if len(call) == 2 and call[0] == "init_sta":
+                config_dict = call[1]["config_dict"]
+                break
+        assert config_dict is not None
+        report_dir = Path(config_dict["-temp_directory_path"]) / "timing_reporter"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        if config_dict.get("-output_timing_reports") == "1":
+            (report_dir / "qor_summary.rpt").write_text("report\n", encoding="utf-8")
+            (report_dir / "timing_max.rpt").write_text("report\n", encoding="utf-8")
+        if config_dict.get("-output_timing_features") == "1":
+            for filename in self.structured_timing_filenames:
+                (report_dir / filename).write_text("{}\n", encoding="utf-8")
+        if self.emit_sdf:
+            sdf_dir = Path(config_dict["-temp_directory_path"]) / "sdf_writer"
+            sdf_dir.mkdir(parents=True, exist_ok=True)
+            (sdf_dir / "gcd.sdf").write_text("(DELAYFILE\n)\n", encoding="utf-8")
+        return True
+
+    def destroy_sta(self):
+        self.calls.append(("destroy_sta", (), {}))
+        return True
+
+
+def make_module() -> ECCToolsModule:
+    module = ECCToolsModule.__new__(ECCToolsModule)
+    module.ecc = FakeStaEcc()
+    return module
+
+
+def test_run_timing_splits_text_reports_and_structured_artifacts(tmp_path):
+    module = make_module()
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        report_dir=report_dir,
+        feature_dir=feature_dir,
+        output_modes=("structured", "report"),
+        max_paths_per_analysis=7,
+        corner="MAX_125/RCworst",
+    )
+
+    assert (report_dir / "qor_summary.rpt").is_file()
+    assert (report_dir / "timing_max.rpt").is_file()
+    assert (feature_dir / "qor_summary.json").is_file()
+    assert (feature_dir / "timing_paths.json").is_file()
+    init_config = next(
+        call[1] for call in module.ecc.calls if len(call) == 2 and call[0] == "init_sta"
+    )
+    assert init_config["config_dict"] == {
+        "-temp_directory_path": str(tmp_path / "data" / "sta"),
+        "-output_timing_reports": "1",
+        "-output_timing_features": "1",
+        "-timing_path_limit": "7",
+        "-timing_corner": "MAX_125/RCworst",
+    }
+
+
+def test_run_timing_accepts_qor_summary_without_timing_paths(tmp_path):
+    module = make_module()
+    module.ecc.structured_timing_filenames = ("qor_summary.json",)
+    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        feature_dir=feature_dir,
+        output_modes=("structured",),
+        corner="MAX_125/RCworst",
+    )
+
+    assert (feature_dir / "qor_summary.json").is_file()
+    assert not (feature_dir / "timing_paths.json").exists()
+
+
+def test_run_timing_rejects_invalid_output_modes(tmp_path):
+    module = make_module()
+
+    with pytest.raises(ValueError, match="Unsupported STA output modes"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            feature_dir=tmp_path / "feature",
+            output_modes=("structured", "raw"),
+        )
+
+    assert module.ecc.calls == []
+
+
+def test_run_timing_publishes_sdf_alongside_text_reports(tmp_path):
+    module = make_module()
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        report_dir=report_dir,
+        output_modes=("report",),
+        corner="MAX_125/RCworst",
+    )
+
+    assert sorted(path.name for path in report_dir.iterdir()) == [
+        "gcd.sdf",
+        "qor_summary.rpt",
+        "timing_max.rpt",
+    ]
+
+
+def test_run_timing_raises_when_sdf_missing(tmp_path):
+    module = make_module()
+    module.ecc.emit_sdf = False
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+
+    with pytest.raises(FileNotFoundError, match="SDF"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            report_dir=report_dir,
+            output_modes=("report",),
+            corner="MAX_125/RCworst",
+        )
+
+    assert not report_dir.exists()
+
+
+def test_run_timing_structured_only_does_not_require_sdf(tmp_path):
+    module = make_module()
+    module.ecc.emit_sdf = False
+    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        feature_dir=feature_dir,
+        output_modes=("structured",),
+        corner="MAX_125/RCworst",
+    )
+
+    assert (feature_dir / "qor_summary.json").is_file()
+
+
+def test_run_timing_removes_stale_sdf_when_rerun_fails(tmp_path):
+    module = make_module()
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+
+    module.run_timing(
+        work_dir=tmp_path / "data" / "sta",
+        report_dir=report_dir,
+        output_modes=("report",),
+        corner="MAX_125/RCworst",
+    )
+    assert (report_dir / "gcd.sdf").is_file()
+
+    module.ecc.emit_sdf = False
+    with pytest.raises(FileNotFoundError, match="SDF"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            report_dir=report_dir,
+            output_modes=("report",),
+            corner="MAX_125/RCworst",
+        )
+
+    assert not (report_dir / "gcd.sdf").exists()

--- a/test/tools/ecc/test_module_timing.py
+++ b/test/tools/ecc/test_module_timing.py
@@ -198,3 +198,58 @@ def test_run_timing_removes_stale_sdf_when_rerun_fails(tmp_path):
         )
 
     assert not (report_dir / "gcd.sdf").exists()
+
+
+def test_run_timing_publishes_nothing_when_structured_artifact_missing(tmp_path):
+    module = make_module()
+    module.ecc.structured_timing_filenames = ("timing_paths.json",)
+    report_dir = tmp_path / "report" / "MAX_125" / "RCworst"
+    feature_dir = tmp_path / "feature" / "MAX_125" / "RCworst"
+
+    with pytest.raises(FileNotFoundError, match="structured"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            report_dir=report_dir,
+            feature_dir=feature_dir,
+            output_modes=("report", "structured"),
+            corner="MAX_125/RCworst",
+        )
+
+    assert not report_dir.exists()
+    assert not feature_dir.exists()
+
+
+def test_run_timing_stringifies_path_arguments(tmp_path):
+    module = make_module()
+
+    module.run_timing(
+        config=Path("/ws/config/sta.json"),
+        work_dir=tmp_path / "sta_work",
+        report_dir=tmp_path / "sta_report",
+        feature_dir=tmp_path / "sta_feature",
+        lib_paths=[Path("/pdk/lib.lib")],
+        sdc_path=Path("/ws/design.sdc"),
+        spef_path=Path("/ws/design.spef"),
+        corner="MAX_125/RCworst",
+    )
+
+    assert module.ecc.calls == [
+        ("lib_init", {"lib_paths": ["/pdk/lib.lib"]}),
+        ("sdc_init", "/ws/design.sdc"),
+        ("spef_init", "/ws/design.spef"),
+        (
+            "init_sta",
+            {
+                "config": "/ws/config/sta.json",
+                "config_dict": {
+                    "-temp_directory_path": str(tmp_path / "sta_work"),
+                    "-output_timing_reports": "1",
+                    "-output_timing_features": "1",
+                    "-timing_path_limit": "20",
+                    "-timing_corner": "MAX_125/RCworst",
+                },
+            },
+        ),
+        ("run_sta", (), {}),
+        ("destroy_sta", (), {}),
+    ]


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [ ] Focused pytest:
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [x] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [x] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
