### PR TITLE
fix: restore process stdio around integration flow runs, bump ecc in uv.lock

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,9 +1,13 @@
+import os
+import sys
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
 
 from chipcompiler.data import create_workspace, get_design_parameters, get_pdk
 from chipcompiler.engine import EngineDB, EngineFlow
+from chipcompiler.utility.log import flush_cstdio
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -47,7 +51,24 @@ def run_workspace_flow(
             engine_flow.add_step(step=step, tool=tool, state=state)
 
     engine_flow.create_step_workspaces()
-    return engine_flow.run_steps()
+
+    # EngineFlow.run_step dup2's fd 1/2 into each step's log file and never
+    # restores them. Save/restore around the flow so pytest's own reporting
+    # is not swallowed by the last step's log.
+    saved_fds = (os.dup(1), os.dup(2))
+    saved_streams = (sys.stdout, sys.stderr)
+    try:
+        return engine_flow.run_steps()
+    finally:
+        with suppress(Exception):
+            sys.stdout.flush()
+            sys.stderr.flush()
+        flush_cstdio()
+        os.dup2(saved_fds[0], 1)
+        os.dup2(saved_fds[1], 2)
+        os.close(saved_fds[0])
+        os.close(saved_fds[1])
+        sys.stdout, sys.stderr = saved_streams
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "ecc"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "ecc-dreamplace" },


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
