### PR TITLE
chore(gh): refine ISSUE_TEMPLATE and pull_request_template format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report errors or unexpected behavior in ECC.
-title: "[Bug]: "
+title: "bug: "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement or new capability for ECC.
-title: "[Feature]: "
+title: "feature: "
 labels:
   - enhancement
 body:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## What Changed
 
--
+- 
 
 ## Scope
 
@@ -13,25 +13,6 @@ Select the areas touched by this PR:
 - [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
 - [ ] Tests/docs only
 
-
-
-## Validation
-
-List the commands you ran. Mark checks that are not applicable as N/A.
-
-- [ ] `uv run pytest test/`
-- [ ] Focused pytest:
-- [ ] `uv run ruff check chipcompiler test`
-- [ ] `uv run ruff format --check chipcompiler test`
-- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
-- [ ] Nix smoke: `nix run .#cli -- --help`
-- [ ] Manual flow smoke:
-- [ ] Other:
-
-Skipped checks and reason:
-
--
-
 ## Runtime And Packaging Impact
 
 - [ ] No runtime or packaging impact
@@ -42,6 +23,23 @@ Skipped checks and reason:
 - [ ] PyInstaller, Nix, or release artifact changed
 
 Notes:
+
+-
+
+
+## Validation
+
+List the commands you ran. Mark checks that are not applicable as N/A.
+
+- [ ] `uv run pytest test/`
+- [ ] `uv run ruff check chipcompiler test`
+- [ ] `uv run ruff format --check chipcompiler test`
+- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
+- [ ] Nix smoke: `nix run .#cli -- --help`
+- [ ] Manual flow smoke:
+- [ ] Other:
+
+Skipped checks and reason:
 
 -
 


### PR DESCRIPTION
## What Changed

-

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only



## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] Focused pytest:
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
