### PR TITLE
feat: build a stable mechanism for mutual communication between GUI and ECC

### DIFF
--- a/chipcompiler/data/workspace/__init__.py
+++ b/chipcompiler/data/workspace/__init__.py
@@ -819,8 +819,17 @@ def _reset_workspace_runtime_parameters(workspace: Workspace) -> None:
     save_parameter(workspace.parameters)
 
 
-def prepare_workspace_for_rerun(workspace: Workspace, engine_flow) -> None:
-    """Delete old run artifacts and restore runtime files before a full-flow rerun."""
+def prepare_workspace_for_rerun(
+    workspace: Workspace,
+    engine_flow,
+    *,
+    preserve_user_inputs: bool = False,
+) -> None:
+    """Delete old run artifacts and restore runtime files before a full-flow rerun.
+
+    GUI reruns retain the user's current configuration and parameter values. CLI
+    keeps the established runtime-parameter reset behavior.
+    """
     import shutil
 
     workspace_root = Path(workspace.directory).resolve()
@@ -856,9 +865,9 @@ def prepare_workspace_for_rerun(workspace: Workspace, engine_flow) -> None:
     workspace.home.set_checklist(workspace_root / "home" / "checklist.json")
     workspace.home.set_parameters(workspace.parameters.path)
     _reset_workspace_checklist(workspace)
-    _reset_workspace_runtime_parameters(workspace)
-
-    refresh_workspace_config(workspace)
+    if not preserve_user_inputs:
+        _reset_workspace_runtime_parameters(workspace)
+        refresh_workspace_config(workspace)
 
     if hasattr(engine_flow, "engine_db"):
         engine_flow.engine_db = None

--- a/chipcompiler/engine/db.py
+++ b/chipcompiler/engine/db.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from chipcompiler.data import Workspace, WorkspaceStep
+from chipcompiler.data import StepEnum, Workspace, WorkspaceStep
 
 
 class EngineDB:
@@ -39,6 +39,11 @@ class EngineDB:
         if step is None:
             return False
 
+        # Synthesis has no physical design input, so the native DB is not
+        # applicable until a later flow step provides one.
+        if step.name == StepEnum.SYNTHESIS.value:
+            return False
+
         # check eda tool exist
         from chipcompiler.tools import load_eda_module
 
@@ -52,9 +57,8 @@ class EngineDB:
         if self.ecc_module is not None:
             self.workspace.logger.info(f"ecc db initialize success for step {step.name}.")
             return True
-        else:
-            self.workspace.logger.warning(f"ecc db initialize failed for step {step.name}.")
-            return False
+        self.workspace.logger.warning(f"ecc db initialize failed for step {step.name}.")
+        return False
 
     def update_db_from_step(self, step: WorkspaceStep):
         """

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -559,6 +559,7 @@ class EngineFlow:
             return StateEnum.Invalid
 
         return state
+
     def init_db_engine_for_step(self, workspace_step: WorkspaceStep) -> bool:
         """Initialize the native DB engine from an explicitly selected step."""
         if self.engine_db is None:

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -501,21 +501,6 @@ class EngineFlow:
             if self.check_step_result(workspace_step=workspace_step)
             else StateEnum.Imcomplete
         )
-        self.set_state(
-            name=workspace_step.name,
-            tool=workspace_step.tool,
-            state=state,
-            runtime=runtime,
-            peak_memory=peak_memory_mb,
-        )
-        self.workspace.logger.info(
-            "[RESULT] %s state=%s runtime=%s mem=%sMB exitcode=%s",
-            step_tag,
-            state.value,
-            runtime,
-            peak_memory_mb,
-            0,
-        )
 
         # save layout snapshot on success
         if state == StateEnum.Success:
@@ -547,6 +532,21 @@ class EngineFlow:
             from chipcompiler.tools import save_layout_image
 
             save_layout_image(workspace=self.workspace, step=workspace_step)
+        self.set_state(
+            name=workspace_step.name,
+            tool=workspace_step.tool,
+            state=state,
+            runtime=runtime,
+            peak_memory=peak_memory_mb,
+        )
+        self.workspace.logger.info(
+            "[RESULT] %s state=%s runtime=%s mem=%sMB exitcode=%s",
+            step_tag,
+            state.value,
+            runtime,
+            peak_memory_mb,
+            0,
+        )
 
         self.clear_db_engine_after_step(workspace_step, state)
         _notify_flow_observer(observer, "on_step_completed", workspace_step, state)

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -384,7 +384,7 @@ class EngineFlow:
         payload["constraints"] = {"sdc": timing_constraints}
         return json_write(file_path=feature_path, data=payload)
 
-    def run_steps(self, *, rerun=False) -> bool:
+    def run_steps(self, *, rerun: bool = False, observer=None) -> bool:
         """
         run all flow steps
         """
@@ -394,7 +394,11 @@ class EngineFlow:
                 f"{workspace_step.tool} - begin step - {workspace_step.name}"
             )
             self.init_db_engine()
-            state = self.run_step(workspace_step, rerun=rerun)
+            state = (
+                self.run_step(workspace_step, rerun=rerun)
+                if observer is None
+                else self.run_step(workspace_step, rerun=rerun, observer=observer)
+            )
 
             log_flow(workspace=self.workspace)
             self.workspace.logger.log_section(
@@ -417,7 +421,13 @@ class EngineFlow:
 
         return True
 
-    def run_step(self, workspace_step: WorkspaceStep | str, *, rerun: bool = False) -> StateEnum:
+    def run_step(
+        self,
+        workspace_step: WorkspaceStep | str,
+        *,
+        rerun: bool = False,
+        observer=None,
+    ) -> StateEnum:
         """
         run single step
         """
@@ -433,12 +443,14 @@ class EngineFlow:
         ):
             self.workspace.logger.info("[SKIP] %s already succeeded", step_tag)
             self.clear_db_engine_after_step(workspace_step, StateEnum.Success)
+            _notify_flow_observer(observer, "on_step_skipped", workspace_step)
             return StateEnum.Success
 
         # set state ongoing
         start_time = time.time()
         timing_constraints = self.timing_constraint_facts()
         self.set_state(name=workspace_step.name, tool=workspace_step.tool, state=StateEnum.Ongoing)
+        _notify_flow_observer(observer, "on_step_started", workspace_step)
 
         # run step
         log_file = workspace_step.log.file or ""
@@ -537,12 +549,15 @@ class EngineFlow:
             save_layout_image(workspace=self.workspace, step=workspace_step)
 
         self.clear_db_engine_after_step(workspace_step, state)
-
-        if elapsed < 3:
-            time.sleep(3)
+        _notify_flow_observer(observer, "on_step_completed", workspace_step, state)
+        if state == StateEnum.Success and not _wait_for_step_rendered(
+            observer,
+            workspace_step,
+            state,
+        ):
+            return StateEnum.Invalid
 
         return state
-
     def init_db_engine_for_step(self, workspace_step: WorkspaceStep) -> bool:
         """Initialize the native DB engine from an explicitly selected step."""
         if self.engine_db is None:
@@ -551,3 +566,31 @@ class EngineFlow:
             return True
 
         return self.engine_db.create_db_engine(step=workspace_step)
+
+
+def _notify_flow_observer(observer, method_name: str, *args) -> None:
+    """Keep optional GUI observers outside the flow engine's failure domain."""
+    if observer is None:
+        return
+    callback = getattr(observer, method_name, None)
+    if not callable(callback):
+        return
+    try:
+        callback(*args)
+    except Exception:
+        # Runtime observers must never turn a completed tool execution into a
+        # failed flow. The coordinator records transport failures separately.
+        logging.getLogger(__name__).exception("flow observer callback failed: %s", method_name)
+
+
+def _wait_for_step_rendered(observer, workspace_step: WorkspaceStep, state: StateEnum) -> bool:
+    if observer is None or state != StateEnum.Success:
+        return True
+    callback = getattr(observer, "wait_for_step_rendered", None)
+    if not callable(callback):
+        return True
+    try:
+        return bool(callback(workspace_step, state))
+    except Exception:
+        logging.getLogger(__name__).exception("flow observer render gate failed")
+        return False

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -502,6 +502,22 @@ class EngineFlow:
             else StateEnum.Imcomplete
         )
 
+        self.set_state(
+            name=workspace_step.name,
+            tool=workspace_step.tool,
+            state=state,
+            runtime=runtime,
+            peak_memory=peak_memory_mb,
+        )
+        self.workspace.logger.info(
+            "[RESULT] %s state=%s runtime=%s mem=%sMB exitcode=%s",
+            step_tag,
+            state.value,
+            runtime,
+            peak_memory_mb,
+            0,
+        )
+
         # save layout snapshot on success
         if state == StateEnum.Success:
             if self.save_step_flow_facts(
@@ -532,21 +548,6 @@ class EngineFlow:
             from chipcompiler.tools import save_layout_image
 
             save_layout_image(workspace=self.workspace, step=workspace_step)
-        self.set_state(
-            name=workspace_step.name,
-            tool=workspace_step.tool,
-            state=state,
-            runtime=runtime,
-            peak_memory=peak_memory_mb,
-        )
-        self.workspace.logger.info(
-            "[RESULT] %s state=%s runtime=%s mem=%sMB exitcode=%s",
-            step_tag,
-            state.value,
-            runtime,
-            peak_memory_mb,
-            0,
-        )
 
         self.clear_db_engine_after_step(workspace_step, state)
         _notify_flow_observer(observer, "on_step_completed", workspace_step, state)

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -15,6 +15,10 @@ from chipcompiler.runtime.requests import (
     LayoutEditBeginRequest,
     LayoutEditDiscardRequest,
     LayoutEditSaveRequest,
+    OperationAckStepRenderedRequest,
+    OperationIdRequest,
+    OperationStartFlowRequest,
+    OperationStartStepRequest,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
@@ -95,6 +99,36 @@ RUNTIME_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="flow.run_step",
         request_model=FlowRunStepRequest,
         handler_name="flow_run_step",
+    ),
+    RuntimeMethodSpec(
+        method_name="operation.start_flow",
+        request_model=OperationStartFlowRequest,
+        handler_name="start_flow_operation",
+    ),
+    RuntimeMethodSpec(
+        method_name="operation.start_step",
+        request_model=OperationStartStepRequest,
+        handler_name="start_step_operation",
+    ),
+    RuntimeMethodSpec(
+        method_name="operation.status",
+        request_model=OperationIdRequest,
+        handler_name="operation_status",
+    ),
+    RuntimeMethodSpec(
+        method_name="operation.cancel",
+        request_model=OperationIdRequest,
+        handler_name="cancel_operation",
+    ),
+    RuntimeMethodSpec(
+        method_name="operation.ack_step_rendered",
+        request_model=OperationAckStepRenderedRequest,
+        handler_name="acknowledge_step_rendered",
+    ),
+    RuntimeMethodSpec(
+        method_name="workspace.snapshot",
+        request_model=WorkspaceIdRequest,
+        handler_name="workspace_snapshot",
     ),
 )
 

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -1,0 +1,493 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_LOG_POLL_INTERVAL_SECONDS = 0.25
+_MAX_LOG_CHUNK_BYTES = 16 * 1024
+_MAX_FINAL_LOG_BYTES = 64 * 1024
+
+
+@dataclass
+class _StepLogTail:
+    """A bounded worker-side reader for one active step log."""
+
+    operation_id: str
+    path: Path
+    step: str
+    tool: str
+    cursor: int
+    stopped: threading.Event = field(default_factory=threading.Event)
+    thread: threading.Thread | None = None
+
+
+class RuntimeOperationConflict(RuntimeError):
+    """A workspace already owns a non-terminal runtime operation."""
+
+
+class RuntimeOperationCancelled(RuntimeError):
+    """Cancellation was accepted at a safe step boundary."""
+
+
+@dataclass
+class RuntimeOperation:
+    operation_id: str
+    workspace_id: str
+    kind: str
+    origin: str
+    rerun: bool
+    step: str = ""
+    idempotency_key: str = ""
+    state: str = "queued"
+    current_step: str = ""
+    current_tool: str = ""
+    error: dict[str, Any] | None = None
+    result: dict[str, Any] | None = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    sequence: int = 0
+    awaiting_event_id: str | None = None
+    acked_event_ids: set[str] = field(default_factory=set)
+    cancel_requested: bool = False
+    interruptibility: str = "deferred"
+
+
+class RuntimeOperationManager:
+    """Owns asynchronous GUI operations and their exactly-once event stream."""
+
+    def __init__(self, publisher: Callable[[dict[str, Any]], None] | None = None):
+        self._publisher = publisher
+        self._lock = threading.RLock()
+        self._render_gate = threading.Condition(self._lock)
+        self._operations: dict[str, RuntimeOperation] = {}
+        self._active_by_workspace: dict[str, str] = {}
+        self._idempotency: dict[tuple[str, str], str] = {}
+        self._step_log_tails: dict[str, _StepLogTail] = {}
+        self._next_operation_id = 1
+        self._workspace_sequences: dict[str, int] = {}
+
+    def set_publisher(self, publisher: Callable[[dict[str, Any]], None] | None) -> None:
+        with self._lock:
+            self._publisher = publisher
+
+    def start(
+        self,
+        *,
+        workspace_id: str,
+        kind: str,
+        origin: str,
+        rerun: bool,
+        step: str,
+        idempotency_key: str,
+        runner: Callable[[RuntimeFlowObserver], dict[str, Any]],
+    ) -> dict[str, Any]:
+        with self._lock:
+            if idempotency_key:
+                known_id = self._idempotency.get((workspace_id, idempotency_key))
+                if known_id is not None:
+                    return {
+                        **self._operation_payload(self._operations[known_id]),
+                        "deduplicated": True,
+                    }
+
+            active_id = self._active_by_workspace.get(workspace_id)
+            if active_id is not None:
+                active = self._operations[active_id]
+                raise RuntimeOperationConflict(
+                    f"workspace already has an active operation: {active.operation_id}"
+                )
+
+            operation = RuntimeOperation(
+                operation_id=f"operation-{self._next_operation_id}",
+                workspace_id=workspace_id,
+                kind=kind,
+                origin=origin,
+                rerun=rerun,
+                step=step,
+                idempotency_key=idempotency_key,
+            )
+            self._next_operation_id += 1
+            self._operations[operation.operation_id] = operation
+            self._active_by_workspace[workspace_id] = operation.operation_id
+            if idempotency_key:
+                self._idempotency[(workspace_id, idempotency_key)] = operation.operation_id
+            queued_event = self._new_event_locked(operation, "operation.queued", {})
+
+        self._publish(queued_event)
+        thread = threading.Thread(
+            target=self._run,
+            args=(operation.operation_id, runner),
+            name=f"ecc-runtime-{operation.operation_id}",
+            daemon=True,
+        )
+        thread.start()
+        return self.operation_status(operation.operation_id)
+
+    def operation_status(self, operation_id: str) -> dict[str, Any]:
+        with self._lock:
+            operation = self._operations.get(operation_id)
+            if operation is None:
+                raise KeyError(operation_id)
+            return self._operation_payload(operation)
+
+    def workspace_snapshot(self, workspace_id: str) -> dict[str, Any]:
+        with self._lock:
+            operations = [
+                self._operation_payload(operation)
+                for operation in self._operations.values()
+                if operation.workspace_id == workspace_id
+            ]
+            return {
+                "workspaceId": workspace_id,
+                "lastEventId": f"{workspace_id}:{self._workspace_sequences.get(workspace_id, 0)}",
+                "operations": operations,
+            }
+
+    def acknowledge_step_rendered(self, operation_id: str, event_id: str) -> dict[str, Any]:
+        with self._render_gate:
+            operation = self._operations.get(operation_id)
+            if operation is None:
+                raise KeyError(operation_id)
+            if event_id in operation.acked_event_ids:
+                return {
+                    "accepted": True,
+                    "duplicate": True,
+                    "operationId": operation_id,
+                    "eventId": event_id,
+                }
+            if operation.awaiting_event_id != event_id:
+                return {
+                    "accepted": False,
+                    "duplicate": False,
+                    "operationId": operation_id,
+                    "eventId": event_id,
+                }
+            operation.acked_event_ids.add(event_id)
+            operation.awaiting_event_id = None
+            operation.updated_at = time.time()
+            self._render_gate.notify_all()
+            return {
+                "accepted": True,
+                "duplicate": False,
+                "operationId": operation_id,
+                "eventId": event_id,
+            }
+
+    def request_cancel(self, operation_id: str) -> dict[str, Any]:
+        with self._render_gate:
+            operation = self._operations.get(operation_id)
+            if operation is None:
+                raise KeyError(operation_id)
+            if operation.state in {"succeeded", "failed", "cancelled"}:
+                return {"accepted": False, "operationId": operation_id, "state": operation.state}
+            operation.cancel_requested = True
+            operation.updated_at = time.time()
+            event = self._new_event_locked(operation, "operation.cancel_requested", {})
+            self._render_gate.notify_all()
+        self._publish(event)
+        return {"accepted": True, "operationId": operation_id, "state": operation.state}
+
+    def shutdown_barrier(self) -> dict[str, Any] | None:
+        with self._lock:
+            for operation_id in self._active_by_workspace.values():
+                operation = self._operations[operation_id]
+                return {
+                    "operationId": operation.operation_id,
+                    "workspaceId": operation.workspace_id,
+                    "state": operation.state,
+                    "step": operation.current_step,
+                    "interruptibility": operation.interruptibility,
+                    "safeToStop": bool(operation.awaiting_event_id),
+                    "cancelRequested": operation.cancel_requested,
+                }
+        return None
+
+    def _run(
+        self,
+        operation_id: str,
+        runner: Callable[[RuntimeFlowObserver], dict[str, Any]],
+    ) -> None:
+        with self._lock:
+            operation = self._operations[operation_id]
+            operation.state = "running"
+            operation.updated_at = time.time()
+            started_event = self._new_event_locked(operation, "operation.started", {})
+        self._publish(started_event)
+
+        observer = RuntimeFlowObserver(self, operation_id)
+        try:
+            result = runner(observer)
+            with self._lock:
+                operation = self._operations[operation_id]
+                if operation.cancel_requested:
+                    raise RuntimeOperationCancelled("operation cancelled at a step boundary")
+                operation.state = "succeeded"
+                operation.result = result
+                operation.updated_at = time.time()
+                event = self._new_event_locked(operation, "operation.completed", {"result": result})
+        except RuntimeOperationCancelled as exc:
+            with self._lock:
+                operation = self._operations[operation_id]
+                operation.state = "cancelled"
+                operation.error = {"message": str(exc), "code": "cancelled"}
+                operation.updated_at = time.time()
+                event = self._new_event_locked(
+                    operation, "operation.cancelled", {"error": operation.error}
+                )
+        except Exception as exc:
+            with self._lock:
+                operation = self._operations[operation_id]
+                if operation.cancel_requested:
+                    operation.state = "cancelled"
+                    operation.error = {"message": str(exc), "code": "cancelled"}
+                    event_type = "operation.cancelled"
+                else:
+                    operation.state = "failed"
+                    operation.error = {"message": str(exc), "code": "command_failed"}
+                    event_type = "operation.failed"
+                operation.updated_at = time.time()
+                event = self._new_event_locked(operation, event_type, {"error": operation.error})
+        self._publish(event)
+        self._stop_step_log_tail(operation_id)
+        with self._lock:
+            self._active_by_workspace.pop(self._operations[operation_id].workspace_id, None)
+
+    def step_started(self, operation_id: str, workspace_step: Any) -> None:
+        self._stop_step_log_tail(operation_id)
+        with self._lock:
+            operation = self._operations[operation_id]
+            operation.current_step = str(getattr(workspace_step, "name", ""))
+            operation.current_tool = str(getattr(workspace_step, "tool", ""))
+            operation.updated_at = time.time()
+            event = self._new_event_locked(
+                operation,
+                "step.started",
+                {
+                    "step": operation.current_step,
+                    "tool": operation.current_tool,
+                    "state": "Ongoing",
+                },
+            )
+            log_tail = _step_log_tail_for(
+                operation_id,
+                getattr(workspace_step, "log", None),
+                operation.current_step,
+                operation.current_tool,
+            )
+            if log_tail is not None:
+                self._step_log_tails[operation_id] = log_tail
+        self._publish(event)
+        if log_tail is not None:
+            thread = threading.Thread(
+                target=self._tail_step_log,
+                args=(log_tail,),
+                name=f"ecc-runtime-log-{operation_id}",
+                daemon=True,
+            )
+            log_tail.thread = thread
+            thread.start()
+
+    def step_completed(self, operation_id: str, workspace_step: Any, state: Any) -> None:
+        self._stop_step_log_tail(operation_id)
+        state_value = str(getattr(state, "value", state))
+        final_log = _read_final_log(getattr(workspace_step, "log", None))
+        with self._render_gate:
+            operation = self._operations[operation_id]
+            operation.current_step = str(getattr(workspace_step, "name", ""))
+            operation.current_tool = str(getattr(workspace_step, "tool", ""))
+            operation.updated_at = time.time()
+            payload: dict[str, Any] = {
+                "finalLog": final_log,
+                "step": operation.current_step,
+                "tool": operation.current_tool,
+                "state": state_value,
+            }
+            event = self._new_event_locked(operation, "step.completed", payload)
+            if state_value == "Success":
+                operation.awaiting_event_id = event["eventId"]
+        self._publish(event)
+
+    def step_skipped(self, operation_id: str, workspace_step: Any) -> None:
+        self._stop_step_log_tail(operation_id)
+        with self._lock:
+            operation = self._operations[operation_id]
+            operation.current_step = str(getattr(workspace_step, "name", ""))
+            operation.current_tool = str(getattr(workspace_step, "tool", ""))
+            operation.updated_at = time.time()
+            event = self._new_event_locked(
+                operation,
+                "step.completed",
+                {
+                    "step": operation.current_step,
+                    "tool": operation.current_tool,
+                    "state": "Skipped",
+                },
+            )
+        self._publish(event)
+
+    def wait_for_step_rendered(self, operation_id: str) -> bool:
+        with self._render_gate:
+            operation = self._operations[operation_id]
+            while operation.awaiting_event_id and not operation.cancel_requested:
+                self._render_gate.wait(timeout=1.0)
+            return not operation.cancel_requested
+
+    def _tail_step_log(self, log_tail: _StepLogTail) -> None:
+        while not log_tail.stopped.is_set():
+            self._publish_step_log_delta(log_tail)
+            log_tail.stopped.wait(_LOG_POLL_INTERVAL_SECONDS)
+
+    def _publish_step_log_delta(self, log_tail: _StepLogTail) -> None:
+        try:
+            size = log_tail.path.stat().st_size
+            if size < log_tail.cursor:
+                # A rerun may truncate or replace a log file. The renderer treats
+                # this as a new bounded stream for the same step attempt.
+                log_tail.cursor = 0
+            if size <= log_tail.cursor:
+                return
+            with log_tail.path.open("rb") as log_file:
+                log_file.seek(log_tail.cursor)
+                chunk = log_file.read(_MAX_LOG_CHUNK_BYTES)
+        except OSError:
+            return
+
+        if not chunk:
+            return
+        log_tail.cursor += len(chunk)
+        text = chunk.decode("utf-8", errors="replace")
+        with self._lock:
+            if self._step_log_tails.get(log_tail.operation_id) is not log_tail:
+                return
+            operation = self._operations.get(log_tail.operation_id)
+            if operation is None:
+                return
+            event = self._new_event_locked(
+                operation,
+                "step.log",
+                {
+                    "chunk": text,
+                    "cursor": log_tail.cursor,
+                    "step": log_tail.step,
+                    "tool": log_tail.tool,
+                },
+            )
+        self._publish(event)
+
+    def _stop_step_log_tail(self, operation_id: str) -> None:
+        with self._lock:
+            log_tail = self._step_log_tails.pop(operation_id, None)
+        if log_tail is None:
+            return
+        log_tail.stopped.set()
+        if log_tail.thread is not None and log_tail.thread is not threading.current_thread():
+            log_tail.thread.join(timeout=_LOG_POLL_INTERVAL_SECONDS + 0.25)
+
+    def _new_event_locked(
+        self,
+        operation: RuntimeOperation,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        sequence = self._workspace_sequences.get(operation.workspace_id, 0) + 1
+        self._workspace_sequences[operation.workspace_id] = sequence
+        operation.sequence = sequence
+        return {
+            "eventId": f"{operation.workspace_id}:{sequence}",
+            "sequence": sequence,
+            "type": event_type,
+            "workspaceId": operation.workspace_id,
+            "operationId": operation.operation_id,
+            "origin": operation.origin,
+            "kind": operation.kind,
+            "rerun": operation.rerun,
+            "timestamp": time.time(),
+            "payload": payload,
+        }
+
+    @staticmethod
+    def _operation_payload(operation: RuntimeOperation) -> dict[str, Any]:
+        return {
+            "operationId": operation.operation_id,
+            "workspaceId": operation.workspace_id,
+            "kind": operation.kind,
+            "origin": operation.origin,
+            "rerun": operation.rerun,
+            "step": operation.step,
+            "state": operation.state,
+            "currentStep": operation.current_step,
+            "currentTool": operation.current_tool,
+            "error": operation.error,
+            "result": operation.result,
+            "awaitingEventId": operation.awaiting_event_id,
+            "cancelRequested": operation.cancel_requested,
+            "interruptibility": operation.interruptibility,
+            "safeToStop": bool(operation.awaiting_event_id),
+            "shutdownBarrier": operation.state not in {"succeeded", "failed", "cancelled"},
+            "createdAt": operation.created_at,
+            "updatedAt": operation.updated_at,
+        }
+
+    def _publish(self, event: dict[str, Any]) -> None:
+        publisher = self._publisher
+        if publisher is not None:
+            publisher(event)
+
+
+class RuntimeFlowObserver:
+    def __init__(self, manager: RuntimeOperationManager, operation_id: str):
+        self._manager = manager
+        self._operation_id = operation_id
+
+    def on_step_started(self, workspace_step: Any) -> None:
+        self._manager.step_started(self._operation_id, workspace_step)
+
+    def on_step_completed(self, workspace_step: Any, state: Any) -> None:
+        self._manager.step_completed(self._operation_id, workspace_step, state)
+
+    def on_step_skipped(self, workspace_step: Any) -> None:
+        self._manager.step_skipped(self._operation_id, workspace_step)
+
+    def wait_for_step_rendered(self, _workspace_step: Any, _state: Any) -> bool:
+        return self._manager.wait_for_step_rendered(self._operation_id)
+
+
+def _read_final_log(log: Any) -> str:
+    path = getattr(log, "file", None)
+    if not path:
+        return ""
+    try:
+        with Path(path).open("rb") as log_file:
+            log_file.seek(0, 2)
+            size = log_file.tell()
+            log_file.seek(max(0, size - _MAX_FINAL_LOG_BYTES))
+            return log_file.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _step_log_tail_for(
+    operation_id: str,
+    log: Any,
+    step: str,
+    tool: str,
+) -> _StepLogTail | None:
+    path = getattr(log, "file", None)
+    if not path:
+        return None
+    log_path = Path(path)
+    try:
+        cursor = log_path.stat().st_size
+    except OSError:
+        cursor = 0
+    return _StepLogTail(
+        operation_id=operation_id,
+        path=log_path,
+        step=step,
+        tool=tool,
+        cursor=cursor,
+    )

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -380,9 +380,7 @@ class RuntimeOperationManager:
             event = self._new_event_locked(operation, "step.completed", payload)
             if state_value == "Success":
                 operation.workspace_revision += 1
-                step_commit_id = (
-                    f"{operation.operation_id}:step:{operation.workspace_revision}"
-                )
+                step_commit_id = f"{operation.operation_id}:step:{operation.workspace_revision}"
                 payload["stepCommitId"] = step_commit_id
                 payload["workspaceRevision"] = operation.workspace_revision
                 operation.awaiting_event_id = event["eventId"]

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 _LOG_POLL_INTERVAL_SECONDS = 0.25
 _MAX_LOG_CHUNK_BYTES = 16 * 1024
@@ -36,13 +37,11 @@ class RuntimeOperationCancelled(RuntimeError):
     """Cancellation was accepted at a safe step boundary."""
 
 
-class RuntimeOperationRenderSyncTimeout(RuntimeError):
-    """The GUI did not confirm a committed step within the recovery window."""
-
-
 @dataclass
 class RuntimeOperation:
     operation_id: str
+    run_session_id: str
+    runtime_instance_id: str
     workspace_id: str
     kind: str
     origin: str
@@ -65,6 +64,7 @@ class RuntimeOperation:
     render_retry_count: int = 0
     render_wait_started_at: float | None = None
     last_render_ack_at: float | None = None
+    render_sync_degraded: bool = False
     acked_event_ids: set[str] = field(default_factory=set)
     cancel_requested: bool = False
     interruptibility: str = "deferred"
@@ -81,7 +81,7 @@ class RuntimeOperationManager:
         self._active_by_workspace: dict[str, str] = {}
         self._idempotency: dict[tuple[str, str], str] = {}
         self._step_log_tails: dict[str, _StepLogTail] = {}
-        self._next_operation_id = 1
+        self._runtime_instance_id = uuid4().hex
         self._workspace_sequences: dict[str, int] = {}
 
     def set_publisher(self, publisher: Callable[[dict[str, Any]], None] | None) -> None:
@@ -116,7 +116,9 @@ class RuntimeOperationManager:
                 )
 
             operation = RuntimeOperation(
-                operation_id=f"operation-{self._next_operation_id}",
+                operation_id=f"operation-{uuid4().hex}",
+                run_session_id=uuid4().hex,
+                runtime_instance_id=self._runtime_instance_id,
                 workspace_id=workspace_id,
                 kind=kind,
                 origin=origin,
@@ -124,7 +126,6 @@ class RuntimeOperationManager:
                 step=step,
                 idempotency_key=idempotency_key,
             )
-            self._next_operation_id += 1
             self._operations[operation.operation_id] = operation
             self._active_by_workspace[workspace_id] = operation.operation_id
             if idempotency_key:
@@ -157,7 +158,11 @@ class RuntimeOperationManager:
             ]
             return {
                 "workspaceId": workspace_id,
-                "lastEventId": f"{workspace_id}:{self._workspace_sequences.get(workspace_id, 0)}",
+                "runtimeInstanceId": self._runtime_instance_id,
+                "lastEventId": (
+                    f"{self._runtime_instance_id}:{workspace_id}:"
+                    f"{self._workspace_sequences.get(workspace_id, 0)}"
+                ),
                 "operations": operations,
             }
 
@@ -271,19 +276,18 @@ class RuntimeOperationManager:
                 operation.result = result
                 operation.updated_at = time.time()
                 event = self._new_event_locked(operation, "operation.completed", {"result": result})
-        except (RuntimeOperationCancelled, RuntimeOperationRenderSyncTimeout) as exc:
+        except RuntimeOperationCancelled as exc:
             with self._lock:
                 operation = self._operations[operation_id]
-                is_timeout = isinstance(exc, RuntimeOperationRenderSyncTimeout)
-                operation.state = "failed" if is_timeout else "cancelled"
+                operation.state = "cancelled"
                 operation.error = {
                     "message": str(exc),
-                    "code": "gui_sync_timeout" if is_timeout else "cancelled",
+                    "code": "cancelled",
                 }
                 operation.updated_at = time.time()
                 event = self._new_event_locked(
                     operation,
-                    "operation.failed" if is_timeout else "operation.cancelled",
+                    "operation.cancelled",
                     {"error": operation.error},
                 )
         except Exception as exc:
@@ -383,13 +387,14 @@ class RuntimeOperationManager:
                 step_commit_id = f"{operation.operation_id}:step:{operation.workspace_revision}"
                 payload["stepCommitId"] = step_commit_id
                 payload["workspaceRevision"] = operation.workspace_revision
-                operation.awaiting_event_id = event["eventId"]
-                operation.awaiting_event = event
-                operation.awaiting_step_commit_id = step_commit_id
-                operation.render_sync_state = "waiting_for_gui_sync"
-                operation.render_retry_count = 0
-                operation.render_wait_started_at = time.monotonic()
-                operation.state = "waiting_for_gui_sync"
+                if not operation.render_sync_degraded:
+                    operation.awaiting_event_id = event["eventId"]
+                    operation.awaiting_event = event
+                    operation.awaiting_step_commit_id = step_commit_id
+                    operation.render_sync_state = "waiting_for_gui_sync"
+                    operation.render_retry_count = 0
+                    operation.render_wait_started_at = time.monotonic()
+                    operation.state = "waiting_for_gui_sync"
         self._publish(event)
 
     def step_skipped(self, operation_id: str, workspace_step: Any) -> None:
@@ -412,6 +417,7 @@ class RuntimeOperationManager:
 
     def wait_for_step_rendered(self, operation_id: str) -> bool:
         while True:
+            degraded_event: dict[str, Any] | None = None
             replay_event: dict[str, Any] | None = None
             pause_event: dict[str, Any] | None = None
             with self._render_gate:
@@ -430,17 +436,25 @@ class RuntimeOperationManager:
                 started_at = operation.render_wait_started_at or time.monotonic()
                 elapsed = time.monotonic() - started_at
                 if elapsed >= _RENDER_ACK_ABORT_SECONDS:
+                    awaiting_event_id = operation.awaiting_event_id
+                    awaiting_step_commit_id = operation.awaiting_step_commit_id
                     operation.awaiting_event_id = None
                     operation.awaiting_event = None
                     operation.awaiting_step_commit_id = None
-                    operation.render_sync_state = "timed_out"
-                    operation.state = "failed"
+                    operation.render_sync_state = "gui_sync_degraded"
+                    operation.render_sync_degraded = True
+                    operation.state = "running"
                     operation.updated_at = time.time()
-                    raise RuntimeOperationRenderSyncTimeout(
-                        "GUI did not confirm the committed step before the render-sync timeout"
+                    degraded_event = self._new_event_locked(
+                        operation,
+                        "operation.gui_sync_degraded",
+                        {
+                            "eventId": awaiting_event_id,
+                            "stepCommitId": awaiting_step_commit_id,
+                            "workspaceRevision": operation.workspace_revision,
+                        },
                     )
-
-                if (
+                elif (
                     elapsed >= _RENDER_ACK_PAUSE_SECONDS
                     and operation.render_sync_state != "paused_for_gui_recovery"
                 ):
@@ -457,18 +471,22 @@ class RuntimeOperationManager:
                         },
                     )
 
-                operation.render_retry_count += 1
-                if operation.awaiting_event is not None:
-                    replay_event = {
-                        **operation.awaiting_event,
-                        "payload": {
-                            **operation.awaiting_event["payload"],
-                            "replayed": True,
-                            "retryCount": operation.render_retry_count,
-                        },
-                    }
-                self._render_gate.wait(timeout=_RENDER_ACK_RETRY_SECONDS)
+                if degraded_event is None:
+                    operation.render_retry_count += 1
+                    if operation.awaiting_event is not None:
+                        replay_event = {
+                            **operation.awaiting_event,
+                            "payload": {
+                                **operation.awaiting_event["payload"],
+                                "replayed": True,
+                                "retryCount": operation.render_retry_count,
+                            },
+                        }
+                    self._render_gate.wait(timeout=_RENDER_ACK_RETRY_SECONDS)
 
+            if degraded_event is not None:
+                self._publish(degraded_event)
+                return True
             if pause_event is not None:
                 self._publish(pause_event)
             if replay_event is not None:
@@ -535,7 +553,9 @@ class RuntimeOperationManager:
         self._workspace_sequences[operation.workspace_id] = sequence
         operation.sequence = sequence
         return {
-            "eventId": f"{operation.workspace_id}:{sequence}",
+            "eventId": f"{self._runtime_instance_id}:{operation.operation_id}:{sequence}",
+            "runtimeInstanceId": self._runtime_instance_id,
+            "runSessionId": operation.run_session_id,
             "sequence": sequence,
             "type": event_type,
             "workspaceId": operation.workspace_id,
@@ -551,6 +571,8 @@ class RuntimeOperationManager:
     def _operation_payload(operation: RuntimeOperation) -> dict[str, Any]:
         return {
             "operationId": operation.operation_id,
+            "runSessionId": operation.run_session_id,
+            "runtimeInstanceId": operation.runtime_instance_id,
             "workspaceId": operation.workspace_id,
             "kind": operation.kind,
             "origin": operation.origin,

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -10,6 +10,9 @@ from typing import Any
 _LOG_POLL_INTERVAL_SECONDS = 0.25
 _MAX_LOG_CHUNK_BYTES = 16 * 1024
 _MAX_FINAL_LOG_BYTES = 64 * 1024
+_RENDER_ACK_RETRY_SECONDS = 5.0
+_RENDER_ACK_PAUSE_SECONDS = 30.0
+_RENDER_ACK_ABORT_SECONDS = 300.0
 
 
 @dataclass
@@ -33,6 +36,10 @@ class RuntimeOperationCancelled(RuntimeError):
     """Cancellation was accepted at a safe step boundary."""
 
 
+class RuntimeOperationRenderSyncTimeout(RuntimeError):
+    """The GUI did not confirm a committed step within the recovery window."""
+
+
 @dataclass
 class RuntimeOperation:
     operation_id: str
@@ -51,6 +58,13 @@ class RuntimeOperation:
     updated_at: float = field(default_factory=time.time)
     sequence: int = 0
     awaiting_event_id: str | None = None
+    awaiting_event: dict[str, Any] | None = None
+    awaiting_step_commit_id: str | None = None
+    workspace_revision: int = 0
+    render_sync_state: str = "idle"
+    render_retry_count: int = 0
+    render_wait_started_at: float | None = None
+    last_render_ack_at: float | None = None
     acked_event_ids: set[str] = field(default_factory=set)
     cancel_requested: bool = False
     interruptibility: str = "deferred"
@@ -147,7 +161,13 @@ class RuntimeOperationManager:
                 "operations": operations,
             }
 
-    def acknowledge_step_rendered(self, operation_id: str, event_id: str) -> dict[str, Any]:
+    def acknowledge_step_rendered(
+        self,
+        operation_id: str,
+        event_id: str,
+        step_commit_id: str = "",
+        workspace_revision: int | None = None,
+    ) -> dict[str, Any]:
         with self._render_gate:
             operation = self._operations.get(operation_id)
             if operation is None:
@@ -166,8 +186,30 @@ class RuntimeOperationManager:
                     "operationId": operation_id,
                     "eventId": event_id,
                 }
+            if step_commit_id and operation.awaiting_step_commit_id != step_commit_id:
+                return {
+                    "accepted": False,
+                    "duplicate": False,
+                    "operationId": operation_id,
+                    "eventId": event_id,
+                }
+            if (
+                workspace_revision is not None
+                and workspace_revision != operation.workspace_revision
+            ):
+                return {
+                    "accepted": False,
+                    "duplicate": False,
+                    "operationId": operation_id,
+                    "eventId": event_id,
+                }
             operation.acked_event_ids.add(event_id)
             operation.awaiting_event_id = None
+            operation.awaiting_event = None
+            operation.awaiting_step_commit_id = None
+            operation.render_sync_state = "idle"
+            operation.render_wait_started_at = None
+            operation.last_render_ack_at = time.time()
             operation.updated_at = time.time()
             self._render_gate.notify_all()
             return {
@@ -229,14 +271,20 @@ class RuntimeOperationManager:
                 operation.result = result
                 operation.updated_at = time.time()
                 event = self._new_event_locked(operation, "operation.completed", {"result": result})
-        except RuntimeOperationCancelled as exc:
+        except (RuntimeOperationCancelled, RuntimeOperationRenderSyncTimeout) as exc:
             with self._lock:
                 operation = self._operations[operation_id]
-                operation.state = "cancelled"
-                operation.error = {"message": str(exc), "code": "cancelled"}
+                is_timeout = isinstance(exc, RuntimeOperationRenderSyncTimeout)
+                operation.state = "failed" if is_timeout else "cancelled"
+                operation.error = {
+                    "message": str(exc),
+                    "code": "gui_sync_timeout" if is_timeout else "cancelled",
+                }
                 operation.updated_at = time.time()
                 event = self._new_event_locked(
-                    operation, "operation.cancelled", {"error": operation.error}
+                    operation,
+                    "operation.failed" if is_timeout else "operation.cancelled",
+                    {"error": operation.error},
                 )
         except Exception as exc:
             with self._lock:
@@ -308,7 +356,19 @@ class RuntimeOperationManager:
             }
             event = self._new_event_locked(operation, "step.completed", payload)
             if state_value == "Success":
+                operation.workspace_revision += 1
+                step_commit_id = (
+                    f"{operation.operation_id}:step:{operation.workspace_revision}"
+                )
+                payload["stepCommitId"] = step_commit_id
+                payload["workspaceRevision"] = operation.workspace_revision
                 operation.awaiting_event_id = event["eventId"]
+                operation.awaiting_event = event
+                operation.awaiting_step_commit_id = step_commit_id
+                operation.render_sync_state = "waiting_for_gui_sync"
+                operation.render_retry_count = 0
+                operation.render_wait_started_at = time.monotonic()
+                operation.state = "waiting_for_gui_sync"
         self._publish(event)
 
     def step_skipped(self, operation_id: str, workspace_step: Any) -> None:
@@ -330,11 +390,68 @@ class RuntimeOperationManager:
         self._publish(event)
 
     def wait_for_step_rendered(self, operation_id: str) -> bool:
-        with self._render_gate:
-            operation = self._operations[operation_id]
-            while operation.awaiting_event_id and not operation.cancel_requested:
-                self._render_gate.wait(timeout=1.0)
-            return not operation.cancel_requested
+        while True:
+            replay_event: dict[str, Any] | None = None
+            pause_event: dict[str, Any] | None = None
+            with self._render_gate:
+                operation = self._operations[operation_id]
+                if operation.cancel_requested:
+                    return False
+                if not operation.awaiting_event_id:
+                    if operation.state in {
+                        "waiting_for_gui_sync",
+                        "paused_for_gui_recovery",
+                    }:
+                        operation.state = "running"
+                        operation.updated_at = time.time()
+                    return True
+
+                started_at = operation.render_wait_started_at or time.monotonic()
+                elapsed = time.monotonic() - started_at
+                if elapsed >= _RENDER_ACK_ABORT_SECONDS:
+                    operation.awaiting_event_id = None
+                    operation.awaiting_event = None
+                    operation.awaiting_step_commit_id = None
+                    operation.render_sync_state = "timed_out"
+                    operation.state = "failed"
+                    operation.updated_at = time.time()
+                    raise RuntimeOperationRenderSyncTimeout(
+                        "GUI did not confirm the committed step before the render-sync timeout"
+                    )
+
+                if (
+                    elapsed >= _RENDER_ACK_PAUSE_SECONDS
+                    and operation.render_sync_state != "paused_for_gui_recovery"
+                ):
+                    operation.render_sync_state = "paused_for_gui_recovery"
+                    operation.state = "paused_for_gui_recovery"
+                    operation.updated_at = time.time()
+                    pause_event = self._new_event_locked(
+                        operation,
+                        "operation.gui_sync_paused",
+                        {
+                            "eventId": operation.awaiting_event_id,
+                            "stepCommitId": operation.awaiting_step_commit_id,
+                            "workspaceRevision": operation.workspace_revision,
+                        },
+                    )
+
+                operation.render_retry_count += 1
+                if operation.awaiting_event is not None:
+                    replay_event = {
+                        **operation.awaiting_event,
+                        "payload": {
+                            **operation.awaiting_event["payload"],
+                            "replayed": True,
+                            "retryCount": operation.render_retry_count,
+                        },
+                    }
+                self._render_gate.wait(timeout=_RENDER_ACK_RETRY_SECONDS)
+
+            if pause_event is not None:
+                self._publish(pause_event)
+            if replay_event is not None:
+                self._publish(replay_event)
 
     def _tail_step_log(self, log_tail: _StepLogTail) -> None:
         while not log_tail.stopped.is_set():
@@ -424,6 +541,11 @@ class RuntimeOperationManager:
             "error": operation.error,
             "result": operation.result,
             "awaitingEventId": operation.awaiting_event_id,
+            "awaitingStepCommitId": operation.awaiting_step_commit_id,
+            "workspaceRevision": operation.workspace_revision,
+            "renderSyncState": operation.render_sync_state,
+            "renderRetryCount": operation.render_retry_count,
+            "lastRenderAckAt": operation.last_render_ack_at,
             "cancelRequested": operation.cancel_requested,
             "interruptibility": operation.interruptibility,
             "safeToStop": bool(operation.awaiting_event_id),

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -339,6 +339,29 @@ class RuntimeOperationManager:
             log_tail.thread = thread
             thread.start()
 
+    def rerun_prepared(
+        self,
+        operation_id: str,
+        *,
+        affected_steps: list[str],
+        scope: str,
+        target_step: str = "",
+    ) -> None:
+        """Publish the idempotent GUI reset boundary before a rerun starts."""
+        with self._lock:
+            operation = self._operations[operation_id]
+            operation.updated_at = time.time()
+            event = self._new_event_locked(
+                operation,
+                "operation.rerun_prepared",
+                {
+                    "affectedSteps": affected_steps,
+                    "scope": scope,
+                    "targetStep": target_step,
+                },
+            )
+        self._publish(event)
+
     def step_completed(self, operation_id: str, workspace_step: Any, state: Any) -> None:
         self._stop_step_log_tail(operation_id)
         state_value = str(getattr(state, "value", state))
@@ -567,6 +590,20 @@ class RuntimeFlowObserver:
 
     def on_step_started(self, workspace_step: Any) -> None:
         self._manager.step_started(self._operation_id, workspace_step)
+
+    def on_rerun_prepared(
+        self,
+        *,
+        affected_steps: list[str],
+        scope: str,
+        target_step: str = "",
+    ) -> None:
+        self._manager.rerun_prepared(
+            self._operation_id,
+            affected_steps=affected_steps,
+            scope=scope,
+            target_step=target_step,
+        )
 
     def on_step_completed(self, workspace_step: Any, state: Any) -> None:
         self._manager.step_completed(self._operation_id, workspace_step, state)

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -97,6 +97,8 @@ class OperationIdRequest:
 class OperationAckStepRenderedRequest:
     operation_id: str
     event_id: str
+    step_commit_id: str = ""
+    workspace_revision: int | None = None
 
 
 @dataclass(frozen=True)
@@ -172,6 +174,8 @@ FIELD_ALIASES = {
     "workspaceId": "workspace_id",
     "operationId": "operation_id",
     "eventId": "event_id",
+    "stepCommitId": "step_commit_id",
+    "workspaceRevision": "workspace_revision",
     "idempotencyKey": "idempotency_key",
     "configPath": "config_path",
     "outputPath": "output_path",

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -215,9 +215,7 @@ def parse_request_model(model: type, params: object):
         if required and _is_missing(values[field.name]):
             raise RequestValidationError(f"missing required field: {field.name}")
 
-        if field.name in {"rerun", "reset_dependents"} and not isinstance(
-            values[field.name], bool
-        ):
+        if field.name in {"rerun", "reset_dependents"} and not isinstance(values[field.name], bool):
             raise RequestValidationError(f"{field.name} must be a boolean")
 
     return model(**values)

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -72,6 +72,34 @@ class FlowRunStepRequest:
 
 
 @dataclass(frozen=True)
+class OperationStartFlowRequest:
+    workspace_id: str
+    rerun: bool = False
+    origin: str = "gui"
+    idempotency_key: str = ""
+
+
+@dataclass(frozen=True)
+class OperationStartStepRequest:
+    workspace_id: str
+    step: str
+    rerun: bool = False
+    origin: str = "gui"
+    idempotency_key: str = ""
+
+
+@dataclass(frozen=True)
+class OperationIdRequest:
+    operation_id: str
+
+
+@dataclass(frozen=True)
+class OperationAckStepRenderedRequest:
+    operation_id: str
+    event_id: str
+
+
+@dataclass(frozen=True)
 class DbEnsureRequest:
     workspace_id: str
     step: str = ""
@@ -142,6 +170,9 @@ FIELD_ALIASES = {
     "paramJson": "parameters",
     "rtlList": "rtl_list",
     "workspaceId": "workspace_id",
+    "operationId": "operation_id",
+    "eventId": "event_id",
+    "idempotencyKey": "idempotency_key",
     "configPath": "config_path",
     "outputPath": "output_path",
     "infoId": "info_id",

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -84,6 +84,7 @@ class OperationStartStepRequest:
     workspace_id: str
     step: str
     rerun: bool = False
+    reset_dependents: bool = False
     origin: str = "gui"
     idempotency_key: str = ""
 
@@ -177,6 +178,7 @@ FIELD_ALIASES = {
     "stepCommitId": "step_commit_id",
     "workspaceRevision": "workspace_revision",
     "idempotencyKey": "idempotency_key",
+    "resetDependents": "reset_dependents",
     "configPath": "config_path",
     "outputPath": "output_path",
     "infoId": "info_id",
@@ -213,8 +215,10 @@ def parse_request_model(model: type, params: object):
         if required and _is_missing(values[field.name]):
             raise RequestValidationError(f"missing required field: {field.name}")
 
-        if field.name == "rerun" and not isinstance(values[field.name], bool):
-            raise RequestValidationError("rerun must be a boolean")
+        if field.name in {"rerun", "reset_dependents"} and not isinstance(
+            values[field.name], bool
+        ):
+            raise RequestValidationError(f"{field.name} must be a boolean")
 
     return model(**values)
 

--- a/chipcompiler/runtime/server.py
+++ b/chipcompiler/runtime/server.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from jsonrpcserver import Error
 
 import chipcompiler
@@ -13,6 +15,8 @@ BASE_CAPABILITIES = (
     "rpc.hello",
     "rpc.ping",
     "rpc.shutdown",
+    "runtime.v2",
+    "operation.events",
 )
 
 ERROR_CODES = {
@@ -33,6 +37,10 @@ class RuntimeServer:
         self.dispatcher = RpcDispatcher()
         self.api = api or WorkspaceRuntimeApi(persistent_db_enabled=persistent_db_enabled)
         self.should_exit = False
+        self._notification_sink: Callable[[str, dict], None] | None = None
+        set_event_publisher = getattr(self.api, "set_event_publisher", None)
+        if callable(set_event_publisher):
+            set_event_publisher(self._publish_runtime_event)
         self._register_base_methods()
         self._register_runtime_methods()
 
@@ -47,6 +55,14 @@ class RuntimeServer:
 
     def dispatch(self, payload: bytes | str) -> str:
         return self.dispatcher.dispatch(payload)
+
+    def set_notification_sink(self, sink: Callable[[str, dict], None] | None) -> None:
+        self._notification_sink = sink
+
+    def _publish_runtime_event(self, event: dict) -> None:
+        sink = self._notification_sink
+        if sink is not None:
+            sink("runtime.event", event)
 
     def _register_base_methods(self) -> None:
         self.dispatcher.add_method("rpc.hello", self._hello)
@@ -70,6 +86,11 @@ class RuntimeServer:
         return {"ok": True}
 
     def _shutdown(self) -> dict:
+        operations = getattr(self.api, "operations", None)
+        shutdown_barrier = getattr(operations, "shutdown_barrier", None)
+        barrier = shutdown_barrier() if callable(shutdown_barrier) else None
+        if barrier is not None:
+            return {"ok": False, "deferred": True, "shutdownBarrier": barrier}
         self.should_exit = True
         sessions = getattr(self.api, "sessions", None)
         if sessions is not None and hasattr(sessions, "close_all"):

--- a/chipcompiler/runtime/stdio_server.py
+++ b/chipcompiler/runtime/stdio_server.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import sys
 import os
 import queue
+import sys
 import threading
 from typing import BinaryIO
 
@@ -12,7 +12,6 @@ from chipcompiler.runtime.transport import (
     TransportError,
     encode_content_length_frame,
 )
-
 
 _STOP = object()
 

--- a/chipcompiler/runtime/stdio_server.py
+++ b/chipcompiler/runtime/stdio_server.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import sys
+import os
+import queue
+import threading
 from typing import BinaryIO
 
 from chipcompiler.runtime.server import RuntimeServer
@@ -9,6 +12,63 @@ from chipcompiler.runtime.transport import (
     TransportError,
     encode_content_length_frame,
 )
+
+
+_STOP = object()
+
+
+class _ProtocolWriter:
+    """Serialize protocol output through an fd immune to tool stdio redirects."""
+
+    def __init__(self, output_stream: BinaryIO):
+        self._output_stream = output_stream
+        self._output_fd: int | None = None
+        try:
+            self._output_fd = os.dup(output_stream.fileno())
+        except (AttributeError, OSError):
+            # BytesIO is used by unit tests and has no file descriptor.
+            self._output_fd = None
+        self._messages: queue.Queue[bytes | object] = queue.Queue()
+        self._thread = threading.Thread(target=self._write_loop, name="ecc-rpc-writer", daemon=True)
+        self._thread.start()
+
+    def send_response(self, response: str) -> None:
+        self._messages.put(encode_content_length_frame(response))
+
+    def send_notification(self, method: str, params: dict) -> None:
+        import json
+
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "method": method, "params": params},
+            separators=(",", ":"),
+        )
+        self._messages.put(encode_content_length_frame(payload))
+
+    def close(self) -> None:
+        self._messages.put(_STOP)
+        self._thread.join()
+        if self._output_fd is not None:
+            os.close(self._output_fd)
+            self._output_fd = None
+
+    def _write_loop(self) -> None:
+        while True:
+            message = self._messages.get()
+            if message is _STOP:
+                return
+            assert isinstance(message, bytes)
+            if self._output_fd is None:
+                self._output_stream.write(message)
+                self._output_stream.flush()
+                continue
+            _write_all(self._output_fd, message)
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        view = view[written:]
 
 
 def run_stdio_server(
@@ -20,29 +80,32 @@ def run_stdio_server(
 ) -> int:
     runtime_server = server or RuntimeServer(persistent_db_enabled=persistent_db_enabled)
     decoder = ContentLengthDecoder()
+    writer = _ProtocolWriter(output_stream)
+    runtime_server.set_notification_sink(writer.send_notification)
 
-    while not runtime_server.should_exit:
-        chunk = _read_chunk(input_stream)
-        if not chunk:
-            break
-        try:
-            messages = decoder.feed(chunk)
-        except TransportError as exc:
-            print(f"transport error: {exc}", file=sys.stderr)
-            return 1
-
-        for message in messages:
-            response = runtime_server.dispatch(message)
-            if runtime_server.should_exit and not response:
+    try:
+        while not runtime_server.should_exit:
+            chunk = _read_chunk(input_stream)
+            if not chunk:
                 break
-            if not response:
-                continue
-            output_stream.write(encode_content_length_frame(response))
-            output_stream.flush()
-            if runtime_server.should_exit:
-                break
+            try:
+                messages = decoder.feed(chunk)
+            except TransportError as exc:
+                print(f"transport error: {exc}", file=sys.stderr)
+                return 1
 
-    return 0
+            for message in messages:
+                response = runtime_server.dispatch(message)
+                if runtime_server.should_exit and not response:
+                    break
+                if response:
+                    writer.send_response(response)
+                if runtime_server.should_exit:
+                    break
+        return 0
+    finally:
+        runtime_server.set_notification_sink(None)
+        writer.close()
 
 
 def _read_chunk(input_stream: BinaryIO) -> bytes:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -25,6 +25,10 @@ from chipcompiler.runtime.requests import (
     LayoutEditBeginRequest,
     LayoutEditDiscardRequest,
     LayoutEditSaveRequest,
+    OperationAckStepRenderedRequest,
+    OperationIdRequest,
+    OperationStartFlowRequest,
+    OperationStartStepRequest,
     WorkspaceCreateRequest,
     WorkspaceExportSignoffRequest,
     WorkspaceIdRequest,
@@ -32,6 +36,10 @@ from chipcompiler.runtime.requests import (
     WorkspaceInspectSignoffRequest,
     WorkspaceOpenRequest,
     WorkspaceSyncConfigRequest,
+)
+from chipcompiler.runtime.operations import (
+    RuntimeOperationConflict,
+    RuntimeOperationManager,
 )
 from chipcompiler.runtime.sessions import (
     LayoutEditSession,
@@ -58,6 +66,7 @@ class WorkspaceRuntimeApi:
         sessions: WorkspaceSessionRegistry | None = None,
         *,
         persistent_db_enabled: bool = False,
+        event_publisher: Callable[[dict[str, Any]], None] | None = None,
     ):
         self.persistent_db_enabled = persistent_db_enabled
         self.sessions = sessions or WorkspaceSessionRegistry(db_releaser=_close_db_handle)
@@ -68,6 +77,10 @@ class WorkspaceRuntimeApi:
         # session is reset, so a second workspace cannot replace the store
         # underneath an active editor.
         self._layout_edit_lock = threading.RLock()
+        self.operations = RuntimeOperationManager(event_publisher)
+
+    def set_event_publisher(self, publisher: Callable[[dict[str, Any]], None] | None) -> None:
+        self.operations.set_publisher(publisher)
 
     def create_workspace(self, request: WorkspaceCreateRequest) -> dict:
         if not request.directory:
@@ -222,6 +235,9 @@ class WorkspaceRuntimeApi:
         return self._with_session_mutation_lock(request.workspace_id, close)
 
     def flow_run(self, request: FlowRunRequest) -> dict:
+        return self._flow_run(request)
+
+    def _flow_run(self, request: FlowRunRequest, *, observer=None) -> dict:
         def run(session: WorkspaceSession) -> dict:
             should_capture = self._should_capture_session_db(session)
             previous_db = session.db_handle if should_capture else None
@@ -236,7 +252,7 @@ class WorkspaceRuntimeApi:
             if request.rerun:
                 self._prepare_workspace_for_rerun(session.workspace, engine_flow)
             try:
-                ok = engine_flow.run_steps(rerun=request.rerun)
+                ok = _run_engine_flow_steps(engine_flow, rerun=request.rerun, observer=observer)
             finally:
                 if should_capture:
                     self._capture_flow_db(
@@ -257,6 +273,9 @@ class WorkspaceRuntimeApi:
         return self._with_session_mutation_lock(request.workspace_id, run)
 
     def flow_run_step(self, request: FlowRunStepRequest) -> dict:
+        return self._flow_run_step(request)
+
+    def _flow_run_step(self, request: FlowRunStepRequest, *, observer=None) -> dict:
         def run_step(session: WorkspaceSession) -> dict:
             should_capture = self._should_capture_session_db(session)
             previous_db = session.db_handle if should_capture else None
@@ -290,7 +309,12 @@ class WorkspaceRuntimeApi:
                 )
                 if not step_already_succeeded:
                     _init_db_engine_for_workspace_step(engine_flow, workspace_step)
-                state = engine_flow.run_step(workspace_step, rerun=request.rerun)
+                state = _run_engine_flow_step(
+                    engine_flow,
+                    workspace_step,
+                    rerun=request.rerun,
+                    observer=observer,
+                )
             finally:
                 if should_capture:
                     self._capture_flow_db(
@@ -312,6 +336,103 @@ class WorkspaceRuntimeApi:
             return result
 
         return self._with_session_mutation_lock(request.workspace_id, run_step)
+
+    def start_flow_operation(self, request: OperationStartFlowRequest) -> dict:
+        self._require_gui_operation_origin(request.origin)
+        self._get_session(request.workspace_id)
+        try:
+            return self.operations.start(
+                workspace_id=request.workspace_id,
+                kind="flow",
+                origin=request.origin,
+                rerun=request.rerun,
+                step="",
+                idempotency_key=request.idempotency_key,
+                runner=lambda observer: self._flow_run(
+                    FlowRunRequest(workspace_id=request.workspace_id, rerun=request.rerun),
+                    observer=observer,
+                ),
+            )
+        except RuntimeOperationConflict as exc:
+            raise RuntimeApiError("command_failed", str(exc)) from exc
+
+    def start_step_operation(self, request: OperationStartStepRequest) -> dict:
+        self._require_gui_operation_origin(request.origin)
+        self._get_session(request.workspace_id)
+        try:
+            return self.operations.start(
+                workspace_id=request.workspace_id,
+                kind="step",
+                origin=request.origin,
+                rerun=request.rerun,
+                step=request.step,
+                idempotency_key=request.idempotency_key,
+                runner=lambda observer: self._flow_run_step(
+                    FlowRunStepRequest(
+                        workspace_id=request.workspace_id,
+                        step=request.step,
+                        rerun=request.rerun,
+                    ),
+                    observer=observer,
+                ),
+            )
+        except RuntimeOperationConflict as exc:
+            raise RuntimeApiError("command_failed", str(exc)) from exc
+
+    def operation_status(self, request: OperationIdRequest) -> dict:
+        try:
+            return self.operations.operation_status(request.operation_id)
+        except KeyError as exc:
+            raise RuntimeApiError(
+                "invalid_request",
+                f"operation not found: {request.operation_id}",
+            ) from exc
+
+    def cancel_operation(self, request: OperationIdRequest) -> dict:
+        try:
+            return self.operations.request_cancel(request.operation_id)
+        except KeyError as exc:
+            raise RuntimeApiError(
+                "invalid_request",
+                f"operation not found: {request.operation_id}",
+            ) from exc
+
+    def acknowledge_step_rendered(self, request: OperationAckStepRenderedRequest) -> dict:
+        try:
+            return self.operations.acknowledge_step_rendered(
+                request.operation_id,
+                request.event_id,
+            )
+        except KeyError as exc:
+            raise RuntimeApiError(
+                "invalid_request",
+                f"operation not found: {request.operation_id}",
+            ) from exc
+
+    def workspace_snapshot(self, request: WorkspaceIdRequest) -> dict:
+        session = self._get_session(request.workspace_id)
+        flow_data = getattr(getattr(session.workspace, "flow", None), "data", {})
+        raw_steps = flow_data.get("steps", []) if isinstance(flow_data, dict) else []
+        steps = [
+            {
+                "name": str(step.get("name", "")),
+                "tool": str(step.get("tool", "")),
+                "state": str(step.get("state", "Unstart")),
+                "runtime": str(step.get("runtime", "")),
+                "peakMemory": step.get("peak memory (mb)", 0),
+            }
+            for step in raw_steps
+            if isinstance(step, dict)
+        ]
+        return {
+            **self.operations.workspace_snapshot(request.workspace_id),
+            "directory": str(session.directory),
+            "flow": {"steps": steps},
+            "home": stringify_paths(deepcopy(getattr(session.workspace.home, "data", {}))),
+            "parameters": stringify_paths(
+                deepcopy(getattr(session.workspace.parameters, "data", {}))
+            ),
+        }
 
     def db_ensure(self, request: DbEnsureRequest) -> dict:
         self._require_persistent_db()
@@ -623,6 +744,11 @@ class WorkspaceRuntimeApi:
     def _require_persistent_db(self) -> None:
         if not self.persistent_db_enabled:
             raise RuntimeApiError("command_failed", "persistent_db_disabled")
+
+    @staticmethod
+    def _require_gui_operation_origin(origin: str) -> None:
+        if origin != "gui":
+            raise RuntimeApiError("invalid_request", "operation origin must be gui")
 
     def _new_layout_edit_id(self) -> str:
         edit_session_id = f"layout-edit-{self._next_layout_edit_id}"
@@ -1911,3 +2037,28 @@ def _success_state():
 
 def _state_value(state: Any) -> str:
     return getattr(state, "value", str(state))
+
+
+def _run_engine_flow_steps(engine_flow, *, rerun: bool, observer) -> bool:
+    run_steps = engine_flow.run_steps
+    if observer is not None and _callable_accepts_keyword(run_steps, "observer"):
+        return run_steps(rerun=rerun, observer=observer)
+    return run_steps(rerun=rerun)
+
+
+def _run_engine_flow_step(engine_flow, workspace_step, *, rerun: bool, observer):
+    run_step = engine_flow.run_step
+    if observer is not None and _callable_accepts_keyword(run_step, "observer"):
+        return run_step(workspace_step, rerun=rerun, observer=observer)
+    return run_step(workspace_step, rerun=rerun)
+
+
+def _callable_accepts_keyword(callback, keyword: str) -> bool:
+    try:
+        parameters = inspect.signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == keyword or parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -237,7 +237,13 @@ class WorkspaceRuntimeApi:
     def flow_run(self, request: FlowRunRequest) -> dict:
         return self._flow_run(request)
 
-    def _flow_run(self, request: FlowRunRequest, *, observer=None) -> dict:
+    def _flow_run(
+        self,
+        request: FlowRunRequest,
+        *,
+        observer=None,
+        preserve_user_inputs: bool = False,
+    ) -> dict:
         def run(session: WorkspaceSession) -> dict:
             should_capture = self._should_capture_session_db(session)
             previous_db = session.db_handle if should_capture else None
@@ -251,7 +257,11 @@ class WorkspaceRuntimeApi:
             )
             if request.rerun:
                 affected_steps = list(getattr(engine_flow, "workspace_steps", []))
-                self._prepare_workspace_for_rerun(session.workspace, engine_flow)
+                self._prepare_workspace_for_rerun(
+                    session.workspace,
+                    engine_flow,
+                    preserve_user_inputs=preserve_user_inputs,
+                )
                 self._notify_rerun_prepared(
                     observer,
                     affected_steps,
@@ -378,6 +388,7 @@ class WorkspaceRuntimeApi:
                 runner=lambda observer: self._flow_run(
                     FlowRunRequest(workspace_id=request.workspace_id, rerun=request.rerun),
                     observer=observer,
+                    preserve_user_inputs=request.rerun,
                 ),
             )
         except RuntimeOperationConflict as exc:
@@ -868,10 +879,20 @@ class WorkspaceRuntimeApi:
 
         data_api.refresh_workspace_config(workspace)
 
-    def _prepare_workspace_for_rerun(self, workspace, engine_flow) -> None:
+    def _prepare_workspace_for_rerun(
+        self,
+        workspace,
+        engine_flow,
+        *,
+        preserve_user_inputs: bool = False,
+    ) -> None:
         import chipcompiler.data as data_api
 
-        data_api.prepare_workspace_for_rerun(workspace, engine_flow)
+        data_api.prepare_workspace_for_rerun(
+            workspace,
+            engine_flow,
+            preserve_user_inputs=preserve_user_inputs,
+        )
 
     @staticmethod
     def _rerun_affected_steps(engine_flow, workspace_step, *, reset_dependents: bool):

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -250,7 +250,13 @@ class WorkspaceRuntimeApi:
                 attach_session_db=should_capture and not request.rerun,
             )
             if request.rerun:
+                affected_steps = list(getattr(engine_flow, "workspace_steps", []))
                 self._prepare_workspace_for_rerun(session.workspace, engine_flow)
+                self._notify_rerun_prepared(
+                    observer,
+                    affected_steps,
+                    scope="flow",
+                )
             try:
                 ok = _run_engine_flow_steps(engine_flow, rerun=request.rerun, observer=observer)
             finally:
@@ -275,7 +281,13 @@ class WorkspaceRuntimeApi:
     def flow_run_step(self, request: FlowRunStepRequest) -> dict:
         return self._flow_run_step(request)
 
-    def _flow_run_step(self, request: FlowRunStepRequest, *, observer=None) -> dict:
+    def _flow_run_step(
+        self,
+        request: FlowRunStepRequest,
+        *,
+        observer=None,
+        reset_dependents: bool = False,
+    ) -> dict:
         def run_step(session: WorkspaceSession) -> dict:
             should_capture = self._should_capture_session_db(session)
             previous_db = session.db_handle if should_capture else None
@@ -299,7 +311,22 @@ class WorkspaceRuntimeApi:
             if workspace_step is None:
                 raise RuntimeApiError("command_failed", f"step not found: {request.step}")
             if request.rerun:
-                self._prepare_step_for_rerun(session.workspace, engine_flow, workspace_step)
+                affected_steps = self._rerun_affected_steps(
+                    engine_flow,
+                    workspace_step,
+                    reset_dependents=reset_dependents,
+                )
+                self._prepare_steps_for_rerun(
+                    session.workspace,
+                    engine_flow,
+                    affected_steps,
+                )
+                self._notify_rerun_prepared(
+                    observer,
+                    affected_steps,
+                    scope="step",
+                    target_step=workspace_step.name,
+                )
 
             try:
                 step_already_succeeded = not request.rerun and engine_flow.check_state(
@@ -374,6 +401,7 @@ class WorkspaceRuntimeApi:
                         rerun=request.rerun,
                     ),
                     observer=observer,
+                    reset_dependents=request.reset_dependents,
                 ),
             )
         except RuntimeOperationConflict as exc:
@@ -846,22 +874,97 @@ class WorkspaceRuntimeApi:
         data_api.prepare_workspace_for_rerun(workspace, engine_flow)
 
     @staticmethod
+    def _rerun_affected_steps(engine_flow, workspace_step, *, reset_dependents: bool):
+        if not reset_dependents:
+            return [workspace_step]
+        workspace_steps = list(getattr(engine_flow, "workspace_steps", []))
+        try:
+            start_index = workspace_steps.index(workspace_step)
+        except ValueError:
+            return [workspace_step]
+        return workspace_steps[start_index:]
+
+    @staticmethod
+    def _notify_rerun_prepared(
+        observer,
+        workspace_steps,
+        *,
+        scope: str,
+        target_step: str = "",
+    ) -> None:
+        callback = getattr(observer, "on_rerun_prepared", None)
+        if callback is None:
+            return
+        callback(
+            affected_steps=[str(getattr(step, "name", "")) for step in workspace_steps],
+            scope=scope,
+            target_step=target_step,
+        )
+
+    @staticmethod
     def _prepare_step_for_rerun(workspace, engine_flow, workspace_step) -> None:
+        WorkspaceRuntimeApi._prepare_steps_for_rerun(
+            workspace,
+            engine_flow,
+            [workspace_step],
+        )
+
+    @staticmethod
+    def _prepare_steps_for_rerun(workspace, engine_flow, workspace_steps) -> None:
         workspace_root = Path(workspace.directory).resolve()
-        for directory in WorkspaceRuntimeApi._step_artifact_dirs(workspace_step):
+        unique_steps = []
+        known_step_keys = set()
+        for workspace_step in workspace_steps:
+            key = (
+                str(getattr(workspace_step, "name", "")),
+                str(getattr(workspace_step, "tool", "")),
+            )
+            if key in known_step_keys:
+                continue
+            known_step_keys.add(key)
+            unique_steps.append(workspace_step)
+
+        artifact_directories = []
+        known_directories = set()
+        for workspace_step in unique_steps:
+            for directory in WorkspaceRuntimeApi._step_artifact_dirs(workspace_step):
+                resolved = WorkspaceRuntimeApi._validate_step_artifact_dir(
+                    workspace_root,
+                    directory,
+                    workspace_step.name,
+                )
+                if resolved in known_directories:
+                    continue
+                known_directories.add(resolved)
+                artifact_directories.append((workspace_step.name, directory))
+
+        for step_name, directory in artifact_directories:
             WorkspaceRuntimeApi._clear_step_artifact_dir(
                 workspace_root,
                 directory,
-                workspace_step.name,
+                step_name,
             )
 
-        record = engine_flow.get_step(workspace_step.name, workspace_step.tool)
-        if record is not None:
-            record.update({"state": "Unstart", "runtime": "", "peak memory (mb)": 0})
+        updated_record = False
+        for workspace_step in unique_steps:
+            record = engine_flow.get_step(workspace_step.name, workspace_step.tool)
+            if record is None:
+                continue
+            record.update(
+                {
+                    "state": "Unstart",
+                    "runtime": "",
+                    "peak memory (mb)": 0,
+                    "info": {},
+                }
+            )
+            updated_record = True
+        if updated_record:
             engine_flow.save()
 
-        WorkspaceRuntimeApi._reset_step_subflow(workspace_step)
-        WorkspaceRuntimeApi._reset_step_checklist(workspace_step)
+        for workspace_step in unique_steps:
+            WorkspaceRuntimeApi._reset_step_subflow(workspace_step)
+            WorkspaceRuntimeApi._reset_step_checklist(workspace_step)
 
     @staticmethod
     def _reset_step_subflow(workspace_step) -> None:
@@ -892,14 +995,14 @@ class WorkspaceRuntimeApi:
 
     @staticmethod
     def _reset_step_checklist(workspace_step) -> None:
-        from chipcompiler.utility import json_write
+        from chipcompiler.data import Checklist
 
         checklist = getattr(workspace_step, "checklist", None)
         path = getattr(checklist, "path", None)
         if not path:
             return
         checklist_path = Path(path)
-        json_write(checklist_path, {"path": str(checklist_path), "checklist": []})
+        Checklist(checklist_path).replace([])
         checklist.checklist = []
 
     @staticmethod
@@ -918,6 +1021,22 @@ class WorkspaceRuntimeApi:
         directory: Path,
         step_name: str,
     ) -> None:
+        WorkspaceRuntimeApi._validate_step_artifact_dir(workspace_root, directory, step_name)
+        if directory.exists():
+            if not directory.is_dir():
+                raise RuntimeApiError(
+                    "command_failed",
+                    f"step artifact is not a directory: {step_name}",
+                )
+            shutil.rmtree(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _validate_step_artifact_dir(
+        workspace_root: Path,
+        directory: Path,
+        step_name: str,
+    ) -> Path:
         resolved = directory.resolve()
         if (
             resolved == workspace_root
@@ -928,14 +1047,12 @@ class WorkspaceRuntimeApi:
                 "command_failed",
                 f"step artifact escapes workspace: {step_name}",
             )
-        if directory.exists():
-            if not directory.is_dir():
-                raise RuntimeApiError(
-                    "command_failed",
-                    f"step artifact is not a directory: {step_name}",
-                )
-            shutil.rmtree(directory)
-        directory.mkdir(parents=True, exist_ok=True)
+        if directory.exists() and not directory.is_dir():
+            raise RuntimeApiError(
+                "command_failed",
+                f"step artifact is not a directory: {step_name}",
+            )
+        return resolved
 
 
 def _layout_edit_begin_result(edit_session: LayoutEditSession, *, reused: bool) -> dict:

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -13,6 +13,10 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, TypeVar
 
+from chipcompiler.runtime.operations import (
+    RuntimeOperationConflict,
+    RuntimeOperationManager,
+)
 from chipcompiler.runtime.requests import (
     DbEnsureRequest,
     DbReleaseRequest,
@@ -36,10 +40,6 @@ from chipcompiler.runtime.requests import (
     WorkspaceInspectSignoffRequest,
     WorkspaceOpenRequest,
     WorkspaceSyncConfigRequest,
-)
-from chipcompiler.runtime.operations import (
-    RuntimeOperationConflict,
-    RuntimeOperationManager,
 )
 from chipcompiler.runtime.sessions import (
     LayoutEditSession,
@@ -402,6 +402,8 @@ class WorkspaceRuntimeApi:
             return self.operations.acknowledge_step_rendered(
                 request.operation_id,
                 request.event_id,
+                request.step_commit_id,
+                request.workspace_revision,
             )
         except KeyError as exc:
             raise RuntimeApiError(

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -450,7 +450,7 @@ def save_data(
                     f"({margin[0]} , {margin[1]}) "
                     f"({core_bounding_width + margin[0]} , {core_bounding_height + margin[1]})"
                 ),
-                "Utilitization": core_usage,
+                # "Utilitization": core_usage,
                 "Aspect ratio": aspect_ratio,
             },
         }

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -437,8 +437,6 @@ def save_data(
 
         margin = workspace.parameters.data.get("Core", {}).get("Margin", [0, 0])
 
-        core_usage = db_json.get("Design Layout", {}).get("core_usage", 0)
-
         aspect_ratio = die_bounding_width / die_bounding_height if die_bounding_height > 0 else 1
 
         update_param = {
@@ -450,7 +448,6 @@ def save_data(
                     f"({margin[0]} , {margin[1]}) "
                     f"({core_bounding_width + margin[0]} , {core_bounding_height + margin[1]})"
                 ),
-                # "Utilitization": core_usage,
                 "Aspect ratio": aspect_ratio,
             },
         }

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -1003,6 +1003,28 @@ def test_prepare_workspace_for_rerun_deletes_old_artifacts_and_resets_home_state
     assert engine_flow.clear_calls == 1
     assert engine_flow.create_calls == 1
 
+    parameter_path = workspace_dir / "home" / "parameters.json"
+    preserved_parameters = json_read(parameter_path)
+    preserved_parameters["Die"] = {"Size": [120.0, 80.0], "Area": 9600.0}
+    preserved_parameters["Core"] = {
+        **preserved_parameters["Core"],
+        "Size": [100.0, 60.0],
+        "Area": 6000.0,
+        "Bounding box": "0 0 100 60",
+    }
+    json_write(parameter_path, preserved_parameters)
+    workspace.parameters.data = preserved_parameters
+    preserved_parameter_text = parameter_path.read_text()
+
+    prepare_workspace_for_rerun(
+        workspace,
+        FakeEngineFlow(),
+        preserve_user_inputs=True,
+    )
+
+    assert parameter_path.read_text() == preserved_parameter_text
+    assert (workspace_dir / "config" / "flow_config.json").read_text() == config_before
+
 
 def test_create_workspace_sg13g2_persists_pdk_root_in_parameters(
     tmp_path, minimal_sg13g2_pdk_factory, default_sg13g2_parameters

--- a/test/engine/test_db.py
+++ b/test/engine/test_db.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+from chipcompiler.data import StepEnum
 from chipcompiler.engine.db import EngineDB
 
 
@@ -33,3 +36,47 @@ def test_engine_db_close_is_idempotent():
 
     assert ecc_module.calls == ["close"]
     assert engine_db.ecc_module is None
+
+
+class FakeLogger:
+    def __init__(self):
+        self.info_messages = []
+        self.warning_messages = []
+
+    def info(self, message):
+        self.info_messages.append(message)
+
+    def warning(self, message):
+        self.warning_messages.append(message)
+
+
+def test_engine_db_skips_synthesis_without_a_failure_warning(monkeypatch):
+    logger = FakeLogger()
+    workspace = SimpleNamespace(logger=logger)
+    db_engine = EngineDB(workspace=workspace)
+    create_calls = []
+
+    monkeypatch.setattr("chipcompiler.tools.load_eda_module", lambda _name: object())
+    monkeypatch.setattr(
+        "chipcompiler.tools.ecc.create_db_engine",
+        lambda *_args: create_calls.append(True),
+    )
+
+    assert db_engine.create_db_engine(SimpleNamespace(name=StepEnum.SYNTHESIS.value)) is False
+    assert create_calls == []
+    assert logger.warning_messages == []
+
+
+def test_engine_db_warns_when_a_physical_step_cannot_initialize(monkeypatch):
+    logger = FakeLogger()
+    workspace = SimpleNamespace(logger=logger)
+    db_engine = EngineDB(workspace=workspace)
+
+    monkeypatch.setattr("chipcompiler.tools.load_eda_module", lambda _name: object())
+    monkeypatch.setattr("chipcompiler.tools.ecc.create_db_engine", lambda *_args: None)
+
+    step = SimpleNamespace(name=StepEnum.FLOORPLAN.value)
+    assert db_engine.create_db_engine(step) is False
+    assert logger.warning_messages == [
+        f"ecc db initialize failed for step {StepEnum.FLOORPLAN.value}."
+    ]

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -28,6 +28,12 @@ def test_runtime_method_registry_contains_current_methods_once():
         "workspace.inspect_signoff",
         "flow.run",
         "flow.run_step",
+        "operation.start_flow",
+        "operation.start_step",
+        "operation.status",
+        "operation.cancel",
+        "operation.ack_step_rendered",
+        "workspace.snapshot",
     )
 
     assert runtime_method_names() == expected_methods

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -2,6 +2,7 @@ import threading
 from types import SimpleNamespace
 
 from chipcompiler.data import StateEnum
+from chipcompiler.runtime import operations
 from chipcompiler.runtime.operations import RuntimeOperationManager
 
 
@@ -30,14 +31,24 @@ def test_successful_step_waits_for_matching_render_ack_before_completing():
         runner=runner,
     )
 
-    assert started["state"] in {"queued", "running"}
+    assert started["state"] in {"queued", "running", "waiting_for_gui_sync"}
     assert entered_render_gate.wait(timeout=1)
     assert not completed.wait(timeout=0.05)
     step_completed = next(event for event in events if event["type"] == "step.completed")
+    assert step_completed["payload"]["stepCommitId"]
+    assert step_completed["payload"]["workspaceRevision"] == 1
+    assert not manager.acknowledge_step_rendered(
+        started["operationId"],
+        step_completed["eventId"],
+        "wrong-step-commit",
+        step_completed["payload"]["workspaceRevision"],
+    )["accepted"]
 
     assert manager.acknowledge_step_rendered(
         started["operationId"],
         step_completed["eventId"],
+        step_completed["payload"]["stepCommitId"],
+        step_completed["payload"]["workspaceRevision"],
     ) == {
         "accepted": True,
         "duplicate": False,
@@ -47,6 +58,56 @@ def test_successful_step_waits_for_matching_render_ack_before_completing():
     assert completed.wait(timeout=1)
     assert manager.operation_status(started["operationId"])["state"] == "succeeded"
     assert events[-1]["type"] == "operation.completed"
+
+
+def test_render_ack_replays_one_commit_then_pauses_before_a_bounded_timeout(monkeypatch):
+    monkeypatch.setattr(operations, "_RENDER_ACK_RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(operations, "_RENDER_ACK_PAUSE_SECONDS", 0.02)
+    monkeypatch.setattr(operations, "_RENDER_ACK_ABORT_SECONDS", 0.5)
+    events = []
+    entered_render_gate = threading.Event()
+    manager = RuntimeOperationManager(events.append)
+    step = SimpleNamespace(name="Synthesis", tool="yosys", log=SimpleNamespace(file=""))
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Success)
+        entered_render_gate.set()
+        assert observer.wait_for_step_rendered(step, StateEnum.Success)
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-replay",
+        runner=runner,
+    )
+    assert entered_render_gate.wait(timeout=1)
+    step_completed = _wait_for_event(events, "step.completed")
+    paused = _wait_for_event(events, "operation.gui_sync_paused")
+    replays = [
+        event
+        for event in events
+        if event["type"] == "step.completed" and event["payload"].get("replayed")
+    ]
+    assert paused["payload"]["stepCommitId"] == step_completed["payload"]["stepCommitId"]
+    assert replays
+    assert all(event["eventId"] == step_completed["eventId"] for event in replays)
+    assert (
+        manager.operation_status(started["operationId"])["renderSyncState"]
+        == "paused_for_gui_recovery"
+    )
+
+    assert manager.acknowledge_step_rendered(
+        started["operationId"],
+        step_completed["eventId"],
+        step_completed["payload"]["stepCommitId"],
+        step_completed["payload"]["workspaceRevision"],
+    )["accepted"]
+    assert _wait_for_terminal(manager, started["operationId"])["state"] == "succeeded"
 
 
 def test_ack_and_start_requests_are_idempotent():

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -150,6 +150,40 @@ def test_ack_and_start_requests_are_idempotent():
     assert _wait_for_terminal(manager, first["operationId"])["state"] == "succeeded"
 
 
+def test_event_identity_is_unique_across_sidecar_operation_managers():
+    first_events = []
+    second_events = []
+    first = RuntimeOperationManager(first_events.append)
+    second = RuntimeOperationManager(second_events.append)
+
+    first.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="first",
+        runner=lambda _observer: {"rerun": False},
+    )
+    second.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=True,
+        step="",
+        idempotency_key="second",
+        runner=lambda _observer: {"rerun": True},
+    )
+
+    first_queued = _wait_for_event(first_events, "operation.queued")
+    second_queued = _wait_for_event(second_events, "operation.queued")
+    assert first_queued["sequence"] == second_queued["sequence"] == 1
+    assert first_queued["eventId"] != second_queued["eventId"]
+    assert first_queued["runtimeInstanceId"] != second_queued["runtimeInstanceId"]
+    assert first_queued["operationId"] != second_queued["operationId"]
+    assert first_queued["runSessionId"] != second_queued["runSessionId"]
+
+
 def test_rerun_prepared_event_carries_the_affected_steps_once():
     events = []
     manager = RuntimeOperationManager(events.append)
@@ -189,6 +223,49 @@ def test_rerun_prepared_event_carries_the_affected_steps_once():
         "targetStep": "Floorplan",
     }
     assert len([event for event in events if event["type"] == "operation.rerun_prepared"]) == 1
+
+
+def test_render_ack_timeout_degrades_and_allows_the_flow_to_continue(monkeypatch):
+    monkeypatch.setattr(operations, "_RENDER_ACK_RETRY_SECONDS", 0.01)
+    monkeypatch.setattr(operations, "_RENDER_ACK_PAUSE_SECONDS", 0.02)
+    monkeypatch.setattr(operations, "_RENDER_ACK_ABORT_SECONDS", 0.04)
+    events = []
+    manager = RuntimeOperationManager(events.append)
+    step = SimpleNamespace(name="Synthesis", tool="yosys", log=SimpleNamespace(file=""))
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Success)
+        assert observer.wait_for_step_rendered(step, StateEnum.Success)
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Success)
+        assert observer.wait_for_step_rendered(step, StateEnum.Success)
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-degraded-sync",
+        runner=runner,
+    )
+
+    degraded = _wait_for_event(events, "operation.gui_sync_degraded")
+    assert degraded["payload"]["stepCommitId"]
+    assert _wait_for_terminal(manager, started["operationId"])["state"] == "succeeded"
+    completed_events = [
+        event
+        for event in events
+        if event["type"] == "step.completed" and not event["payload"].get("replayed")
+    ]
+    assert len(completed_events) == 2
+    assert completed_events[1]["payload"]["stepCommitId"]
+    assert (
+        manager.operation_status(started["operationId"])["renderSyncState"] == "gui_sync_degraded"
+    )
+    assert not any(event["type"] == "operation.failed" for event in events)
 
 
 def test_active_operation_reports_a_shutdown_barrier_and_safe_boundary():

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -1,0 +1,178 @@
+import threading
+from types import SimpleNamespace
+
+from chipcompiler.data import StateEnum
+from chipcompiler.runtime.operations import RuntimeOperationManager
+
+
+def test_successful_step_waits_for_matching_render_ack_before_completing():
+    events = []
+    entered_render_gate = threading.Event()
+    completed = threading.Event()
+    manager = RuntimeOperationManager(events.append)
+    step = SimpleNamespace(name="Synthesis", tool="yosys", log=SimpleNamespace(file=""))
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Success)
+        entered_render_gate.set()
+        assert observer.wait_for_step_rendered(step, StateEnum.Success)
+        completed.set()
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-1",
+        runner=runner,
+    )
+
+    assert started["state"] in {"queued", "running"}
+    assert entered_render_gate.wait(timeout=1)
+    assert not completed.wait(timeout=0.05)
+    step_completed = next(event for event in events if event["type"] == "step.completed")
+
+    assert manager.acknowledge_step_rendered(
+        started["operationId"],
+        step_completed["eventId"],
+    ) == {
+        "accepted": True,
+        "duplicate": False,
+        "operationId": started["operationId"],
+        "eventId": step_completed["eventId"],
+    }
+    assert completed.wait(timeout=1)
+    assert manager.operation_status(started["operationId"])["state"] == "succeeded"
+    assert events[-1]["type"] == "operation.completed"
+
+
+def test_ack_and_start_requests_are_idempotent():
+    events = []
+    release = threading.Event()
+    manager = RuntimeOperationManager(events.append)
+
+    def runner(_observer):
+        assert release.wait(timeout=1)
+        return {"rerun": False}
+
+    first = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-1",
+        runner=runner,
+    )
+    duplicate = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-1",
+        runner=runner,
+    )
+
+    assert duplicate["operationId"] == first["operationId"]
+    assert duplicate["deduplicated"] is True
+    assert manager.acknowledge_step_rendered(first["operationId"], "workspace-1:missing") == {
+        "accepted": False,
+        "duplicate": False,
+        "operationId": first["operationId"],
+        "eventId": "workspace-1:missing",
+    }
+    release.set()
+    assert _wait_for_terminal(manager, first["operationId"])["state"] == "succeeded"
+
+
+def test_active_operation_reports_a_shutdown_barrier_and_safe_boundary():
+    release = threading.Event()
+    manager = RuntimeOperationManager()
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-1",
+        runner=lambda _observer: (release.wait(timeout=1), {"rerun": False})[1],
+    )
+
+    barrier = manager.shutdown_barrier()
+    status = manager.operation_status(started["operationId"])
+
+    assert barrier is not None
+    assert barrier["operationId"] == started["operationId"]
+    assert barrier["interruptibility"] == "deferred"
+    assert status["shutdownBarrier"] is True
+    assert status["safeToStop"] is False
+    release.set()
+
+
+def test_step_log_events_stream_only_new_log_bytes_and_keep_final_tail(tmp_path):
+    events = []
+    step_started = threading.Event()
+    complete_step = threading.Event()
+    manager = RuntimeOperationManager(events.append)
+    log_file = tmp_path / "Synthesis.log"
+    log_file.write_text("previous run\n", encoding="utf-8")
+    step = SimpleNamespace(
+        name="Synthesis",
+        tool="yosys",
+        log=SimpleNamespace(file=str(log_file)),
+    )
+
+    def runner(observer):
+        observer.on_step_started(step)
+        step_started.set()
+        assert complete_step.wait(timeout=2)
+        observer.on_step_completed(step, StateEnum.Success)
+        assert observer.wait_for_step_rendered(step, StateEnum.Success)
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-log-stream",
+        runner=runner,
+    )
+    assert step_started.wait(timeout=1)
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write("live line one\nlive line two\n")
+
+    step_log = _wait_for_event(events, "step.log")
+    assert step_log["payload"]["chunk"] == "live line one\nlive line two\n"
+    assert step_log["payload"]["cursor"] == log_file.stat().st_size
+
+    complete_step.set()
+    step_complete = _wait_for_event(events, "step.completed")
+    assert step_complete["payload"]["finalLog"] == ("previous run\nlive line one\nlive line two\n")
+    assert manager.acknowledge_step_rendered(started["operationId"], step_complete["eventId"])[
+        "accepted"
+    ]
+    assert _wait_for_terminal(manager, started["operationId"])["state"] == "succeeded"
+
+
+def _wait_for_event(events: list[dict], event_type: str) -> dict:
+    for _ in range(200):
+        for event in events:
+            if event["type"] == event_type:
+                return event
+        threading.Event().wait(0.01)
+    raise AssertionError(f"event not received: {event_type}")
+
+
+def _wait_for_terminal(manager: RuntimeOperationManager, operation_id: str) -> dict:
+    for _ in range(100):
+        status = manager.operation_status(operation_id)
+        if status["state"] in {"succeeded", "failed", "cancelled"}:
+            return status
+        threading.Event().wait(0.01)
+    return manager.operation_status(operation_id)

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -150,6 +150,47 @@ def test_ack_and_start_requests_are_idempotent():
     assert _wait_for_terminal(manager, first["operationId"])["state"] == "succeeded"
 
 
+def test_rerun_prepared_event_carries_the_affected_steps_once():
+    events = []
+    manager = RuntimeOperationManager(events.append)
+
+    def runner(observer):
+        observer.on_rerun_prepared(
+            scope="step",
+            target_step="Floorplan",
+            affected_steps=["Floorplan", "route"],
+        )
+        return {"rerun": True}
+
+    first = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=True,
+        step="Floorplan",
+        idempotency_key="rerun-prepared",
+        runner=runner,
+    )
+    duplicate = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=True,
+        step="Floorplan",
+        idempotency_key="rerun-prepared",
+        runner=runner,
+    )
+
+    assert duplicate["operationId"] == first["operationId"]
+    prepared = _wait_for_event(events, "operation.rerun_prepared")
+    assert prepared["payload"] == {
+        "affectedSteps": ["Floorplan", "route"],
+        "scope": "step",
+        "targetStep": "Floorplan",
+    }
+    assert len([event for event in events if event["type"] == "operation.rerun_prepared"]) == 1
+
+
 def test_active_operation_reports_a_shutdown_barrier_and_safe_boundary():
     release = threading.Event()
     manager = RuntimeOperationManager()

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -113,6 +113,34 @@ def test_active_operation_reports_a_shutdown_barrier_and_safe_boundary():
     release.set()
 
 
+def test_cancel_at_render_ack_boundary_releases_the_waiting_flow():
+    entered_render_gate = threading.Event()
+    manager = RuntimeOperationManager()
+    step = SimpleNamespace(name="Synthesis", tool="yosys", log=SimpleNamespace(file=""))
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Success)
+        entered_render_gate.set()
+        if not observer.wait_for_step_rendered(step, StateEnum.Success):
+            raise RuntimeError("operation cancelled at a render boundary")
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="flow",
+        origin="gui",
+        rerun=False,
+        step="",
+        idempotency_key="request-cancel-at-gate",
+        runner=runner,
+    )
+    assert entered_render_gate.wait(timeout=1)
+
+    assert manager.request_cancel(started["operationId"])["accepted"] is True
+    assert _wait_for_terminal(manager, started["operationId"])["state"] == "cancelled"
+
+
 def test_step_log_events_stream_only_new_log_bytes_and_keep_final_tail(tmp_path):
     events = []
     step_started = threading.Event()

--- a/test/runtime/test_requests.py
+++ b/test/runtime/test_requests.py
@@ -15,6 +15,7 @@ from chipcompiler.runtime.requests import (
     LayoutEditBeginRequest,
     LayoutEditDiscardRequest,
     LayoutEditSaveRequest,
+    OperationStartStepRequest,
     RequestValidationError,
     WorkspaceCloseRequest,
     WorkspaceCreateRequest,
@@ -102,8 +103,21 @@ def test_workspace_create_maps_camel_case_fields_and_preserves_pdk_json():
         ("flow.run", {"workspaceId": "ws-1", "rerun": True}, FlowRunRequest),
         (
             "flow.run_step",
-            {"workspaceId": "ws-1", "step": "Synthesis", "rerun": True},
+            {
+                "workspaceId": "ws-1",
+                "step": "Synthesis",
+                "rerun": True,
+            },
             FlowRunStepRequest,
+        ),
+        (
+            "operation.start_step",
+            {
+                "workspaceId": "ws-1",
+                "step": "Synthesis",
+                "resetDependents": True,
+            },
+            OperationStartStepRequest,
         ),
     ],
 )
@@ -284,6 +298,32 @@ def test_rerun_must_be_boolean(method, params):
         _parse_runtime_request(method, params)
 
     assert exc_info.value.reason == "rerun must be a boolean"
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        (
+            "operation.start_step",
+            {"workspaceId": "ws-1", "step": "Synthesis", "resetDependents": 1},
+        ),
+    ],
+)
+def test_reset_dependents_must_be_boolean(method, params):
+    with pytest.raises(RequestValidationError) as exc_info:
+        _parse_runtime_request(method, params)
+
+    assert exc_info.value.reason == "reset_dependents must be a boolean"
+
+
+def test_direct_flow_run_step_rejects_gui_only_reset_dependents_field():
+    with pytest.raises(RequestValidationError) as exc_info:
+        _parse_runtime_request(
+            "flow.run_step",
+            {"workspaceId": "ws-1", "step": "Synthesis", "resetDependents": True},
+        )
+
+    assert exc_info.value.reason == "unknown field: reset_dependents"
 
 
 def test_unknown_runtime_method_has_no_request_model():

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -55,6 +55,24 @@ class CompleteFakeApi:
     def flow_run_step(self, _request):
         raise AssertionError("unexpected flow_run_step call")
 
+    def start_flow_operation(self, _request):
+        raise AssertionError("unexpected start_flow_operation call")
+
+    def start_step_operation(self, _request):
+        raise AssertionError("unexpected start_step_operation call")
+
+    def operation_status(self, _request):
+        raise AssertionError("unexpected operation_status call")
+
+    def cancel_operation(self, _request):
+        raise AssertionError("unexpected cancel_operation call")
+
+    def acknowledge_step_rendered(self, _request):
+        raise AssertionError("unexpected acknowledge_step_rendered call")
+
+    def workspace_snapshot(self, _request):
+        raise AssertionError("unexpected workspace_snapshot call")
+
     def db_ensure(self, _request):
         raise AssertionError("unexpected db_ensure call")
 
@@ -96,6 +114,9 @@ def test_rpc_hello_returns_version_and_capabilities():
     assert response["result"]["eccVersion"]
     assert "rpc.ping" in response["result"]["capabilities"]
     assert "rpc.shutdown" in response["result"]["capabilities"]
+    assert "runtime.v2" in response["result"]["capabilities"]
+    assert "operation.events" in response["result"]["capabilities"]
+    assert "workspace.snapshot" in response["result"]["capabilities"]
     assert "db.ensure" not in response["result"]["capabilities"]
     assert "db.release" not in response["result"]["capabilities"]
 

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -12,6 +12,7 @@ from chipcompiler.runtime.requests import (
     DbReleaseRequest,
     FlowRunRequest,
     FlowRunStepRequest,
+    OperationStartFlowRequest,
     WorkspaceCreateRequest,
     WorkspaceIdRequest,
     WorkspaceInfoRequest,
@@ -199,7 +200,9 @@ def _install_runtime_mocks(monkeypatch, tmp_path, *, create_workspace_files=True
     monkeypatch.setattr("chipcompiler.data.create_workspace", fake_create_workspace)
     monkeypatch.setattr("chipcompiler.data.load_workspace", fake_load_workspace)
     monkeypatch.setattr("chipcompiler.data.refresh_workspace_config", lambda workspace: None)
-    monkeypatch.setattr("chipcompiler.data.prepare_workspace_for_rerun", lambda ws, flow: None)
+    monkeypatch.setattr(
+        "chipcompiler.data.prepare_workspace_for_rerun", lambda ws, flow, **_kwargs: None
+    )
     monkeypatch.setattr("chipcompiler.engine.EngineFlow", DummyFlow)
     monkeypatch.setattr(
         "chipcompiler.rtl2gds.build_rtl2gds_flow",
@@ -460,7 +463,7 @@ def test_refresh_sync_and_reset_flow_use_session(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         "chipcompiler.data.prepare_workspace_for_rerun",
-        lambda workspace, flow: prepared.append((workspace.directory, flow)),
+        lambda workspace, flow, **_kwargs: prepared.append((workspace.directory, flow)),
     )
     config_dir = ws / "config"
     config_dir.mkdir()
@@ -546,7 +549,7 @@ def test_reset_flow_releases_active_session_db_before_prepare(monkeypatch, tmp_p
     _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
     prepared = []
 
-    def prepare(workspace, flow):
+    def prepare(workspace, flow, **_kwargs):
         prepared.append((workspace.directory, flow))
         assert api.sessions.get_session(workspace_id).db_handle is None
 
@@ -622,7 +625,9 @@ def test_reset_flow_waits_for_session_mutation_lock(monkeypatch, tmp_path):
         return SimpleNamespace()
 
     monkeypatch.setattr("chipcompiler.runtime.workspace_api.build_flow_for_workspace", build_flow)
-    monkeypatch.setattr("chipcompiler.data.prepare_workspace_for_rerun", lambda _ws, _flow: None)
+    monkeypatch.setattr(
+        "chipcompiler.data.prepare_workspace_for_rerun", lambda _ws, _flow, **_kwargs: None
+    )
 
     _assert_call_waits_for_session_lock(
         api=api,
@@ -798,7 +803,7 @@ def test_flow_run_uses_run_steps_and_prepare_on_rerun(monkeypatch, tmp_path):
     prepared = []
     monkeypatch.setattr(
         "chipcompiler.data.prepare_workspace_for_rerun",
-        lambda workspace, flow: prepared.append((workspace.directory, flow)),
+        lambda workspace, flow, **kwargs: prepared.append((workspace.directory, flow, kwargs)),
     )
     api = WorkspaceRuntimeApi()
     workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
@@ -807,8 +812,44 @@ def test_flow_run_uses_run_steps_and_prepare_on_rerun(monkeypatch, tmp_path):
 
     flow = DummyFlow.instances[-1]
     assert result == {"rerun": True}
-    assert prepared == [(ws.resolve(), flow)]
+    assert prepared == [(ws.resolve(), flow, {"preserve_user_inputs": False})]
     assert flow.run_steps_calls == [True]
+
+
+def test_gui_flow_operation_rerun_preserves_current_user_inputs(monkeypatch, tmp_path):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    api = WorkspaceRuntimeApi()
+    workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
+    captured = {}
+
+    def fake_flow_run(request, *, observer=None, preserve_user_inputs=False):
+        captured.update(
+            request=request,
+            observer=observer,
+            preserve_user_inputs=preserve_user_inputs,
+        )
+        return {"rerun": request.rerun}
+
+    def fake_start(**kwargs):
+        return kwargs["runner"](None)
+
+    monkeypatch.setattr(api, "_flow_run", fake_flow_run)
+    monkeypatch.setattr(api.operations, "start", fake_start)
+
+    result = api.start_flow_operation(
+        OperationStartFlowRequest(
+            workspace_id=workspace_id,
+            origin="gui",
+            rerun=True,
+            idempotency_key="gui-rerun",
+        )
+    )
+
+    assert result == {"rerun": True}
+    assert captured["request"].workspace_id == workspace_id
+    assert captured["request"].rerun is True
+    assert captured["observer"] is None
+    assert captured["preserve_user_inputs"] is True
 
 
 def test_flow_run_without_active_session_db_closes_transient_db(
@@ -851,7 +892,7 @@ def test_flow_run_rerun_releases_stale_db_and_captures_new_db(monkeypatch, tmp_p
     _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
     prepared = []
 
-    def prepare(workspace, flow):
+    def prepare(workspace, flow, **_kwargs):
         prepared.append((workspace.directory, flow))
         assert api.sessions.get_session(workspace_id).db_handle is None
 

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -1215,6 +1215,7 @@ def test_flow_run_step_rerun_clears_step_artifacts_and_resets_step_state(monkeyp
         "state": "Unstart",
         "runtime": "",
         "peak memory (mb)": 0,
+        "info": {},
     }
     assert json.loads(subflow_path.read_text()) == {
         "path": str(subflow_path),
@@ -1228,10 +1229,131 @@ def test_flow_run_step_rerun_clears_step_artifacts_and_resets_step_state(monkeyp
             }
         ],
     }
-    assert json.loads(checklist_path.read_text()) == {
-        "path": str(checklist_path),
-        "checklist": [],
+    checklist = json.loads(checklist_path.read_text())
+    assert checklist["schema_version"] == 3
+    assert checklist["kind"] == "signoff_checklist"
+    assert checklist["checker_revision"] == "signoff-v1"
+    assert checklist["status"] == "ready"
+    assert checklist["summary"] == {
+        "passed": 0,
+        "blocked": 0,
+        "attention": 0,
+        "unavailable": 0,
     }
+    assert checklist["checklist"] == []
+
+
+def test_flow_run_step_gui_rerun_resets_target_and_downstream_subflows(monkeypatch, tmp_path):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+
+    def step_spec(name, tool):
+        step_dir = ws / f"{name}_{tool}"
+        artifact_dir = step_dir / "output"
+        (artifact_dir / "nested").mkdir(parents=True)
+        (artifact_dir / "nested" / "stale").write_text(name)
+        subflow_path = step_dir / "subflow.json"
+        subflow_path.write_text(
+            json.dumps(
+                {
+                    "path": str(subflow_path),
+                    "steps": [
+                        {
+                            "name": "load data",
+                            "state": "Success",
+                            "runtime": "0:00:01",
+                            "peak memory (mb)": 10,
+                            "info": {"stale": name},
+                        },
+                        {
+                            "name": "run tool",
+                            "state": "Success",
+                            "runtime": "0:00:02",
+                            "peak memory (mb)": 20,
+                            "info": {"stale": name},
+                        },
+                    ],
+                }
+            )
+        )
+        checklist_path = step_dir / "checklist.json"
+        checklist_path.write_text(json.dumps({"checklist": [{"item": name}]}))
+        return {
+            "name": name,
+            "tool": tool,
+            "output": {"dir": artifact_dir},
+            "subflow": SimpleNamespace(path=subflow_path, steps=[]),
+            "checklist": SimpleNamespace(path=checklist_path, checklist=[]),
+        }
+
+    synthesis = step_spec("Synthesis", "yosys")
+    floorplan = step_spec("Floorplan", "ecc")
+    route = step_spec("route", "ecc")
+    DummyFlow.workspace_step_specs = (synthesis, floorplan, route)
+    api = WorkspaceRuntimeApi()
+    workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
+    session = api.sessions.get_session(workspace_id)
+    session.workspace.flow.data = {
+        "steps": [
+            {
+                "name": spec["name"],
+                "tool": spec["tool"],
+                "state": "Success",
+                "runtime": "0:00:04",
+                "peak memory (mb)": 30,
+                "info": {"stale": spec["name"]},
+            }
+            for spec in (synthesis, floorplan, route)
+        ]
+    }
+
+    result = api._flow_run_step(
+        FlowRunStepRequest(
+            workspace_id=workspace_id,
+            step="Floorplan",
+            rerun=True,
+        ),
+        reset_dependents=True,
+    )
+
+    assert result == {"step": "Floorplan", "state": "Success"}
+    assert (ws / "Synthesis_yosys" / "output" / "nested" / "stale").read_text() == "Synthesis"
+    for spec in (floorplan, route):
+        assert list(spec["output"]["dir"].iterdir()) == []
+        checklist = json.loads(spec["checklist"].path.read_text())
+        assert checklist["schema_version"] == 3
+        assert checklist["kind"] == "signoff_checklist"
+        assert checklist["checker_revision"] == "signoff-v1"
+        assert checklist["status"] == "ready"
+        assert checklist["summary"] == {
+            "passed": 0,
+            "blocked": 0,
+            "attention": 0,
+            "unavailable": 0,
+        }
+        assert checklist["checklist"] == []
+        reset_subflow = json.loads(spec["subflow"].path.read_text())
+        assert all(
+            step["state"] == "Unstart"
+            and step["runtime"] == ""
+            and step["peak memory (mb)"] == 0
+            and step["info"] == {}
+            for step in reset_subflow["steps"]
+        )
+
+    records = {record["name"]: record for record in session.workspace.flow.data["steps"]}
+    assert any(
+        record["name"] == "Synthesis" and record["state"] == "Success"
+        for record in session.workspace.flow.data["steps"]
+    )
+    for name in ("Floorplan", "route"):
+        assert records[name] == {
+            "name": name,
+            "tool": "ecc",
+            "state": "Unstart",
+            "runtime": "",
+            "peak memory (mb)": 0,
+            "info": {},
+        }
 
 
 def test_flow_run_step_rerun_rejects_an_open_layout_edit(monkeypatch, tmp_path):

--- a/test/test_engine_flow.py
+++ b/test/test_engine_flow.py
@@ -78,7 +78,7 @@ def test_engine_flow_persists_run_facts_before_refreshing_qor_analysis(
     }
 
 
-def test_engine_flow_delays_short_step_before_return(monkeypatch, tmp_path):
+def test_engine_flow_does_not_delay_short_step_before_return(monkeypatch, tmp_path):
     workspace = Workspace()
     workspace.flow.data = {
         "steps": [{"name": "route", "tool": "ecc", "state": "Unstart"}],
@@ -93,7 +93,7 @@ def test_engine_flow_delays_short_step_before_return(monkeypatch, tmp_path):
     monkeypatch.setattr(flow_module.time, "sleep", sleep_calls.append)
 
     assert engine_flow.run_step(workspace_step) is StateEnum.Imcomplete
-    assert sleep_calls == [3]
+    assert sleep_calls == []
 
 
 def test_check_step_result_synthesis_uses_common_verilog(tmp_path):

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -9,6 +9,7 @@ from chipcompiler.data import (
     EccReport,
     EccStep,
     OriginDesign,
+    Parameters,
     StepEnum,
     StepInput,
     Workspace,
@@ -523,6 +524,40 @@ def test_save_data_writes_geometry_snapshot_for_physical_step(tmp_path):
     assert module.geometry_output == step.output.geometry
     assert step.output.geometry_manifest is not None
     assert step.output.geometry_manifest.is_file()
+
+
+def test_save_data_preserves_core_utilization_parameter(tmp_path, monkeypatch):
+    parameter_path = tmp_path / "home" / "parameters.json"
+    parameter_path.parent.mkdir()
+    workspace = Workspace(
+        directory=tmp_path,
+        design=OriginDesign(name="gcd", top_module="gcd"),
+        parameters=Parameters(
+            path=parameter_path,
+            data={"Core": {"Margin": [2, 3], "Utilitization": 0.61}},
+        ),
+    )
+    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+    module = SnapshotSaveEccModule(write_snapshot=True)
+    monkeypatch.setattr(
+        ecc_runner,
+        "json_read",
+        lambda _path: {
+            "Design Layout": {
+                "die_bounding_width": 100,
+                "die_bounding_height": 50,
+                "die_area": 5000,
+                "core_bounding_width": 80,
+                "core_bounding_height": 30,
+                "core_area": 2400,
+                "core_usage": 0.42,
+            }
+        },
+    )
+
+    assert ecc_runner.save_data(workspace, step, module, feature_step=False) is True
+    assert workspace.parameters.data["Core"]["Utilitization"] == 0.61
+    assert json.loads(parameter_path.read_text(encoding="utf-8"))["Core"]["Utilitization"] == 0.61
 
 
 def test_save_data_fails_when_geometry_snapshot_cannot_be_written(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "ecc"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "ecc-dreamplace" },


### PR DESCRIPTION
## What Changed

- Build a stable mechanism for mutual communication between GUI and ECC

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
