### PR TITLE
feat(cli): run steps of an existing workspace via ecc run --workspace

### DIFF
--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import shlex
 import shutil
 import sys
 
@@ -187,6 +188,19 @@ def _canonically_inside(path: str, anchor: str) -> bool:
 
 
 def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
+    if command_input.workspace is not None:
+        return _run_workspace(command_input, ctx)
+
+    if any(
+        (
+            command_input.resume,
+            command_input.from_step is not None,
+            command_input.only is not None,
+            command_input.force,
+        )
+    ):
+        return CommandResult.err([{"kind": "error", "error": "selector_requires_workspace"}])
+
     from chipcompiler import rtl2gds as rtl2gds_api
     from chipcompiler.cli.project.config import (
         resolve_pdk_overrides,
@@ -451,3 +465,84 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
             }
         ]
     )
+
+
+def _run_workspace(command_input: RunInput, ctx: CommandContext) -> CommandResult:
+    def error(kind: str, **fields) -> CommandResult:
+        return CommandResult.err([{"kind": "error", "error": kind, **fields}])
+
+    if ctx.project is not None or command_input.project.run_id is not None:
+        return error("project_workspace_conflict")
+    if command_input.overwrite:
+        return error("overwrite_requires_project")
+    if command_input.param_set:
+        return error("set_requires_project")
+    selectors = sum(
+        (
+            command_input.resume,
+            command_input.from_step is not None,
+            command_input.only is not None,
+        )
+    )
+    if selectors > 1:
+        return error("selector_conflict")
+    if command_input.force and command_input.only is None:
+        return error("force_requires_only")
+
+    from chipcompiler.data import load_workspace
+    from chipcompiler.engine import EngineFlow, rerun
+
+    workspace_path = os.path.abspath(os.path.expanduser(command_input.workspace))
+    try:
+        workspace = load_workspace(workspace_path)
+    except Exception as exc:
+        return error("invalid_workspace", workspace=workspace_path, reason=str(exc))
+    if workspace is None:
+        return error("invalid_workspace", workspace=workspace_path)
+
+    try:
+        engine_flow = EngineFlow(workspace=workspace)
+    except Exception as exc:
+        return error("invalid_workspace", workspace=workspace_path, reason=str(exc))
+    if not engine_flow.has_init():
+        return error("missing_flow", workspace=workspace_path)
+
+    try:
+        selected = rerun.selected_step_names(
+            engine_flow,
+            from_step=command_input.from_step,
+            only=command_input.only,
+            force=command_input.force,
+        )
+    except ValueError as exc:
+        return error("unknown_step", workspace=workspace_path, reason=str(exc))
+
+    from chipcompiler.cli.rendering.progress import preserve_cli_stdio
+
+    try:
+        with preserve_cli_stdio():
+            if selected:
+                engine_flow.create_step_workspaces(executable_steps=set(selected))
+            if command_input.only is not None:
+                result = rerun.run_only(engine_flow, command_input.only, force=command_input.force)
+            elif command_input.from_step is not None:
+                result = rerun.run_from(engine_flow, command_input.from_step)
+            else:
+                result = rerun.run_resume(engine_flow)
+    except ValueError as exc:
+        return error("step_unavailable", workspace=workspace_path, reason=str(exc))
+    except Exception as exc:
+        return error("flow_failed", workspace=workspace_path, reason=str(exc))
+
+    record = {
+        "run": "workspace",
+        "status": "success" if result.ok else "failed",
+        "workspace": workspace_path,
+        "executed_steps": list(result.executed),
+        "no_op": result.ok and not result.executed,
+    }
+    if result.ok:
+        return CommandResult.ok([record])
+    record["failed_step"] = result.failed
+    record["resume_cmd"] = f"ecc run --workspace {shlex.quote(workspace_path)} --resume"
+    return CommandResult.err([record])

--- a/chipcompiler/cli/commands/project.py
+++ b/chipcompiler/cli/commands/project.py
@@ -62,6 +62,26 @@ def run_cmd(
     project: ProjectOption = None,
     run_id: RunIdOption = None,
     overwrite: Annotated[bool, typer.Option("--overwrite")] = False,
+    workspace: Annotated[
+        str | None,
+        typer.Option("--workspace", help="Reuse an existing workspace in place"),
+    ] = None,
+    resume: Annotated[
+        bool,
+        typer.Option("--resume", help="Continue from the first non-successful step"),
+    ] = False,
+    from_step: Annotated[
+        str | None,
+        typer.Option("--from", help="Re-execute a step and its persisted suffix"),
+    ] = None,
+    only: Annotated[
+        str | None,
+        typer.Option("--only", help="Run exactly one persisted step"),
+    ] = None,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Re-execute an already successful --only step"),
+    ] = False,
     json_output: JsonOption = False,
     jsonl: JsonlOption = False,
     param_set: Annotated[
@@ -78,6 +98,11 @@ def run_cmd(
         project=project_options(project, run_id),
         overwrite=overwrite,
         param_set=tuple(param_set or ()),
+        workspace=workspace,
+        resume=resume,
+        from_step=from_step,
+        only=only,
+        force=force,
     )
     execute_command("run", command_input, project_handlers.run)
 

--- a/chipcompiler/cli/core/inputs.py
+++ b/chipcompiler/cli/core/inputs.py
@@ -35,6 +35,11 @@ class RunInput:
     project: ProjectOptions
     overwrite: bool = False
     param_set: tuple[str, ...] = ()
+    workspace: str | None = None
+    resume: bool = False
+    from_step: str | None = None
+    only: str | None = None
+    force: bool = False
 
 
 @dataclass(frozen=True)

--- a/chipcompiler/cli/rendering/progress.py
+++ b/chipcompiler/cli/rendering/progress.py
@@ -256,7 +256,7 @@ def _stable_stream_from(stream):
 
 
 @contextlib.contextmanager
-def _preserve_cli_stdio():
+def preserve_cli_stdio():
     saved_stdout = sys.stdout
     saved_stderr = sys.stderr
     saved_stdout_fd = None
@@ -447,7 +447,7 @@ def run_flow_with_progress(engine_flow, ctx, project, stderr):
             start = time.time()
 
             try:
-                with _preserve_cli_stdio():
+                with preserve_cli_stdio():
                     if not engine_flow.check_state(
                         name=workspace_step.name,
                         tool=workspace_step.tool,

--- a/chipcompiler/engine/__init__.py
+++ b/chipcompiler/engine/__init__.py
@@ -1,5 +1,12 @@
 from .db import EngineDB
 from .flow import EngineFlow
+from .rerun import StepRunResult
 from .signoff import SignoffPackageCollector, SignoffPackageOptions
 
-__all__ = ["EngineDB", "EngineFlow", "SignoffPackageCollector", "SignoffPackageOptions"]
+__all__ = [
+    "EngineDB",
+    "EngineFlow",
+    "StepRunResult",
+    "SignoffPackageCollector",
+    "SignoffPackageOptions",
+]

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -18,6 +18,7 @@ from chipcompiler.utility.log import redirect_stdio_to_file
 
 logger = logging.getLogger(__name__)
 
+
 _GEOMETRY_SNAPSHOT_STEPS = frozenset(
     {
         StepEnum.FLOORPLAN.value,
@@ -257,10 +258,15 @@ class EngineFlow:
         """
         return SignoffPackageCollector(self.workspace).collect(options)
 
-    def create_step_workspaces(self):
+    def create_step_workspaces(self, *, executable_steps: set[str] | None = None):
         """
         create all step workspaces
+
+        executable_steps: names of the steps that will actually run. Only those
+        steps verify tool dependencies; other steps are always built so the
+        input/output chaining stays intact when a non-selected tool is absent.
         """
+        self.workspace_steps = []
         pre_step = None
         for step in self.workspace.flow.data.get("steps", []):
             if pre_step is None:
@@ -285,6 +291,7 @@ class EngineFlow:
                 input_verilog=input_verilog,
                 input_db=input_db,
                 initialize_config=True,
+                check_dependency=executable_steps is None or step["name"] in executable_steps,
             )
             # save workspace step
             if eda_step is not None:
@@ -539,3 +546,12 @@ class EngineFlow:
         self.clear_db_engine_after_step(workspace_step, state)
 
         return state
+
+    def init_db_engine_for_step(self, workspace_step: WorkspaceStep) -> bool:
+        """Initialize the native DB engine from an explicitly selected step."""
+        if self.engine_db is None:
+            self.engine_db = EngineDB(workspace=self.workspace)
+        elif self.engine_db.has_init():
+            return True
+
+        return self.engine_db.create_db_engine(step=workspace_step)

--- a/chipcompiler/engine/rerun.py
+++ b/chipcompiler/engine/rerun.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+"""Re-execution of persisted flow steps in an existing workspace.
+
+Selection primitives behind ``ecc run --workspace``: resume from the first
+non-successful step, re-execute a step and its persisted suffix, or run
+exactly one step. Everything here drives an ``EngineFlow`` that was loaded
+from an existing workspace; execution itself stays in ``EngineFlow.run_step``.
+"""
+
+import os
+import shutil
+import traceback
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+from chipcompiler.data import StateEnum, Workspace, WorkspaceStep, log_flow
+from chipcompiler.utility.log import redirect_stdio_to_file
+from chipcompiler.utility.path import path_is_within
+
+if TYPE_CHECKING:
+    from chipcompiler.engine.flow import EngineFlow
+
+
+class StepRunResult(NamedTuple):
+    ok: bool
+    executed: tuple[str, ...]
+    failed: str | None = None
+
+
+def selected_step_names(
+    flow: "EngineFlow", *, from_step: str = None, only: str = None, force: bool = False
+) -> list[str]:
+    """Resolve a run selector to the persisted step names it would execute."""
+    steps = flow.workspace.flow.data.get("steps", [])
+    if only is not None:
+        index = _require_step_index(flow, only)
+        if not force and steps[index].get("state") == StateEnum.Success.value:
+            return []
+        return [steps[index]["name"]]
+    if from_step is not None:
+        return [step["name"] for step in steps[_require_step_index(flow, from_step) :]]
+    for index, step in enumerate(steps):
+        if step.get("state") != StateEnum.Success.value:
+            return [step["name"] for step in steps[index:]]
+    return []
+
+
+def run_resume(flow: "EngineFlow") -> StepRunResult:
+    """Resume from the first non-successful step, re-executing the persisted suffix."""
+    for step in flow.workspace.flow.data.get("steps", []):
+        if step.get("state") != StateEnum.Success.value:
+            return run_from(flow, step["name"])
+    return StepRunResult(ok=True, executed=())
+
+
+def run_from(flow: "EngineFlow", name: str) -> StepRunResult:
+    """Re-execute the named step and every following step in persisted order."""
+    steps = flow.workspace.flow.data.get("steps", [])
+    index = _require_step_index(flow, name)
+    _require_steps_available(flow, len(steps) - 1)
+    suffix = flow.workspace_steps[index:]
+    output_dirs = _validated_output_dirs(flow.workspace, suffix)
+    _invalidate_suffix(flow, index)
+    return _run_selected(flow, list(zip(suffix, output_dirs, strict=True)))
+
+
+def run_only(flow: "EngineFlow", name: str, *, force: bool = False) -> StepRunResult:
+    """Run exactly one persisted step; a successful step is re-run only with force."""
+    steps = flow.workspace.flow.data.get("steps", [])
+    index = _require_step_index(flow, name)
+    if not force and steps[index].get("state") == StateEnum.Success.value:
+        return StepRunResult(ok=True, executed=())
+    _require_steps_available(flow, index)
+    workspace_step = flow.get_workspace_step(name)
+    (output_dir,) = _validated_output_dirs(flow.workspace, [workspace_step])
+    _invalidate_suffix(flow, index)
+    return _run_selected(flow, [(workspace_step, output_dir)])
+
+
+def _require_step_index(flow: "EngineFlow", name: str) -> int:
+    steps = flow.workspace.flow.data.get("steps", [])
+    for index, step in enumerate(steps):
+        if step.get("name") == name:
+            return index
+    available = ", ".join(str(step.get("name")) for step in steps)
+    raise ValueError(f"unknown step '{name}'; available steps: {available}")
+
+
+def _require_steps_available(flow: "EngineFlow", last_index: int) -> None:
+    """Require flow steps up to last_index to align 1:1 with workspace_steps.
+
+    The input chain of a step is built from its predecessor's outputs, so a
+    step that failed to create (e.g. missing tool) silently shifts the
+    inputs of every following step.
+    """
+    created = [step.name for step in flow.workspace_steps]
+    for index, step in enumerate(flow.workspace.flow.data.get("steps", [])[: last_index + 1]):
+        if index >= len(created) or created[index] != step["name"]:
+            raise ValueError(f"step is unavailable in this workspace: {step['name']}")
+
+
+def _invalidate_suffix(flow: "EngineFlow", index: int) -> None:
+    """Mark the steps from index on as Unstart, persisted before any deletion."""
+    steps = flow.workspace.flow.data.get("steps", [])
+    for step in steps[index:]:
+        step["state"] = StateEnum.Unstart.value
+        step["runtime"] = ""
+        step["peak memory (mb)"] = 0
+    if not flow.save():
+        raise ValueError("failed to persist step invalidation; refusing to modify outputs")
+
+
+def _run_selected(flow: "EngineFlow", selected: list[tuple[WorkspaceStep, Path]]) -> StepRunResult:
+    """Run the selected steps in order, each with a fresh output directory."""
+    # a new selection must not inherit a DB positioned by an earlier run
+    if flow.engine_db is not None:
+        flow.engine_db.close()
+
+    executed = []
+    for workspace_step, output_dir in selected:
+        flow.workspace.logger.log_section(
+            f"{workspace_step.tool} - begin step - {workspace_step.name}"
+        )
+        _reset_output_dir(output_dir)
+        _redirect_to_step_log(workspace_step)
+        flow.init_db_engine_for_step(workspace_step)
+        state = flow.run_step(workspace_step, rerun=True)
+        log_flow(workspace=flow.workspace)
+        flow.workspace.logger.log_section(
+            f"{workspace_step.tool} - end step - {workspace_step.name}"
+        )
+        if state != StateEnum.Success:
+            return StepRunResult(ok=False, executed=tuple(executed), failed=workspace_step.name)
+        executed.append(workspace_step.name)
+    return StepRunResult(ok=True, executed=tuple(executed))
+
+
+def _validated_output_dirs(workspace: Workspace, steps: list[WorkspaceStep]) -> list[Path]:
+    """Validate that each step output is its canonical ``<step_dir>/output`` dir.
+
+    All targets are validated before any deletion or state change happens.
+    """
+    root = Path(workspace.directory).resolve()
+    output_dirs = []
+    for step in steps:
+        step_directory = getattr(step, "directory", None)
+        output_dir = getattr(step.output, "dir", None)
+        if not step_directory or not output_dir:
+            raise ValueError(f"step output directory is missing: {step.name}")
+        step_directory = Path(step_directory)
+        output_dir = Path(output_dir)
+        if step_directory.is_symlink() or output_dir.is_symlink():
+            raise ValueError(f"step output must not be a symlink: {output_dir}")
+        resolved = output_dir.resolve()
+        if (
+            resolved == root
+            or not path_is_within(resolved, root)
+            or resolved != step_directory.resolve() / "output"
+        ):
+            raise ValueError(
+                f"step output is not the canonical workspace output directory: {output_dir}"
+            )
+        output_dirs.append(resolved)
+    return output_dirs
+
+
+def _redirect_to_step_log(workspace_step: WorkspaceStep) -> None:
+    """Redirect stdio before DB init so its warnings land in the step log."""
+    log_file = workspace_step.log.file or ""
+    if not log_file:
+        return
+    log_file = os.path.abspath(log_file)
+    try:
+        os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
+        redirect_stdio_to_file(log_file)
+    except Exception:
+        traceback.print_exc()
+
+
+def _reset_output_dir(output_dir: Path) -> None:
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)

--- a/chipcompiler/tools/eda.py
+++ b/chipcompiler/tools/eda.py
@@ -59,12 +59,13 @@ def create_step(
     output_gds: Path | None = None,
     *,
     initialize_config: bool = False,
+    check_dependency: bool = True,
 ) -> WorkspaceStep:
     """
     Create and return an EDA tool instance based on the given step and eda tool name.
     """
     # check eda tool exist
-    eda_module = load_eda_module(eda, check_dependency=eda != "sizer")
+    eda_module = load_eda_module(eda, check_dependency=check_dependency and eda != "sizer")
     if eda_module is None or not hasattr(eda_module, "build_step"):
         return None
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -389,7 +389,43 @@ CHIPCOMPILER_ICS55_PDK_ROOT=/path/to/pdk uv run ecc
 1. Check `workspace_step.logs/` for tool output.
 2. Inspect `workspace_step.config/` for configs.
 3. Verify `workspace_step.input/` files.
-4. Run individual step with `EngineFlow.run_step()`.
+4. Reproduce or continue the failure in place with `ecc run --workspace`:
+
+```bash
+workspace=/path/to/reported/workspace
+
+# Resume from the first non-successful step (default when no selector is given).
+.venv/bin/ecc run --workspace "$workspace"
+.venv/bin/ecc run --workspace "$workspace" --resume
+
+# Re-execute CTS and every following step in the persisted flow.
+.venv/bin/ecc run --workspace "$workspace" --from CTS
+
+# Run exactly one step; add --force if it already succeeded.
+.venv/bin/ecc run --workspace "$workspace" --only place
+.venv/bin/ecc run --workspace "$workspace" --only place --force
+```
+
+`--resume`, `--from`, and `--only` are mutually exclusive, and `--force` is
+only valid with `--only`. Workspace mode cannot be combined with `--project`,
+`--run-id`, `--overwrite`, or `--set`. Step names must match `home/flow.json`
+exactly.
+
+Workspace mode mutates the workspace in place: each executed step's `output/`
+is replaced, and steps downstream of a re-executed step are marked `Unstart`
+so a later resume re-runs them. Rerunning a step regenerates
+`workspace/config/*.json` from `home/parameters.json`, so adjust parameters
+instead of hand-editing generated configs; keep a copy of a reported workspace
+if it must stay immutable.
+
+For Python-level debugging, invoke the same CLI module directly:
+
+```bash
+.venv/bin/python -m chipcompiler.cli.main run \
+  --workspace "$workspace" \
+  --only place \
+  --force
+```
 
 ### Modify Flow Sequence
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -250,19 +250,32 @@ When omitted, the current working directory is treated as the project directory.
 
 ### Step-Level Execution
 
-Back-end flow work is iterative. Step-level execution must be first-class:
+Back-end flow work is iterative. An existing workspace can be resumed or
+re-executed in place through `ecc run --workspace`:
 
 ```bash
-ecc run --from placement
-ecc run --to routing
-ecc run --only cts
-ecc run --after floorplan
-ecc run --resume
-ecc run --force --step placement
+ecc run --workspace /path/to/workspace
+ecc run --workspace /path/to/workspace --resume
+ecc run --workspace /path/to/workspace --from CTS
+ecc run --workspace /path/to/workspace --only place
+ecc run --workspace /path/to/workspace --only place --force
 ```
 
-The current implementation does not yet expose step-range execution flags.
-`ecc run` executes the configured default RTL-to-GDS flow and supports:
+Step names and order come from the workspace's persisted `home/flow.json`.
+Omitting a selector has resume semantics: execution starts at the first step
+whose state is not `Success` and reuses the successful prefix. `--from <step>`
+re-executes the named step and its persisted suffix. `--only <step>` runs
+exactly that step; an already successful step is a no-op unless `--force` is
+given. Re-executing a step marks downstream steps `Unstart`, replaces the
+executed step's `output/`, and regenerates `workspace/config/*.json` from the
+persisted parameters.
+
+`--resume`, `--from`, and `--only` are mutually exclusive, `--force` requires
+`--only`, and workspace mode cannot be combined with `--project`, `--run-id`,
+`--overwrite`, or `--set`. Arbitrary step sequences, step ranges (`--to`,
+`--after`), and run-time parameter overlays remain planned work.
+
+Project mode creates a fresh `runs/<run_id>` workspace and supports:
 
 ```bash
 ecc run --overwrite

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -1,9 +1,11 @@
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 
 from chipcompiler.cli import main as cli_main
+from chipcompiler.engine import StepRunResult
 
 
 def _set_flow_preset(project_dir, preset):
@@ -212,3 +214,193 @@ class TestRunFlowPreset:
             "spef": str(tmp_path / "absolute.spef"),
             "dont_use": ["ICG*"],
         }
+
+
+class TestWorkspaceRun:
+    @pytest.fixture
+    def workspace_mocks(self, monkeypatch):
+        seen = SimpleNamespace(
+            load_path=None,
+            has_init=True,
+            selected_error=None,
+            selected=None,
+            create_calls=0,
+            executable=None,
+            only=None,
+            from_step=None,
+            resume=False,
+            result=StepRunResult(ok=True, executed=("place",)),
+        )
+
+        class Flow:
+            def __init__(self, workspace):
+                self.workspace = workspace
+
+            def has_init(self):
+                return seen.has_init
+
+            def create_step_workspaces(self, *, executable_steps=None):
+                seen.create_calls += 1
+                seen.executable = executable_steps
+
+        def selected_step_names(flow, *, from_step=None, only=None, force=False):
+            if seen.selected_error is not None:
+                raise seen.selected_error
+            seen.selected = {"from_step": from_step, "only": only, "force": force}
+            if only is not None:
+                return [] if not force else [only]
+            if from_step is not None:
+                return [from_step, "CTS"]
+            return ["place", "CTS"]
+
+        def run_only(flow, name, *, force=False):
+            seen.only = (name, force)
+            return seen.result
+
+        def run_from(flow, name):
+            seen.from_step = name
+            return seen.result
+
+        def run_resume(flow):
+            seen.resume = True
+            return seen.result
+
+        def fake_load_workspace(path):
+            seen.load_path = path
+            return SimpleNamespace(name="workspace")
+
+        monkeypatch.setattr("chipcompiler.data.load_workspace", fake_load_workspace)
+        monkeypatch.setattr("chipcompiler.engine.EngineFlow", Flow)
+        monkeypatch.setattr("chipcompiler.engine.rerun.selected_step_names", selected_step_names)
+        monkeypatch.setattr("chipcompiler.engine.rerun.run_only", run_only)
+        monkeypatch.setattr("chipcompiler.engine.rerun.run_from", run_from)
+        monkeypatch.setattr("chipcompiler.engine.rerun.run_resume", run_resume)
+        monkeypatch.setattr(
+            "chipcompiler.data.create_workspace",
+            lambda **_kwargs: pytest.fail("workspace mode must not create a workspace"),
+        )
+        return seen
+
+    def test_only_force_wiring(self, workspace_mocks, tmp_path, capsys):
+        workspace = str(tmp_path / "workspace")
+
+        rc = cli_main.run(["run", "--workspace", workspace, "--only", "place", "--force", "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 0
+        assert workspace_mocks.load_path == workspace
+        assert workspace_mocks.selected == {"from_step": None, "only": "place", "force": True}
+        assert workspace_mocks.executable == {"place"}
+        assert workspace_mocks.only == ("place", True)
+        assert record["run"] == "workspace"
+        assert record["status"] == "success"
+        assert record["workspace"] == workspace
+        assert record["executed_steps"] == ["place"]
+        assert record["no_op"] is False
+
+    def test_default_selector_is_resume(self, workspace_mocks, tmp_path):
+        rc = cli_main.run(["run", "--workspace", str(tmp_path / "workspace"), "--plain"])
+
+        assert rc == 0
+        assert workspace_mocks.selected == {"from_step": None, "only": None, "force": False}
+        assert workspace_mocks.executable == {"place", "CTS"}
+        assert workspace_mocks.resume is True
+
+    def test_from_step_wiring(self, workspace_mocks, tmp_path):
+        rc = cli_main.run(["run", "--workspace", str(tmp_path / "workspace"), "--from", "CTS"])
+
+        assert rc == 0
+        assert workspace_mocks.from_step == "CTS"
+        assert workspace_mocks.executable == {"CTS"}
+
+    def test_noop_selection_skips_workspace_rebuild(self, workspace_mocks, tmp_path, capsys):
+        workspace_mocks.result = StepRunResult(ok=True, executed=())
+        workspace = str(tmp_path / "workspace")
+
+        rc = cli_main.run(["run", "--workspace", workspace, "--only", "place", "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 0
+        assert workspace_mocks.create_calls == 0
+        assert workspace_mocks.only == ("place", False)
+        assert record == {
+            "run": "workspace",
+            "status": "success",
+            "workspace": workspace,
+            "executed_steps": [],
+            "no_op": True,
+        }
+
+    def test_failed_run_reports_failed_step_and_resume(self, workspace_mocks, tmp_path, capsys):
+        workspace_mocks.result = StepRunResult(ok=False, executed=(), failed="place")
+        workspace = str(tmp_path / "workspace")
+
+        rc = cli_main.run(["run", "--workspace", workspace, "--only", "place", "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record == {
+            "run": "workspace",
+            "status": "failed",
+            "workspace": workspace,
+            "executed_steps": [],
+            "no_op": False,
+            "failed_step": "place",
+            "resume_cmd": f"ecc run --workspace {workspace} --resume",
+        }
+
+    def test_invalid_workspace(self, tmp_path, capsys):
+        rc = cli_main.run(["run", "--workspace", str(tmp_path / "missing"), "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record["error"] == "invalid_workspace"
+
+    def test_missing_flow(self, workspace_mocks, tmp_path, capsys):
+        workspace_mocks.has_init = False
+
+        rc = cli_main.run(["run", "--workspace", str(tmp_path / "workspace"), "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record["error"] == "missing_flow"
+
+    def test_unknown_step(self, workspace_mocks, tmp_path, capsys):
+        workspace_mocks.selected_error = ValueError("unknown step 'bogus'")
+
+        rc = cli_main.run(
+            ["run", "--workspace", str(tmp_path / "workspace"), "--only", "bogus", "--json"]
+        )
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record["error"] == "unknown_step"
+        assert "bogus" in record["reason"]
+
+    @pytest.mark.parametrize(
+        "argv,error",
+        [
+            (["--project", "p", "--workspace", "w"], "project_workspace_conflict"),
+            (["--run-id", "r", "--workspace", "w"], "project_workspace_conflict"),
+            (["--workspace", "w", "--overwrite"], "overwrite_requires_project"),
+            (["--workspace", "w", "--set", "place.target_density=0.6"], "set_requires_project"),
+            (["--workspace", "w", "--resume", "--only", "place"], "selector_conflict"),
+            (["--workspace", "w", "--from", "place", "--only", "CTS"], "selector_conflict"),
+            (["--workspace", "w", "--force"], "force_requires_only"),
+            (["--resume"], "selector_requires_workspace"),
+            (["--from", "place"], "selector_requires_workspace"),
+            (["--only", "place"], "selector_requires_workspace"),
+            (["--force"], "selector_requires_workspace"),
+        ],
+    )
+    def test_option_conflicts(self, argv, error, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "chipcompiler.data.load_workspace",
+            lambda _path: pytest.fail("conflicts must be rejected before workspace load"),
+        )
+
+        rc = cli_main.run(["run", *argv, "--json"])
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record["error"] == error

--- a/test/cli/rendering/test_progress.py
+++ b/test/cli/rendering/test_progress.py
@@ -583,7 +583,7 @@ class TestPreserveCliStdio:
     def test_restores_fd_stdout_stderr_after_redirect(self, tmp_path, capfd):
         log_file = tmp_path / "step.log"
 
-        with progress._preserve_cli_stdio():
+        with progress.preserve_cli_stdio():
             redirected = redirect_stdio_to_file(str(log_file))
             print("inside stdout")
             sys.stderr.write("inside stderr\n")
@@ -601,7 +601,7 @@ class TestPreserveCliStdio:
     def test_restores_fd_stdout_stderr_after_exception(self, tmp_path, capfd):
         log_file = tmp_path / "step.log"
 
-        with pytest.raises(RuntimeError, match="boom"), progress._preserve_cli_stdio():
+        with pytest.raises(RuntimeError, match="boom"), progress.preserve_cli_stdio():
             redirect_stdio_to_file(str(log_file))
             raise RuntimeError("boom")
 

--- a/test/cli/test_typer_cli.py
+++ b/test/cli/test_typer_cli.py
@@ -276,11 +276,11 @@ def test_old_top_level_workspace_form_is_root_parser_error(capsys):
     assert "no such option" in capsys.readouterr().err.lower()
 
 
-def test_run_workspace_like_flag_is_run_parser_error(capsys):
+def test_run_workspace_flag_reaches_workspace_validation(capsys):
     rc = cli_main.run(["run", "--workspace", "gcd"])
 
     assert rc != 0
-    assert "no such option" in capsys.readouterr().err.lower()
+    assert "invalid_workspace" in capsys.readouterr().out
 
 
 def test_status_command_handler_still_returns_command_result(monkeypatch, tmp_path, capsys):

--- a/test/test_engine_rerun.py
+++ b/test/test_engine_rerun.py
@@ -1,0 +1,332 @@
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from chipcompiler.data import EccOutput, EccStep, StateEnum, Workspace
+from chipcompiler.data.workspace import Flow
+from chipcompiler.engine import rerun
+from chipcompiler.engine.flow import EngineFlow
+
+
+def _make_run_flow(tmp_path, steps):
+    """EngineFlow over a persisted flow.json plus aligned workspace steps."""
+    home = tmp_path / "home"
+    home.mkdir()
+    workspace = Workspace(directory=tmp_path, flow=Flow(path=home / "flow.json"))
+    engine_flow = EngineFlow(workspace)
+    engine_flow.workspace.flow.data = {
+        "steps": [
+            {
+                "name": name,
+                "tool": "ecc",
+                "state": state,
+                "runtime": "",
+                "peak memory (mb)": 0,
+                "info": {},
+            }
+            for name, state in steps
+        ]
+    }
+    engine_flow.save()
+    engine_flow.workspace_steps = []
+    for name, _state in steps:
+        directory = tmp_path / f"{name}_ecc"
+        engine_flow.workspace_steps.append(
+            EccStep(
+                name=name,
+                tool="ecc",
+                directory=directory,
+                output=EccOutput(dir=directory / "output"),
+            )
+        )
+    return engine_flow
+
+
+def _fake_execution(engine_flow, monkeypatch, outcomes=None):
+    calls = []
+    outcomes = outcomes or {}
+
+    def run_step(workspace_step, *, rerun=False):
+        calls.append((workspace_step.name, rerun))
+        state = outcomes.get(workspace_step.name, StateEnum.Success)
+        engine_flow.set_state(workspace_step.name, workspace_step.tool, state)
+        return state
+
+    monkeypatch.setattr(engine_flow, "run_step", run_step)
+    monkeypatch.setattr(engine_flow, "init_db_engine_for_step", lambda step: True)
+    return calls
+
+
+def _write_output(engine_flow, name, content="old"):
+    step = engine_flow.get_workspace_step(name)
+    output_dir = step.output.dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = output_dir / f"{name}.def.gz"
+    sentinel.write_text(content, encoding="utf-8")
+    return sentinel
+
+
+def _flow_states(engine_flow):
+    return [step["state"] for step in engine_flow.workspace.flow.data["steps"]]
+
+
+class TestSelectedStepNames:
+    def test_resume_selects_suffix_from_first_non_success(self, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Incomplete"), ("CTS", "Success")],
+        )
+
+        assert rerun.selected_step_names(flow) == ["place", "CTS"]
+
+    def test_resume_all_success_selects_nothing(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+
+        assert rerun.selected_step_names(flow) == []
+
+    def test_from_selects_suffix(self, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Success"), ("CTS", "Success")],
+        )
+
+        assert rerun.selected_step_names(flow, from_step="place") == ["place", "CTS"]
+
+    def test_only_success_step_requires_force(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+
+        assert rerun.selected_step_names(flow, only="place") == []
+        assert rerun.selected_step_names(flow, only="place", force=True) == ["place"]
+
+    def test_unknown_step_lists_available_names(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success"), ("CTS", "Unstart")])
+
+        with pytest.raises(ValueError, match="place.*CTS"):
+            rerun.selected_step_names(flow, only="bogus")
+
+
+class TestRunFrom:
+    def test_reexecutes_suffix_and_clears_only_executed_outputs(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Success"), ("CTS", "Success")],
+        )
+        keep = _write_output(flow, "Synthesis")
+        stale_place = _write_output(flow, "place")
+        stale_cts = _write_output(flow, "CTS")
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_from(flow, "place")
+
+        assert result.ok
+        assert result.executed == ("place", "CTS")
+        assert result.failed is None
+        assert calls == [("place", True), ("CTS", True)]
+        assert keep.read_text(encoding="utf-8") == "old"
+        assert not stale_place.exists()
+        assert not stale_cts.exists()
+
+    def test_failure_stops_suffix_and_keeps_downstream_output(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("place", "Success"), ("CTS", "Success"), ("route", "Success")],
+        )
+        route_output = _write_output(flow, "route")
+        calls = _fake_execution(flow, monkeypatch, outcomes={"CTS": StateEnum.Imcomplete})
+
+        result = rerun.run_from(flow, "place")
+
+        assert not result.ok
+        assert result.executed == ("place",)
+        assert result.failed == "CTS"
+        assert calls == [("place", True), ("CTS", True)]
+        assert _flow_states(flow) == ["Success", "Incomplete", "Unstart"]
+        assert route_output.read_text(encoding="utf-8") == "old"
+
+    def test_suffix_invalidation_is_persisted_before_execution(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Success"), ("CTS", "Success")],
+        )
+        persisted = []
+
+        def run_step(workspace_step, *, rerun=False):
+            disk = json.loads(flow.workspace.flow.path.read_text(encoding="utf-8"))
+            persisted.append([step["state"] for step in disk["steps"]])
+            flow.set_state(workspace_step.name, workspace_step.tool, StateEnum.Success)
+            return StateEnum.Success
+
+        monkeypatch.setattr(flow, "run_step", run_step)
+        monkeypatch.setattr(flow, "init_db_engine_for_step", lambda step: True)
+
+        assert rerun.run_from(flow, "place").ok
+        # the suffix is already persisted Unstart when the first selected step runs
+        assert persisted[0] == ["Success", "Unstart", "Unstart"]
+
+    def test_failed_invalidation_save_refuses_to_modify_outputs(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success"), ("CTS", "Success")])
+        sentinel = _write_output(flow, "place")
+        original = flow.workspace.flow.path.read_bytes()
+        monkeypatch.setattr(flow, "save", lambda: False)
+
+        with pytest.raises(ValueError, match="refusing to modify outputs"):
+            rerun.run_from(flow, "place")
+
+        assert flow.workspace.flow.path.read_bytes() == original
+        assert sentinel.read_text(encoding="utf-8") == "old"
+
+    def test_unknown_step_does_not_mutate_workspace(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        sentinel = _write_output(flow, "place")
+        original = flow.workspace.flow.path.read_bytes()
+        original_data = copy.deepcopy(flow.workspace.flow.data)
+
+        with pytest.raises(ValueError, match="unknown step"):
+            rerun.run_from(flow, "bogus")
+
+        assert flow.workspace.flow.path.read_bytes() == original
+        assert flow.workspace.flow.data == original_data
+        assert sentinel.read_text(encoding="utf-8") == "old"
+
+    def test_missing_workspace_step_breaks_the_chain_and_is_rejected(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("Synthesis", "Success"), ("place", "Success")])
+        flow.workspace_steps = flow.workspace_steps[1:]
+        original = flow.workspace.flow.path.read_bytes()
+        original_data = copy.deepcopy(flow.workspace.flow.data)
+
+        with pytest.raises(ValueError, match="Synthesis"):
+            rerun.run_from(flow, "place")
+
+        assert flow.workspace.flow.path.read_bytes() == original
+        assert flow.workspace.flow.data == original_data
+
+    def test_non_canonical_output_is_rejected_before_mutation(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        sentinel = outside / "keep.txt"
+        sentinel.write_text("keep", encoding="utf-8")
+        flow.workspace_steps[0].output.dir = outside
+        original = flow.workspace.flow.path.read_bytes()
+        original_data = copy.deepcopy(flow.workspace.flow.data)
+
+        with pytest.raises(ValueError, match="canonical"):
+            rerun.run_from(flow, "place")
+
+        assert flow.workspace.flow.path.read_bytes() == original
+        assert flow.workspace.flow.data == original_data
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+
+    def test_closes_inherited_db_engine_before_running(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        closed = []
+        flow.engine_db = SimpleNamespace(close=lambda: closed.append(True))
+        _fake_execution(flow, monkeypatch)
+
+        assert rerun.run_from(flow, "place").ok
+        assert closed == [True]
+
+
+class TestRunOnly:
+    def test_successful_step_without_force_is_noop(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success"), ("CTS", "Success")])
+        sentinel = _write_output(flow, "place")
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_only(flow, "place")
+
+        assert result.ok
+        assert result.executed == ()
+        assert calls == []
+        assert _flow_states(flow) == ["Success", "Success"]
+        assert sentinel.read_text(encoding="utf-8") == "old"
+
+    def test_force_reruns_and_invalidates_downstream(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success"), ("CTS", "Success")])
+        stale_place = _write_output(flow, "place")
+        keep_cts = _write_output(flow, "CTS")
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_only(flow, "place", force=True)
+
+        assert result.ok
+        assert result.executed == ("place",)
+        assert calls == [("place", True)]
+        assert _flow_states(flow) == ["Success", "Unstart"]
+        assert not stale_place.exists()
+        assert keep_cts.read_text(encoding="utf-8") == "old"
+
+    def test_non_success_step_runs_without_force(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Incomplete")])
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_only(flow, "place")
+
+        assert result.ok
+        assert result.executed == ("place",)
+        assert calls == [("place", True)]
+
+    def test_failure_reports_failed_step(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Incomplete")])
+        _fake_execution(flow, monkeypatch, outcomes={"place": StateEnum.Imcomplete})
+
+        result = rerun.run_only(flow, "place")
+
+        assert not result.ok
+        assert result.executed == ()
+        assert result.failed == "place"
+        assert _flow_states(flow) == ["Incomplete"]
+
+
+class TestRunResume:
+    def test_reruns_suffix_from_first_non_success(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Incomplete"), ("CTS", "Success")],
+        )
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_resume(flow)
+
+        assert result.ok
+        assert result.executed == ("place", "CTS")
+        assert calls == [("place", True), ("CTS", True)]
+
+    def test_all_success_is_noop(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_resume(flow)
+
+        assert result.ok
+        assert result.executed == ()
+        assert calls == []
+
+
+class TestInitDbEngineForStep:
+    def test_creates_engine_for_the_selected_step(self, monkeypatch, tmp_path):
+        from chipcompiler.engine import EngineDB
+
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        created = []
+
+        def create_db_engine(self, step):
+            created.append(step)
+            return True
+
+        monkeypatch.setattr(EngineDB, "create_db_engine", create_db_engine)
+        step = flow.workspace_steps[0]
+
+        assert flow.init_db_engine_for_step(step) is True
+        assert created == [step]
+        assert isinstance(flow.engine_db, EngineDB)
+
+    def test_reuses_initialized_engine(self, tmp_path):
+        flow = _make_run_flow(tmp_path, [("place", "Success")])
+        engine_db = SimpleNamespace(has_init=lambda: True)
+        flow.engine_db = engine_db
+
+        assert flow.init_db_engine_for_step(flow.workspace_steps[0]) is True
+        assert flow.engine_db is engine_db


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
