### PR TITLE
 feat: update gui view

### DIFF
--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -538,6 +538,9 @@ class EngineFlow:
 
         self.clear_db_engine_after_step(workspace_step, state)
 
+        if elapsed < 3:
+            time.sleep(3)
+
         return state
 
     def init_db_engine_for_step(self, workspace_step: WorkspaceStep) -> bool:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -269,11 +269,18 @@ class WorkspaceRuntimeApi:
                 attach_session_db=should_capture and not request.rerun,
             )
             if request.rerun:
+                if session.layout_edit_session is not None:
+                    raise RuntimeApiError(
+                        "layout_edit_active",
+                        "close the rendered layout before rerunning this step",
+                    )
                 self._refresh_workspace_config(session.workspace)
 
             workspace_step = engine_flow.get_workspace_step(request.step)
             if workspace_step is None:
                 raise RuntimeApiError("command_failed", f"step not found: {request.step}")
+            if request.rerun:
+                self._prepare_step_for_rerun(session.workspace, engine_flow, workspace_step)
 
             try:
                 step_already_succeeded = not request.rerun and engine_flow.check_state(
@@ -709,6 +716,98 @@ class WorkspaceRuntimeApi:
         import chipcompiler.data as data_api
 
         data_api.prepare_workspace_for_rerun(workspace, engine_flow)
+
+    @staticmethod
+    def _prepare_step_for_rerun(workspace, engine_flow, workspace_step) -> None:
+        workspace_root = Path(workspace.directory).resolve()
+        for directory in WorkspaceRuntimeApi._step_artifact_dirs(workspace_step):
+            WorkspaceRuntimeApi._clear_step_artifact_dir(
+                workspace_root,
+                directory,
+                workspace_step.name,
+            )
+
+        record = engine_flow.get_step(workspace_step.name, workspace_step.tool)
+        if record is not None:
+            record.update({"state": "Unstart", "runtime": "", "peak memory (mb)": 0})
+            engine_flow.save()
+
+        WorkspaceRuntimeApi._reset_step_subflow(workspace_step)
+        WorkspaceRuntimeApi._reset_step_checklist(workspace_step)
+
+    @staticmethod
+    def _reset_step_subflow(workspace_step) -> None:
+        from chipcompiler.utility import json_read, json_write
+
+        subflow = getattr(workspace_step, "subflow", None)
+        path = getattr(subflow, "path", None)
+        if not path:
+            return
+        subflow_path = Path(path)
+        data = json_read(subflow_path)
+        steps = data.get("steps", []) if isinstance(data, dict) else []
+        if not isinstance(steps, list):
+            return
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            step.update(
+                {
+                    "state": "Unstart",
+                    "runtime": "",
+                    "peak memory (mb)": 0,
+                    "info": {},
+                }
+            )
+        json_write(subflow_path, {"path": str(subflow_path), "steps": steps})
+        subflow.steps = steps
+
+    @staticmethod
+    def _reset_step_checklist(workspace_step) -> None:
+        from chipcompiler.utility import json_write
+
+        checklist = getattr(workspace_step, "checklist", None)
+        path = getattr(checklist, "path", None)
+        if not path:
+            return
+        checklist_path = Path(path)
+        json_write(checklist_path, {"path": str(checklist_path), "checklist": []})
+        checklist.checklist = []
+
+    @staticmethod
+    def _step_artifact_dirs(step) -> tuple[Path, ...]:
+        directories: list[Path] = []
+        for field in ("output", "data", "feature", "analysis", "report", "log"):
+            value = getattr(step, field, {})
+            directory = value.get("dir") if isinstance(value, dict) else getattr(value, "dir", None)
+            if directory:
+                directories.append(Path(directory))
+        return tuple(dict.fromkeys(directories))
+
+    @staticmethod
+    def _clear_step_artifact_dir(
+        workspace_root: Path,
+        directory: Path,
+        step_name: str,
+    ) -> None:
+        resolved = directory.resolve()
+        if (
+            resolved == workspace_root
+            or not path_is_within(resolved, workspace_root)
+            or directory.is_symlink()
+        ):
+            raise RuntimeApiError(
+                "command_failed",
+                f"step artifact escapes workspace: {step_name}",
+            )
+        if directory.exists():
+            if not directory.is_dir():
+                raise RuntimeApiError(
+                    "command_failed",
+                    f"step artifact is not a directory: {step_name}",
+                )
+            shutil.rmtree(directory)
+        directory.mkdir(parents=True, exist_ok=True)
 
 
 def _layout_edit_begin_result(edit_session: LayoutEditSession, *, reused: bool) -> dict:

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -3,7 +3,14 @@ import os
 import shutil
 from pathlib import Path
 
-from chipcompiler.data import EccStep, StateEnum, StepEnum, Workspace, WorkspaceStep
+from chipcompiler.data import (
+    EccStep,
+    StateEnum,
+    StepEnum,
+    Workspace,
+    WorkspaceStep,
+    workspace_config_path,
+)
 from chipcompiler.tools.ecc.checklist import EccChecklist
 from chipcompiler.tools.ecc.metrics import (
     build_step_metrics,
@@ -52,6 +59,13 @@ def temperature_token(temperature) -> str:
     return str(temperature).replace("-", "m").replace(".", "p")
 
 
+def _workspace_sta_config_path(workspace: Workspace) -> str | None:
+    if workspace.directory is None:
+        return None
+    config_path = workspace_config_path(workspace.directory, StepEnum.STA.value)
+    return os.fspath(config_path) if config_path is not None else None
+
+
 def copy_rcx_spef_outputs(workspace: Workspace, step: EccStep):
     data_dir_text = os.fspath(step.data.dir or "")
     output_dir_text = os.fspath(step.output.dir or "")
@@ -96,11 +110,11 @@ def copy_rcx_spef_outputs(workspace: Workspace, step: EccStep):
 
 
 def collect_sta_signoff_items(workspace: Workspace) -> list[dict]:
-    sta_config = workspace.config.get(StepEnum.STA.value, "")
-    sta_data = json_read(sta_config)
     workspace_dir = workspace.directory
-    if workspace_dir is None:
+    sta_config = _workspace_sta_config_path(workspace)
+    if workspace_dir is None or sta_config is None:
         return []
+    sta_data = json_read(sta_config)
     rcx_output_dir = workspace_dir / f"{StepEnum.RCX.value}_ecc" / "output"
 
     liberty_by_corner = {liberty.get("corner"): liberty for liberty in sta_data.get("liberty", [])}
@@ -333,8 +347,12 @@ def run_sta_without_spef(
             verilog=netlist_path,
             top_module=workspace.design.top_module,
         )
+        sta_config = _workspace_sta_config_path(workspace)
+        if sta_config is None:
+            raise ValueError("workspace STA config path is not configured")
+
         ecc_module.run_timing(
-            config=workspace.config.get(StepEnum.STA.value, ""),
+            config=sta_config,
             work_dir=work_dir,
             report_dir=report_dir,
             feature_dir=feature_dir,
@@ -862,11 +880,15 @@ def run_harden(
             workspace.logger.error("No signoff STA items found")
             return False
         signoff_item = signoff_items[0]
+        sta_config = _workspace_sta_config_path(workspace)
+        if sta_config is None:
+            workspace.logger.error("workspace STA config path is not configured")
+            return False
 
         ecc_module.write_abstract_lef(output_lef_path=step.output.lef or "")
         ecc_module.write_timing_model(
             output_lib_path=step.output.lib or "",
-            config=workspace.config.get(StepEnum.STA.value, ""),
+            config=sta_config,
             output_dir=(step.data.steps or {}).get(StepEnum.STA.value, ""),
             lib_paths=signoff_item["liberty_files"],
             sdc_path=workspace.pdk.sdc,
@@ -943,6 +965,11 @@ def run_sta(workspace: Workspace, step: EccStep, ecc_module: ECCToolsModule | No
         workspace.logger.error("No signoff STA items found")
         sub_flow.update_step(step_name=EccSubFlowEnum.run_sta.value, state=StateEnum.Imcomplete)
         return False
+    sta_config = _workspace_sta_config_path(workspace)
+    if sta_config is None:
+        workspace.logger.error("workspace STA config path is not configured")
+        sub_flow.update_step(step_name=EccSubFlowEnum.run_sta.value, state=StateEnum.Imcomplete)
+        return False
 
     if not os.path.exists(workspace.pdk.sdc):
         workspace.logger.error("STA SDC does not exist: %s", workspace.pdk.sdc)
@@ -1004,7 +1031,7 @@ def run_sta(workspace: Workspace, step: EccStep, ecc_module: ECCToolsModule | No
         corner = f"{report_dir.parent.name}/{report_dir.name}"
 
         ecc_module.run_timing(
-            config=workspace.config.get(StepEnum.STA.value, ""),
+            config=sta_config,
             work_dir=(step.data.steps or {}).get(StepEnum.STA.value, ""),
             report_dir=report_dir,
             feature_dir=feature_dir,

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -134,6 +134,15 @@ class DummyFlow:
                 return step
         return None
 
+    def get_step(self, name, tool):
+        for step in self.workspace.flow.data.get("steps", []):
+            if step.get("name") == name and step.get("tool") == tool:
+                return step
+        return None
+
+    def save(self):
+        return True
+
     def check_state(self, name, tool, state):
         return getattr(state, "value", state) == StateEnum.Success.value and name in (
             self.successful_steps
@@ -1113,6 +1122,132 @@ def test_flow_run_step_rerun_refreshes_before_db_init(monkeypatch, tmp_path):
         ("init_db_engine",),
         ("run_step", "Floorplan", True),
     ]
+
+
+def test_flow_run_step_rerun_clears_step_artifacts_and_resets_step_state(monkeypatch, tmp_path):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    step_dir = ws / "Floorplan_ecc"
+    artifact_dirs = [
+        step_dir / "output",
+        step_dir / "data",
+        step_dir / "feature",
+        step_dir / "analysis",
+        step_dir / "report",
+        step_dir / "log",
+    ]
+    for directory in artifact_dirs:
+        (directory / "nested").mkdir(parents=True)
+        (directory / "nested" / "stale").write_text("stale")
+    script_dir = step_dir / "script"
+    script_dir.mkdir()
+    (script_dir / "keep.tcl").write_text("keep")
+
+    subflow_path = step_dir / "subflow.json"
+    subflow_path.write_text(
+        json.dumps(
+            {
+                "path": str(subflow_path),
+                "steps": [
+                    {
+                        "name": "load data",
+                        "state": "Success",
+                        "runtime": "0:00:03",
+                        "peak memory (mb)": 24,
+                        "info": {"instances": 12},
+                    }
+                ],
+            }
+        )
+    )
+    checklist_path = step_dir / "checklist.json"
+    checklist_path.write_text(
+        json.dumps(
+            {
+                "path": str(checklist_path),
+                "checklist": [{"item": "stale", "state": "Success"}],
+            }
+        )
+    )
+    DummyFlow.workspace_step_specs = (
+        {
+            "name": "Floorplan",
+            "tool": "ecc",
+            "output": {"dir": step_dir / "output"},
+            "data": {"dir": step_dir / "data"},
+            "feature": {"dir": step_dir / "feature"},
+            "analysis": {"dir": step_dir / "analysis"},
+            "report": {"dir": step_dir / "report"},
+            "log": {"dir": step_dir / "log"},
+            "subflow": SimpleNamespace(path=subflow_path, steps=[]),
+            "checklist": SimpleNamespace(path=checklist_path, checklist=[]),
+        },
+    )
+    api = WorkspaceRuntimeApi()
+    workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
+    session = api.sessions.get_session(workspace_id)
+    session.workspace.flow.data = {
+        "steps": [
+            {
+                "name": "Floorplan",
+                "tool": "ecc",
+                "state": "Success",
+                "runtime": "0:00:04",
+                "peak memory (mb)": 30,
+            }
+        ]
+    }
+
+    result = api.flow_run_step(
+        FlowRunStepRequest(workspace_id=workspace_id, step="Floorplan", rerun=True)
+    )
+
+    assert result == {"step": "Floorplan", "state": "Success"}
+    assert all(list(directory.iterdir()) == [] for directory in artifact_dirs)
+    assert (script_dir / "keep.tcl").read_text() == "keep"
+    flow_record = next(
+        record
+        for record in session.workspace.flow.data["steps"]
+        if record["name"] == "Floorplan" and record["tool"] == "ecc"
+    )
+    assert flow_record == {
+        "name": "Floorplan",
+        "tool": "ecc",
+        "state": "Unstart",
+        "runtime": "",
+        "peak memory (mb)": 0,
+    }
+    assert json.loads(subflow_path.read_text()) == {
+        "path": str(subflow_path),
+        "steps": [
+            {
+                "name": "load data",
+                "state": "Unstart",
+                "runtime": "",
+                "peak memory (mb)": 0,
+                "info": {},
+            }
+        ],
+    }
+    assert json.loads(checklist_path.read_text()) == {
+        "path": str(checklist_path),
+        "checklist": [],
+    }
+
+
+def test_flow_run_step_rerun_rejects_an_open_layout_edit(monkeypatch, tmp_path):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    api = WorkspaceRuntimeApi()
+    workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
+    api.sessions.get_session(workspace_id).layout_edit_session = object()
+
+    with pytest.raises(RuntimeApiError) as exc_info:
+        api.flow_run_step(
+            FlowRunStepRequest(workspace_id=workspace_id, step="Floorplan", rerun=True)
+        )
+
+    assert exc_info.value.code == "layout_edit_active"
+    assert "close the rendered layout" in exc_info.value.message
+    assert DummyFlow.instances[-1].run_calls == []
 
 
 def test_flow_run_step_skips_successful_step_without_db_init(monkeypatch, tmp_path):

--- a/test/test_engine_flow.py
+++ b/test/test_engine_flow.py
@@ -94,6 +94,8 @@ def test_engine_flow_delays_short_step_before_return(monkeypatch, tmp_path):
 
     assert engine_flow.run_step(workspace_step) is StateEnum.Imcomplete
     assert sleep_calls == [3]
+
+
 def test_check_step_result_synthesis_uses_common_verilog(tmp_path):
     verilog = tmp_path / "gcd.v"
     verilog.write_text("module gcd; endmodule\n")

--- a/test/test_engine_flow.py
+++ b/test/test_engine_flow.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import chipcompiler.engine.flow as flow_module
 from chipcompiler import tools
 from chipcompiler.data import (
     EccFeature,
@@ -77,6 +78,22 @@ def test_engine_flow_persists_run_facts_before_refreshing_qor_analysis(
     }
 
 
+def test_engine_flow_delays_short_step_before_return(monkeypatch, tmp_path):
+    workspace = Workspace()
+    workspace.flow.data = {
+        "steps": [{"name": "route", "tool": "ecc", "state": "Unstart"}],
+    }
+    engine_flow = EngineFlow(workspace)
+    workspace_step = EccStep(name="route", directory=tmp_path, tool="ecc")
+    engine_flow.workspace_steps = [workspace_step]
+    engine_flow.engine_db = SimpleNamespace(engine=None)
+    sleep_calls = []
+
+    monkeypatch.setattr(tools, "run_step", lambda **_kwargs: False)
+    monkeypatch.setattr(flow_module.time, "sleep", sleep_calls.append)
+
+    assert engine_flow.run_step(workspace_step) is StateEnum.Imcomplete
+    assert sleep_calls == [3]
 def test_check_step_result_synthesis_uses_common_verilog(tmp_path):
     verilog = tmp_path / "gcd.v"
     verilog.write_text("module gcd; endmodule\n")

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -289,7 +289,7 @@ def test_run_sta_without_spef_reads_netlist_and_writes_to_step_report_and_featur
         (
             "run_timing",
             {
-                "config": workspace.config[StepEnum.STA.value],
+                "config": str(workspace.config[StepEnum.STA.value]),
                 "work_dir": step.data.dir / "sta",
                 "report_dir": step.report.dir / "post_synthesis",
                 "feature_dir": step.feature.dir / "post_synthesis",
@@ -438,12 +438,15 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
         json.dumps({"output": str(tmp_path / "RCX_ecc" / "data")}),
         encoding="utf-8",
     )
+    incorrect_sta_config = tmp_path / "shared-config" / "sta.json"
+    incorrect_sta_config.parent.mkdir()
+    incorrect_sta_config.write_text("{}", encoding="utf-8")
     logger = FakeLogger()
     workspace = Workspace(
         directory=tmp_path,
         design=OriginDesign(name="gcd", top_module="gcd"),
         pdk=PDK(libs=[max_lib, min_lib], sdc=sdc),
-        config={StepEnum.STA.value: sta_config, StepEnum.RCX.value: rcx_config},
+        config={StepEnum.STA.value: incorrect_sta_config, StepEnum.RCX.value: rcx_config},
         logger=logger,
     )
     step = EccStep(
@@ -465,7 +468,7 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
     assert step.report.dir is not None
     assert calls == [
         {
-            "config": sta_config,
+            "config": str(sta_config),
             "work_dir": step.data.steps[StepEnum.STA.value],
             "report_dir": step.report.dir / "MAX_125" / "RCworst",
             "feature_dir": step.feature.dir / "MAX_125" / "RCworst",
@@ -476,7 +479,7 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
             "corner": "MAX_125/RCworst",
         },
         {
-            "config": sta_config,
+            "config": str(sta_config),
             "work_dir": step.data.steps[StepEnum.STA.value],
             "report_dir": step.report.dir / "MIN_m40" / "Cbest",
             "feature_dir": step.feature.dir / "MIN_m40" / "Cbest",


### PR DESCRIPTION
## What Changed

- feat: update gui view

## Scope

Select the areas touched by this PR:

- [x] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
