### PR TITLE
feat: generate full default SDC with PDK-driven output load

### DIFF
--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -41,6 +41,7 @@ class PDK:
     dont_use: list[str] = field(default_factory=list[str])  # don't use cell list
     abc_driver_cell: str = ""  # ABC driving cell
     abc_load: float = 0.015  # ABC output load
+    sdc_load: float = 0.0  # output load (pF) for generated SDC; 0 omits set_load
 
     def __post_init__(self) -> None:
         self.root = optional_path(self.root)
@@ -222,6 +223,7 @@ def _pdk_from_external_config(data: dict, pdk_name: str = "") -> PDK:
         dont_use=data.get("dont_use", []),
         abc_driver_cell=str(data.get("abc_driver_cell", "")),
         abc_load=float(data.get("abc_load", 0.015)),
+        sdc_load=float(data.get("sdc_load", 0.0)),
     )
 
 
@@ -357,6 +359,7 @@ def PDK_ICS55(pdk_root: str | Path = "") -> PDK:
         tie_low_port="Z",
         abc_driver_cell="BUFX0P5H7R",
         abc_load=0.015,
+        sdc_load=0.001,
         dont_use=[
             "DFFSRQX*",
             "DFFSRX*",

--- a/chipcompiler/data/workspace/sdc.py
+++ b/chipcompiler/data/workspace/sdc.py
@@ -11,16 +11,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from chipcompiler.data import Workspace
 
-
-def create_default_sdc(workspace: "Workspace") -> None:
-    """
-    Create SDC file based on PDK and workspace parameters.
-    """
-    clock = workspace.parameters.data.get("clock", "")
-    freq_mhz = workspace.parameters.data.get("frequency_max", 100)
-    max_fanout = workspace.parameters.data.get("max_fanout", 20)
-
-    sdc_content = f"""\
+_SDC_HEAD_CLOCK = """\
 # Auto-generated SDC file
 
 set clk_name          {clock}
@@ -45,15 +36,36 @@ set_input_delay  0  -clock [get_clocks $clk_name] $all_inputs_wo_clk
 set_output_delay 0 -clock [get_clocks $clk_name] [all_outputs]
 """
 
-    if workspace.pdk.sdc_load > 0:
-        sdc_content += f"""
+_SDC_HEAD_VIRTUAL_CLOCK = """\
+# Auto-generated SDC file
+
+set clk_name          __VIRTUAL_CLK__
+set clk_freq_mhz      {freq_mhz}
+set clk_period        [expr 1000.0 / $clk_freq_mhz]
+set clk_io_pct        0.2
+
 # -------------------------------------------------
-# Output load (pF) - {workspace.pdk.name} pdk
+# Clock definition
 # -------------------------------------------------
-set_load {workspace.pdk.sdc_load} [all_outputs]
+create_clock -name $clk_name -period $clk_period
+
+# -------------------------------------------------
+# IO Delay
+# -------------------------------------------------
+set all_inputs_wo_clk  [all_inputs]
+
+set_input_delay  0  -clock [get_clocks $clk_name] $all_inputs_wo_clk
+set_output_delay 0 -clock [get_clocks $clk_name] [all_outputs]
 """
 
-    sdc_content += f"""
+_SDC_OUTPUT_LOAD = """
+# -------------------------------------------------
+# Output load (pF) - {pdk_name} pdk
+# -------------------------------------------------
+set_load {sdc_load} [all_outputs]
+"""
+
+_SDC_TAIL = """
 # -------------------------------------------------
 # Clock uncertainty & transition
 # -------------------------------------------------
@@ -70,6 +82,30 @@ set_input_transition  $input_transition $all_inputs_wo_clk
 # -------------------------------------------------
 set_max_fanout {max_fanout} [current_design]
 """
+
+
+def create_default_sdc(workspace: "Workspace") -> None:
+    """
+    Create SDC file based on PDK and workspace parameters.
+
+    A design without a clock port gets a virtual clock instead, so
+    downstream tools still have a clock object as timing reference.
+    """
+    parameters = workspace.parameters.data
+    freq_mhz = parameters.get("frequency_max", 100)
+
+    clock = parameters.get("clock", "")
+    if clock:
+        sdc_content = _SDC_HEAD_CLOCK.format(clock=clock, freq_mhz=freq_mhz)
+    else:
+        sdc_content = _SDC_HEAD_VIRTUAL_CLOCK.format(freq_mhz=freq_mhz)
+
+    if workspace.pdk.sdc_load > 0:
+        sdc_content += _SDC_OUTPUT_LOAD.format(
+            pdk_name=workspace.pdk.name, sdc_load=workspace.pdk.sdc_load
+        )
+
+    sdc_content += _SDC_TAIL.format(max_fanout=parameters.get("max_fanout", 20))
 
     with open(workspace.pdk.sdc, "w") as file:
         file.write(sdc_content)

--- a/chipcompiler/data/workspace/sdc.py
+++ b/chipcompiler/data/workspace/sdc.py
@@ -16,21 +16,63 @@ def create_default_sdc(workspace: "Workspace") -> None:
     """
     Create SDC file based on PDK and workspace parameters.
     """
-    sdc_content = []
-    sdc_content.append("# Auto-generated SDC file\n")
-    sdc_content.append("\n")
-    sdc_content.append("set clk_name {} \n".format(workspace.parameters.data.get("clock", "")))
-    sdc_content.append("set clk_port_name {}\n".format(workspace.parameters.data.get("clock", "")))
-    sdc_content.append(
-        "set clk_freq_mhz {}\n".format(workspace.parameters.data.get("frequency_max", 100))
-    )
-    sdc_content.append("set clk_period [expr 1000.0 / $clk_freq_mhz]\n")
-    sdc_content.append("set clk_io_pct 0.2\n")
-    sdc_content.append("set clk_port [get_ports $clk_port_name]\n")
-    sdc_content.append("create_clock -name $clk_name -period $clk_period $clk_port\n")
+    clock = workspace.parameters.data.get("clock", "")
+    freq_mhz = workspace.parameters.data.get("frequency_max", 100)
+    max_fanout = workspace.parameters.data.get("max_fanout", 20)
+
+    sdc_content = f"""\
+# Auto-generated SDC file
+
+set clk_name          {clock}
+set clk_port_name     {clock}
+set clk_freq_mhz      {freq_mhz}
+set clk_period        [expr 1000.0 / $clk_freq_mhz]
+set clk_io_pct        0.2
+
+# -------------------------------------------------
+# Clock definition
+# -------------------------------------------------
+set clk_port [get_ports $clk_port_name]
+create_clock -name $clk_name -period $clk_period $clk_port
+
+# -------------------------------------------------
+# IO Delay
+# -------------------------------------------------
+set clk_input          [get_ports $clk_port_name]
+set all_inputs_wo_clk  [remove_from_collection [all_inputs] $clk_input]
+
+set_input_delay  0  -clock [get_clocks $clk_name] $all_inputs_wo_clk
+set_output_delay 0 -clock [get_clocks $clk_name] [all_outputs]
+"""
+
+    if workspace.pdk.sdc_load > 0:
+        sdc_content += f"""
+# -------------------------------------------------
+# Output load (pF) - {workspace.pdk.name} pdk
+# -------------------------------------------------
+set_load {workspace.pdk.sdc_load} [all_outputs]
+"""
+
+    sdc_content += f"""
+# -------------------------------------------------
+# Clock uncertainty & transition
+# -------------------------------------------------
+set clk_uncertainty   [expr $clk_period * 0.05]                 ;# 5% of period
+set clk_transition    [expr min(0.15, $clk_period * 0.03)]      ;# 3%, cap 0.15ns
+set input_transition  [expr min(0.20, $clk_period * 0.05)]      ;# 5%, cap 0.20ns
+
+set_clock_uncertainty $clk_uncertainty  [get_clocks $clk_name]
+set_clock_transition  $clk_transition   [get_clocks $clk_name]
+set_input_transition  $input_transition $all_inputs_wo_clk
+
+# -------------------------------------------------
+# Design-level constraints
+# -------------------------------------------------
+set_max_fanout {max_fanout} [current_design]
+"""
 
     with open(workspace.pdk.sdc, "w") as file:
-        file.writelines(sdc_content)
+        file.write(sdc_content)
 
 
 def refresh_generated_sdc(workspace: "Workspace") -> None:

--- a/chipcompiler/data/workspace/sdc.py
+++ b/chipcompiler/data/workspace/sdc.py
@@ -18,7 +18,6 @@ set clk_name          {clock}
 set clk_port_name     {clock}
 set clk_freq_mhz      {freq_mhz}
 set clk_period        [expr 1000.0 / $clk_freq_mhz]
-set clk_io_pct        0.2
 
 # -------------------------------------------------
 # Clock definition
@@ -42,7 +41,6 @@ _SDC_HEAD_VIRTUAL_CLOCK = """\
 set clk_name          __VIRTUAL_CLK__
 set clk_freq_mhz      {freq_mhz}
 set clk_period        [expr 1000.0 / $clk_freq_mhz]
-set clk_io_pct        0.2
 
 # -------------------------------------------------
 # Clock definition

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -158,6 +158,74 @@ def test_create_workspace_rejects_existing_non_empty_directory(tmp_path):
     assert workspace is None
 
 
+EXPECTED_ICS55_DEFAULT_SDC = """\
+# Auto-generated SDC file
+
+set clk_name          clk
+set clk_port_name     clk
+set clk_freq_mhz      100
+set clk_period        [expr 1000.0 / $clk_freq_mhz]
+set clk_io_pct        0.2
+
+# -------------------------------------------------
+# Clock definition
+# -------------------------------------------------
+set clk_port [get_ports $clk_port_name]
+create_clock -name $clk_name -period $clk_period $clk_port
+
+# -------------------------------------------------
+# IO Delay
+# -------------------------------------------------
+set clk_input          [get_ports $clk_port_name]
+set all_inputs_wo_clk  [remove_from_collection [all_inputs] $clk_input]
+
+set_input_delay  0  -clock [get_clocks $clk_name] $all_inputs_wo_clk
+set_output_delay 0 -clock [get_clocks $clk_name] [all_outputs]
+
+# -------------------------------------------------
+# Output load (pF) - ics55 pdk
+# -------------------------------------------------
+set_load 0.001 [all_outputs]
+
+# -------------------------------------------------
+# Clock uncertainty & transition
+# -------------------------------------------------
+set clk_uncertainty   [expr $clk_period * 0.05]                 ;# 5% of period
+set clk_transition    [expr min(0.15, $clk_period * 0.03)]      ;# 3%, cap 0.15ns
+set input_transition  [expr min(0.20, $clk_period * 0.05)]      ;# 5%, cap 0.20ns
+
+set_clock_uncertainty $clk_uncertainty  [get_clocks $clk_name]
+set_clock_transition  $clk_transition   [get_clocks $clk_name]
+set_input_transition  $input_transition $all_inputs_wo_clk
+
+# -------------------------------------------------
+# Design-level constraints
+# -------------------------------------------------
+set_max_fanout 32 [current_design]
+"""
+
+
+def test_create_workspace_generates_default_sdc_from_parameters(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk="ics55",
+        parameters={**default_ics55_parameters, "max_fanout": 32},
+        pdk_root=str(pdk_root),
+    )
+
+    sdc_path = workspace_dir / "origin" / "gcd.sdc"
+    assert sdc_path.read_text() == EXPECTED_ICS55_DEFAULT_SDC
+
+
 def test_create_workspace_persists_dynamic_flow_steps(
     tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
 ):
@@ -1028,7 +1096,7 @@ def test_refresh_workspace_config_updates_generated_sdc_frequency(
 
     refresh_workspace_config(workspace)
 
-    assert "set clk_freq_mhz 250.0" in workspace.pdk.sdc.read_text(encoding="utf-8")
+    assert "set clk_freq_mhz      250.0" in workspace.pdk.sdc.read_text(encoding="utf-8")
 
 
 def test_refresh_workspace_config_preserves_external_sdc(

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -226,6 +226,71 @@ def test_create_workspace_generates_default_sdc_from_parameters(
     assert sdc_path.read_text() == EXPECTED_ICS55_DEFAULT_SDC
 
 
+EXPECTED_ICS55_VIRTUAL_CLOCK_SDC = """\
+# Auto-generated SDC file
+
+set clk_name          __VIRTUAL_CLK__
+set clk_freq_mhz      100
+set clk_period        [expr 1000.0 / $clk_freq_mhz]
+set clk_io_pct        0.2
+
+# -------------------------------------------------
+# Clock definition
+# -------------------------------------------------
+create_clock -name $clk_name -period $clk_period
+
+# -------------------------------------------------
+# IO Delay
+# -------------------------------------------------
+set all_inputs_wo_clk  [all_inputs]
+
+set_input_delay  0  -clock [get_clocks $clk_name] $all_inputs_wo_clk
+set_output_delay 0 -clock [get_clocks $clk_name] [all_outputs]
+
+# -------------------------------------------------
+# Output load (pF) - ics55 pdk
+# -------------------------------------------------
+set_load 0.001 [all_outputs]
+
+# -------------------------------------------------
+# Clock uncertainty & transition
+# -------------------------------------------------
+set clk_uncertainty   [expr $clk_period * 0.05]                 ;# 5% of period
+set clk_transition    [expr min(0.15, $clk_period * 0.03)]      ;# 3%, cap 0.15ns
+set input_transition  [expr min(0.20, $clk_period * 0.05)]      ;# 5%, cap 0.20ns
+
+set_clock_uncertainty $clk_uncertainty  [get_clocks $clk_name]
+set_clock_transition  $clk_transition   [get_clocks $clk_name]
+set_input_transition  $input_transition $all_inputs_wo_clk
+
+# -------------------------------------------------
+# Design-level constraints
+# -------------------------------------------------
+set_max_fanout 20 [current_design]
+"""
+
+
+def test_create_workspace_generates_virtual_clock_sdc_for_clockless_design(
+    tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
+):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    rtl_path = tmp_path / "gcd.v"
+    rtl_path.write_text("module gcd(input clk, output y); assign y = clk; endmodule\n")
+
+    workspace_dir = tmp_path / "workspace"
+    create_workspace(
+        directory=str(workspace_dir),
+        origin_def="",
+        origin_verilog=str(rtl_path),
+        pdk="ics55",
+        parameters={**default_ics55_parameters, "clock": ""},
+        pdk_root=str(pdk_root),
+    )
+
+    sdc_path = workspace_dir / "origin" / "gcd.sdc"
+    assert sdc_path.read_text() == EXPECTED_ICS55_VIRTUAL_CLOCK_SDC
+
+
 def test_create_workspace_persists_dynamic_flow_steps(
     tmp_path, minimal_ics55_pdk_factory, default_ics55_parameters
 ):

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -165,7 +165,6 @@ set clk_name          clk
 set clk_port_name     clk
 set clk_freq_mhz      100
 set clk_period        [expr 1000.0 / $clk_freq_mhz]
-set clk_io_pct        0.2
 
 # -------------------------------------------------
 # Clock definition
@@ -232,7 +231,6 @@ EXPECTED_ICS55_VIRTUAL_CLOCK_SDC = """\
 set clk_name          __VIRTUAL_CLK__
 set clk_freq_mhz      100
 set clk_period        [expr 1000.0 / $clk_freq_mhz]
-set clk_io_pct        0.2
 
 # -------------------------------------------------
 # Clock definition


### PR DESCRIPTION
Rewrite create_default_sdc as a template that adds IO delay, clock uncertainty/transition and max-fanout constraints on top of the clock definition. Clock name/port, frequency and max fanout come from workspace parameters; the new PDK field sdc_load (set to 0.001 for ics55, also readable from external pdk.json) gates the optional set_load section.

## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
