### PR TITLE
fix: map ics55 latches in yosys synthesis

### DIFF
--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -461,6 +461,37 @@ clockgate {*}$tech_cells_args {*}$exclude_cells
 # technology mapping for flip-flops
 dfflibmap {*}$tech_cells_args {*}$exclude_cells
 
+# dfflibmap intentionally handles only flip-flops.  For ics55 it selects the
+# final matching DFF library in lib_stdcell_list, so use that same H7 variant
+# for the plain D-latch mapping before ABC.
+set ics55_latch_suffix ""
+if {[llength $lib_stdcell_list] > 0} {
+  set dff_lib [lindex $lib_stdcell_list end]
+  if {[regexp {ics55_LLSC_H7C([HLR])_} [file tail $dff_lib] -> vt]} {
+    set ics55_latch_suffix "H7$vt"
+  }
+}
+if {$ics55_latch_suffix ne ""} {
+  set ics55_latch_map "${tmp_dir}/ics55_latch_map.v"
+  set latch_map_file [open $ics55_latch_map "w"]
+  puts $latch_map_file [format {
+module \$_DLATCH_N_ (E, D, Q);
+  input E, D;
+  output Q;
+  LATLX1%s _TECHMAP_REPLACE_ (.D(D), .GN(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_P_ (E, D, Q);
+  input E, D;
+  output Q;
+  LATHX1%s _TECHMAP_REPLACE_ (.D(D), .G(E), .Q(Q));
+endmodule
+} $ics55_latch_suffix $ics55_latch_suffix]
+  close $latch_map_file
+  techmap -map $ics55_latch_map
+  opt -fast -purge
+}
+
 # Optimize again after FF mapping — sometimes FFs create
 # new optimization opportunities (constant propagation, etc.)
 opt -undriven -purge


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
