### PR TITLE
fix: align signoff package origin RTL check with synthesis inputs

### DIFF
--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -17,7 +17,12 @@ from chipcompiler.tools.ecc.sta_qor import (
     STA_TIMING_PATHS_FILENAME,
     sta_artifact_directory,
 )
-from chipcompiler.utility.filelist import FILELIST_SUFFIXES, parse_filelist, resolve_initial_rtl
+from chipcompiler.utility.filelist import (
+    FILELIST_SUFFIXES,
+    parse_filelist,
+    resolve_initial_rtl,
+    rewrite_absolute_entries,
+)
 
 SIGNOFF_REQUIRED_QOR_STEPS = {
     StepEnum.HARDEN.value,
@@ -108,7 +113,12 @@ class SignoffPackageCollector:
         issues: list[SignoffPackageIssue] = []
 
         def add_file(
-            role: str, source: Path | None, destination: str, *, required: bool = False
+            role: str,
+            source: Path | None,
+            destination: str,
+            *,
+            required: bool = False,
+            content: str | None = None,
         ) -> None:
             self._add_file(
                 workspace_dir=workspace_dir,
@@ -122,6 +132,7 @@ class SignoffPackageCollector:
                 missing_optional=missing_optional,
                 issues=issues,
                 materialize=options.materialize,
+                content=content,
             )
 
         flow_path = workspace_dir / "home" / "flow.json"
@@ -265,13 +276,14 @@ class SignoffPackageCollector:
                 configured_filelist is not None and origin_rtl == Path(configured_filelist)
             )
             if is_filelist:
-                add_file("initial.filelist", origin_rtl, rtl_destination, required=True)
                 # Workspace creation copies filelist sources into origin/ keeping
                 # each entry's filelist-relative path (absolute entries land at
-                # their basename); bundle them the same way so the packaged
-                # filelist stays resolvable. +incdir header trees are not bundled.
+                # their basename); bundle them the same way and rewrite absolute
+                # entries to those basenames so the packaged filelist stays
+                # resolvable. +incdir header trees are not bundled.
                 try:
                     rtl_entries = parse_filelist(str(origin_rtl))
+                    filelist_text = rewrite_absolute_entries(origin_rtl.read_text(encoding="utf-8"))
                 except (OSError, ValueError) as error:
                     # Without the entries the packaged filelist would dangle, so
                     # block the export instead of shipping an incomplete package.
@@ -286,6 +298,14 @@ class SignoffPackageCollector:
                         )
                     )
                     rtl_entries = []
+                else:
+                    add_file(
+                        "initial.filelist",
+                        origin_rtl,
+                        rtl_destination,
+                        required=True,
+                        content=filelist_text,
+                    )
                 packaged_entries = set()
                 escaped_entries = []
                 for rtl_entry in rtl_entries:
@@ -615,8 +635,13 @@ class SignoffPackageCollector:
         missing_optional: list[str],
         issues: list[SignoffPackageIssue],
         materialize: bool,
+        content: str | None = None,
     ) -> None:
-        if source is None or not source.is_file() or source.stat().st_size <= 0:
+        if content is not None:
+            missing = not content
+        else:
+            missing = source is None or not source.is_file() or source.stat().st_size <= 0
+        if missing:
             if required:
                 missing_required.append(destination)
             else:
@@ -640,11 +665,14 @@ class SignoffPackageCollector:
         if materialize:
             target = package_dir / destination
             target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source, target)
+            if content is None:
+                shutil.copy2(source, target)
+            else:
+                target.write_text(content, encoding="utf-8")
             size_bytes = target.stat().st_size
             sha256 = self._sha256(target)
         else:
-            size_bytes = source.stat().st_size
+            size_bytes = len(content.encode()) if content is not None else source.stat().st_size
             sha256 = None
         copied.append(
             {

--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -2,6 +2,7 @@ import glob
 import hashlib
 import importlib
 import json
+import os
 import shutil
 import tarfile
 import time
@@ -16,6 +17,7 @@ from chipcompiler.tools.ecc.sta_qor import (
     STA_TIMING_PATHS_FILENAME,
     sta_artifact_directory,
 )
+from chipcompiler.utility.filelist import FILELIST_SUFFIXES, parse_filelist, resolve_initial_rtl
 
 SIGNOFF_REQUIRED_QOR_STEPS = {
     StepEnum.HARDEN.value,
@@ -185,21 +187,27 @@ class SignoffPackageCollector:
                     )
 
         db_config = self._read_json(config_dir / "db_default_config.json")
-        origin_verilog, origin_verilog_reason = self._find_one(
+        configured_filelist = getattr(self.workspace.design, "input_filelist", None)
+        origin_rtl = resolve_initial_rtl(
+            configured_filelist,
+            getattr(self.workspace.design, "origin_verilog", None),
             workspace_dir / "origin",
-            preferred_name=f"{design}.v",
-            pattern="*.v",
         )
-        if origin_verilog is None:
-            missing_required.append("origin Verilog")
+        if origin_rtl is not None:
+            rtl_suffix = ".v.gz" if origin_rtl.name.endswith(".v.gz") else origin_rtl.suffix.lower()
+            rtl_destination = f"initial/{design}{rtl_suffix}"
+        else:
+            rtl_destination = f"initial/{design}.v"
+        if origin_rtl is None or not origin_rtl.is_file():
+            missing_required.append("origin RTL")
             issues.append(
                 SignoffPackageIssue(
                     kind="resource",
-                    label="Origin Verilog",
-                    location=f"origin/{design}.v",
-                    reason=origin_verilog_reason,
+                    label="Origin RTL",
+                    location=self._review_source_path(workspace_dir, origin_rtl, "origin"),
+                    reason="Required file is missing or empty",
                     required=True,
-                    destination=f"initial/{design}.v",
+                    destination=rtl_destination,
                 )
             )
         origin_sdc = self._path_from_config(
@@ -249,8 +257,73 @@ class SignoffPackageCollector:
             destination=f"harden/{design}.png",
         )
 
-        if origin_verilog is not None:
-            add_file("initial.verilog", origin_verilog, f"initial/{design}.v", required=True)
+        if origin_rtl is not None and origin_rtl.is_file():
+            # Like synthesis, a configured input_filelist is always a filelist;
+            # runtime-created ones are suffixless (origin/filelist), so the
+            # suffix check alone would miss them.
+            is_filelist = origin_rtl.suffix.lower() in FILELIST_SUFFIXES or (
+                configured_filelist is not None and origin_rtl == Path(configured_filelist)
+            )
+            if is_filelist:
+                add_file("initial.filelist", origin_rtl, rtl_destination, required=True)
+                # Workspace creation copies filelist sources into origin/ keeping
+                # each entry's filelist-relative path (absolute entries land at
+                # their basename); bundle them the same way so the packaged
+                # filelist stays resolvable. +incdir header trees are not bundled.
+                try:
+                    rtl_entries = parse_filelist(str(origin_rtl))
+                except (OSError, ValueError) as error:
+                    # Without the entries the packaged filelist would dangle, so
+                    # block the export instead of shipping an incomplete package.
+                    issues.append(
+                        SignoffPackageIssue(
+                            kind="resource",
+                            label="Origin RTL sources",
+                            location=self._review_source_path(workspace_dir, origin_rtl, "origin"),
+                            reason=f"Could not parse origin filelist for packaging: {error}",
+                            required=True,
+                            destination=rtl_destination,
+                        )
+                    )
+                    rtl_entries = []
+                packaged_entries = set()
+                escaped_entries = []
+                for rtl_entry in rtl_entries:
+                    relative = (
+                        os.path.basename(rtl_entry) if os.path.isabs(rtl_entry) else rtl_entry
+                    )
+                    # Parent-relative entries would escape initial/ (and already
+                    # escaped origin/ at creation); bundling them corrupts the
+                    # package layout, so they block the export instead.
+                    normalized = os.path.normpath(relative)
+                    if normalized == ".." or normalized.startswith(f"..{os.sep}"):
+                        escaped_entries.append(rtl_entry)
+                        continue
+                    if normalized in packaged_entries:
+                        continue
+                    packaged_entries.add(normalized)
+                    add_file(
+                        "initial.verilog",
+                        workspace_dir / "origin" / normalized,
+                        f"initial/{normalized}",
+                        required=True,
+                    )
+                if escaped_entries:
+                    issues.append(
+                        SignoffPackageIssue(
+                            kind="resource",
+                            label="Origin RTL sources",
+                            location=self._review_source_path(workspace_dir, origin_rtl, "origin"),
+                            reason=(
+                                "Filelist entries escape the package layout: "
+                                + ", ".join(escaped_entries)
+                            ),
+                            required=True,
+                            destination=rtl_destination,
+                        )
+                    )
+            else:
+                add_file("initial.verilog", origin_rtl, rtl_destination, required=True)
         if origin_sdc is not None:
             add_file("initial.sdc", origin_sdc, f"initial/{design}.sdc", required=True)
         add_file(
@@ -451,7 +524,7 @@ class SignoffPackageCollector:
                 "qor_analysis_issue_count": len(analysis_issues),
             },
             "initial": {
-                "verilog": f"initial/{design}.v",
+                "verilog": rtl_destination,
                 "sdc": f"initial/{design}.sdc",
                 "parameters": "initial/parameters.json",
             },

--- a/chipcompiler/tools/ecc/signoff_checklist.py
+++ b/chipcompiler/tools/ecc/signoff_checklist.py
@@ -20,7 +20,7 @@ from chipcompiler.tools.ecc.sta_qor import (
     read_sta_timing_paths,
 )
 from chipcompiler.utility import json_read
-from chipcompiler.utility.filelist import FILELIST_SUFFIXES, RTL_SUFFIXES
+from chipcompiler.utility.filelist import resolve_initial_rtl
 
 _STEP_DIRECTORIES = {
     StepEnum.SYNTHESIS.value: "Synthesis_yosys",
@@ -489,33 +489,6 @@ def _flow_items(workspace: Workspace) -> list[dict]:
     return items
 
 
-def _initial_rtl_path(design, origin_directory: Path) -> Path | None:
-    """Resolve the initial RTL input: filelist first, then a single RTL file.
-
-    Mirrors the synthesis input priority (input_filelist over origin_verilog).
-    Configured paths win when they exist; otherwise glob the origin directory
-    by suffix, since load_workspace drops these attributes for .sv and
-    filelist inputs. A configured path missing on disk is returned last so
-    the item reports it as failed.
-    """
-    configured = (
-        getattr(design, "input_filelist", None),
-        getattr(design, "origin_verilog", None),
-    )
-    for candidate in configured:
-        if candidate and Path(candidate).is_file():
-            return Path(candidate)
-    files = sorted(path for path in origin_directory.glob("*") if path.is_file())
-    for suffixes in (FILELIST_SUFFIXES, RTL_SUFFIXES):
-        match = next((path for path in files if path.suffix.lower() in suffixes), None)
-        if match:
-            return match
-    match = next((path for path in files if path.name.endswith(".v.gz")), None)
-    if match:
-        return match
-    return next((Path(candidate) for candidate in configured if candidate), None)
-
-
 def _workspace_items(workspace: Workspace) -> list[dict]:
     workspace_directory = Path(workspace.directory)
     origin_directory = workspace_directory / "origin"
@@ -528,7 +501,15 @@ def _workspace_items(workspace: Workspace) -> list[dict]:
         origin_sdc = next(iter(sorted(origin_directory.glob("*.sdc"))), None)
     config_keys = ("flow", "db", StepEnum.RCX.value, StepEnum.STA.value)
     inputs = (
-        ("provenance.initial.rtl", "Initial RTL", _initial_rtl_path(design, origin_directory)),
+        (
+            "provenance.initial.rtl",
+            "Initial RTL",
+            resolve_initial_rtl(
+                getattr(design, "input_filelist", None),
+                getattr(design, "origin_verilog", None),
+                origin_directory,
+            ),
+        ),
         ("provenance.initial.sdc", "Initial SDC", origin_sdc),
         *(
             (

--- a/chipcompiler/utility/filelist.py
+++ b/chipcompiler/utility/filelist.py
@@ -23,6 +23,7 @@ Example filelist content:
 """
 
 import os
+from pathlib import Path
 
 FILELIST_SUFFIXES = {".f", ".fl", ".filelist"}
 RTL_SUFFIXES = {".v", ".sv", ".svh", ".vh"}
@@ -32,6 +33,34 @@ UNSUPPORTED_OPTIONS = {
     "-v": "Library files",
     "-y": "Library search directories",
 }
+
+
+def resolve_initial_rtl(
+    input_filelist: str | Path | None,
+    origin_verilog: str | Path | None,
+    origin_directory: Path,
+) -> Path | None:
+    """Resolve the initial RTL input: filelist first, then a single RTL file.
+
+    Mirrors the synthesis input priority (input_filelist over origin_verilog).
+    Configured paths win when they exist; otherwise glob the origin directory
+    by suffix, since load_workspace drops these attributes for .sv and
+    filelist inputs. A configured path missing on disk is returned last so
+    callers can report it as failed.
+    """
+    configured = (input_filelist, origin_verilog)
+    for candidate in configured:
+        if candidate and Path(candidate).is_file():
+            return Path(candidate)
+    files = sorted(path for path in origin_directory.glob("*") if path.is_file())
+    for suffixes in (FILELIST_SUFFIXES, RTL_SUFFIXES):
+        match = next((path for path in files if path.suffix.lower() in suffixes), None)
+        if match:
+            return match
+    match = next((path for path in files if path.name.endswith(".v.gz")), None)
+    if match:
+        return match
+    return next((Path(candidate) for candidate in configured if candidate), None)
 
 
 def parse_filelist(filelist_path: str) -> list[str]:

--- a/chipcompiler/utility/filelist.py
+++ b/chipcompiler/utility/filelist.py
@@ -141,6 +141,24 @@ def _remove_inline_comment(line: str) -> str:
     return line
 
 
+def rewrite_absolute_entries(content: str) -> str:
+    """Rewrite absolute filelist entries to their basenames.
+
+    Workspace creation bundles absolute-entry sources by basename, so a
+    packaged filelist must reference those basenames to stay resolvable.
+    Other lines (relative paths, comments, directives) are kept verbatim.
+    Raises ValueError for unsupported options, like parse_filelist.
+    """
+    lines = []
+    for line_num, line in enumerate(content.splitlines(keepends=True), 1):
+        entry = _parse_line(line, line_num)
+        if entry is not None and os.path.isabs(entry):
+            lines.append(line.replace(entry, os.path.basename(entry), 1))
+        else:
+            lines.append(line)
+    return "".join(lines)
+
+
 def resolve_path(path: str, base_dir: str) -> str:
     """
     Resolve a file path (relative or absolute) based on a base directory.

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -497,3 +497,24 @@ def test_collect_signoff_package_blocks_escaping_filelist_entries(tmp_path):
     assert result.ok is False
     assert any(issue.label == "Origin RTL sources" and issue.required for issue in result.issues)
     assert not (Path(result.package_dir) / "escape.sv").exists()
+
+
+def test_collect_signoff_package_rewrites_absolute_filelist_entries(tmp_path):
+    # Creation copies absolute-entry sources into origin/ by basename; the
+    # packaged filelist must reference those basenames to stay resolvable.
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    external = tmp_path / "external" / "gcd.sv"
+    _write(external, "module gcd; endmodule\n")
+    _write(workspace_dir / "origin" / "gcd.f", f'"{external}"  # top\n')
+    _write(workspace_dir / "origin" / "gcd.sv", "module gcd; endmodule\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is True
+    package_dir = Path(result.package_dir)
+    assert (package_dir / "initial" / "gcd.sv").is_file()
+    packaged_filelist = (package_dir / "initial" / "gcd.f").read_text(encoding="utf-8")
+    assert packaged_filelist == '"gcd.sv"  # top\n'

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -197,6 +197,7 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
     assert not (package_dir / "final" / "final").exists()
 
     summary = json.loads((package_dir / "summary.json").read_text())
+    assert summary["initial"]["verilog"] == "initial/gcd.v"
     assert summary["final"]["verilog"] == "final/design/gcd.v.gz"
     assert summary["qor_metrics"]["schema_version"] == 3
     assert (
@@ -379,3 +380,120 @@ def test_collect_signoff_package_reports_actionable_inspection_issues(tmp_path):
         issue.location == "RCX" and issue.reason == "State is Failed" for issue in result.issues
     )
     assert all(str(workspace_dir) not in issue.location for issue in result.issues)
+
+
+def test_collect_signoff_package_accepts_systemverilog_origin(tmp_path):
+    # load_workspace restores neither input_filelist nor .sv sources, so the
+    # collector must rediscover the RTL by globbing the origin directory.
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    _write(workspace_dir / "origin" / "gcd.sv", "module gcd; endmodule\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is True
+    package_dir = Path(result.package_dir)
+    assert (package_dir / "initial" / "gcd.sv").is_file()
+    summary = json.loads((package_dir / "summary.json").read_text())
+    assert summary["initial"]["verilog"] == "initial/gcd.sv"
+
+
+def test_collect_signoff_package_bundles_filelist_sources(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    _write(workspace_dir / "origin" / "gcd.f", "rtl/gcd.sv\ngcd_pkg.sv\n")
+    _write(workspace_dir / "origin" / "rtl" / "gcd.sv", "module gcd; endmodule\n")
+    _write(workspace_dir / "origin" / "gcd_pkg.sv", "package gcd_pkg; endpackage\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is True
+    package_dir = Path(result.package_dir)
+    assert (package_dir / "initial" / "gcd.f").is_file()
+    assert (package_dir / "initial" / "rtl" / "gcd.sv").is_file()
+    assert (package_dir / "initial" / "gcd_pkg.sv").is_file()
+    summary = json.loads((package_dir / "summary.json").read_text())
+    assert summary["initial"]["verilog"] == "initial/gcd.f"
+    manifest = json.loads((package_dir / "manifest.json").read_text())
+    roles = {item["destination"]: item["role"] for item in manifest["files"]}
+    assert roles["initial/gcd.f"] == "initial.filelist"
+    assert roles["initial/rtl/gcd.sv"] == "initial.verilog"
+    assert roles["initial/gcd_pkg.sv"] == "initial.verilog"
+
+
+def test_collect_signoff_package_blocks_missing_origin_rtl(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is False
+    assert "package.initial.gcd.v" in result.missing_required
+    assert any(
+        issue.label == "Origin RTL"
+        and issue.location == "origin/gcd.v"
+        and issue.destination == "initial/gcd.v"
+        and issue.required
+        for issue in result.issues
+    )
+
+
+def test_collect_signoff_package_bundles_suffixless_filelist(tmp_path):
+    # WorkspaceRuntimeApi writes generated filelists as origin/filelist with no
+    # suffix; the configured attribute, not the suffix, marks it as a filelist.
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    _write(workspace_dir / "origin" / "filelist", "rtl/gcd.sv\n")
+    _write(workspace_dir / "origin" / "rtl" / "gcd.sv", "module gcd; endmodule\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+    engine_flow.workspace.design.input_filelist = workspace_dir / "origin" / "filelist"
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is True
+    package_dir = Path(result.package_dir)
+    assert (package_dir / "initial" / "gcd").is_file()
+    assert (package_dir / "initial" / "rtl" / "gcd.sv").is_file()
+    manifest = json.loads((package_dir / "manifest.json").read_text())
+    roles = {item["destination"]: item["role"] for item in manifest["files"]}
+    assert roles["initial/gcd"] == "initial.filelist"
+    assert roles["initial/rtl/gcd.sv"] == "initial.verilog"
+
+
+def test_collect_signoff_package_blocks_unparseable_filelist(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    _write(workspace_dir / "origin" / "gcd.f", "-f nested.f\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+
+    result = engine_flow.collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is False
+    assert any(issue.label == "Origin RTL sources" and issue.required for issue in result.issues)
+
+
+def test_collect_signoff_package_blocks_escaping_filelist_entries(tmp_path):
+    # The source exists outside origin/, so without the containment guard the
+    # entry would be copied to an escaped destination and the export would pass.
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "origin" / "gcd.v").unlink()
+    _write(workspace_dir / "origin" / "gcd.f", "../escape.sv\n")
+    _write(workspace_dir / "escape.sv", "module escape; endmodule\n")
+    engine_flow = _make_engine_flow(workspace_dir)
+    engine_flow.workspace.design.origin_verilog = None
+
+    result = engine_flow.collect_signoff_package(SignoffPackageOptions(archive=True))
+
+    assert result.ok is False
+    assert any(issue.label == "Origin RTL sources" and issue.required for issue in result.issues)
+    assert not (Path(result.package_dir) / "escape.sv").exists()

--- a/test/utility/filelist/test_parse.py
+++ b/test/utility/filelist/test_parse.py
@@ -6,6 +6,7 @@ from chipcompiler.utility.filelist import (
     get_filelist_info,
     parse_filelist,
     resolve_path,
+    rewrite_absolute_entries,
     validate_filelist,
 )
 
@@ -190,3 +191,26 @@ class TestParseIncdirDirectives:
         )
         dirs = parse_incdir_from_content(content)
         assert dirs == ["./include", "./rtl/common", "./quoted", "./leading", "./tab"]
+
+
+class TestRewriteAbsoluteEntries:
+    def test_rewrites_absolute_entries_to_basenames(self):
+        content = "/abs/path/gcd.sv\nrtl/relative.sv\n"
+
+        assert rewrite_absolute_entries(content) == "gcd.sv\nrtl/relative.sv\n"
+
+    def test_keeps_quotes_and_comments(self):
+        content = '"/abs/path with spaces/gcd.sv"  # top\n// comment\n+incdir+./include\n'
+
+        assert rewrite_absolute_entries(content) == (
+            '"gcd.sv"  # top\n// comment\n+incdir+./include\n'
+        )
+
+    def test_relative_only_content_is_unchanged(self):
+        content = "rtl/gcd.sv\ngcd_pkg.sv"
+
+        assert rewrite_absolute_entries(content) == content
+
+    def test_rejects_unsupported_options(self):
+        with pytest.raises(ValueError, match="Unsupported filelist option"):
+            rewrite_absolute_entries("-f nested.f\n")


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
