### PR TITLE
feat: update subflow and add synthesis output for signoff package

### DIFF
--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -475,6 +475,9 @@ class EngineFlow:
             daemon=True,
         )
         memory_monitor.start()
+        previous_observer = getattr(self.workspace, "_runtime_flow_observer", None)
+        if observer is not None:
+            self.workspace._runtime_flow_observer = observer
         try:
             from chipcompiler.tools import run_step as run_tool_step
 
@@ -488,6 +491,11 @@ class EngineFlow:
         finally:
             stop_memory_monitor.set()
             memory_monitor.join()
+            if observer is not None:
+                if previous_observer is None:
+                    delattr(self.workspace, "_runtime_flow_observer")
+                else:
+                    self.workspace._runtime_flow_observer = previous_observer
 
         # compute metrics
         peak_memory_mb = peak_memory[0] - start_memory_mb

--- a/chipcompiler/engine/signoff.py
+++ b/chipcompiler/engine/signoff.py
@@ -353,6 +353,14 @@ class SignoffPackageCollector:
             required=True,
         )
 
+        synthesis_verilog = self._synthesis_output_verilog()
+        add_file(
+            role="synthesis.verilog",
+            source=synthesis_verilog,
+            destination=f"synthesis/{design}.v.gz",
+            required=True,
+        )
+
         add_file(
             role="final.design.verilog",
             source=workspace_dir / "filler_ecc" / "output" / f"{design}_filler.v.gz",
@@ -548,6 +556,7 @@ class SignoffPackageCollector:
                 "sdc": f"initial/{design}.sdc",
                 "parameters": "initial/parameters.json",
             },
+            "synthesis": {"verilog": f"synthesis/{design}.v.gz"},
             "config": "config/",
             "harden": {
                 "gds": f"harden/{design}.gds",
@@ -596,6 +605,7 @@ class SignoffPackageCollector:
                 f"# {design} Signoff Package\n\n"
                 f"- Workspace: {workspace_dir.resolve()}\n"
                 f"- Status: {summary['status']}\n"
+                "- Mapped synthesis netlist is under `synthesis/`.\n"
                 "- Harden outputs are under `harden/`.\n"
                 "- Final physical resources are under `final/`.\n"
             )
@@ -835,6 +845,16 @@ class SignoffPackageCollector:
                 if name.endswith(suffix):
                     return name[: -len(suffix)]
         return ""
+
+    def _synthesis_output_verilog(self) -> Path | None:
+        """Resolve the netlist from the Yosys step's declared output contract."""
+        synthesis_step = self._build_workspace_step(
+            {"name": StepEnum.SYNTHESIS.value, "tool": "yosys"},
+            previous_step=None,
+        )
+        output = getattr(synthesis_step, "output", None)
+        verilog = getattr(output, "verilog", None)
+        return Path(verilog) if verilog else None
 
     def _required_step_states(self, flow_data: dict) -> dict:
         required = [

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -397,6 +397,31 @@ class RuntimeOperationManager:
                     operation.state = "waiting_for_gui_sync"
         self._publish(event)
 
+    def subflow_stage(
+        self,
+        operation_id: str,
+        workspace_step: Any,
+        subflow_step: dict[str, Any],
+    ) -> None:
+        """Publish a saved inner-flow state without waiting for a render ACK."""
+        with self._lock:
+            operation = self._operations[operation_id]
+            step = str(getattr(workspace_step, "name", ""))
+            tool = str(getattr(workspace_step, "tool", ""))
+            event = self._new_event_locked(
+                operation,
+                "subflow.stage",
+                {
+                    "peakMemory": subflow_step.get("peak memory (mb)", 0),
+                    "runtime": str(subflow_step.get("runtime", "")),
+                    "state": str(subflow_step.get("state", "Unstart")),
+                    "step": step,
+                    "subflowStep": str(subflow_step.get("name", "")),
+                    "tool": tool,
+                },
+            )
+        self._publish(event)
+
     def step_skipped(self, operation_id: str, workspace_step: Any) -> None:
         self._stop_step_log_tail(operation_id)
         with self._lock:
@@ -627,6 +652,9 @@ class RuntimeFlowObserver:
 
     def on_step_completed(self, workspace_step: Any, state: Any) -> None:
         self._manager.step_completed(self._operation_id, workspace_step, state)
+
+    def on_subflow_stage(self, workspace_step: Any, subflow_step: dict[str, Any]) -> None:
+        self._manager.subflow_stage(self._operation_id, workspace_step, subflow_step)
 
     def on_step_skipped(self, workspace_step: Any) -> None:
         self._manager.step_skipped(self._operation_id, workspace_step)

--- a/chipcompiler/runtime/subflow_events.py
+++ b/chipcompiler/runtime/subflow_events.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def publish_subflow_stage(
+    workspace: Any,
+    workspace_step: Any,
+    subflow_step: dict[str, Any],
+) -> None:
+    """Forward a saved inner-flow transition to the optional GUI observer.
+
+    Tool implementations run below the engine layer, so the observer is stored
+    only for the duration of one EngineFlow.run_step invocation. Keeping this
+    bridge optional preserves CLI execution and tool failure semantics.
+    """
+
+    observer = getattr(workspace, "_runtime_flow_observer", None)
+    callback = getattr(observer, "on_subflow_stage", None)
+    if not callable(callback):
+        return
+    try:
+        callback(workspace_step, dict(subflow_step))
+    except Exception:
+        # GUI event delivery must not affect an EDA tool's result.
+        return

--- a/chipcompiler/tools/ecc/subflow.py
+++ b/chipcompiler/tools/ecc/subflow.py
@@ -212,6 +212,10 @@ class EccSubFlow:
 
                 self.save()
 
+                from chipcompiler.runtime.subflow_events import publish_subflow_stage
+
+                publish_subflow_stage(self.workspace, self.workspace_step, step_dict)
+
                 # update home page monitor
                 self.workspace.home.update_monitor(
                     step=self.workspace_step.name,

--- a/chipcompiler/tools/ecc_sizer/subflow.py
+++ b/chipcompiler/tools/ecc_sizer/subflow.py
@@ -101,6 +101,10 @@ class SizerSubFlow:
                 step_dict["info"] = info
                 self.save()
 
+                from chipcompiler.runtime.subflow_events import publish_subflow_stage
+
+                publish_subflow_stage(self.workspace, self.workspace_step, step_dict)
+
                 self.workspace.home.update_monitor(
                     step=self.workspace_step.name,
                     sub_step=step_name,

--- a/chipcompiler/tools/yosys/subflow.py
+++ b/chipcompiler/tools/yosys/subflow.py
@@ -109,6 +109,10 @@ class YosysSubFlow:
 
                 self.save()
 
+                from chipcompiler.runtime.subflow_events import publish_subflow_stage
+
+                publish_subflow_stage(self.workspace, self.workspace_step, step_dict)
+
                 # update home page monitor
                 self.workspace.home.update_monitor(
                     step=self.workspace_step.name,

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -60,6 +60,50 @@ def test_successful_step_waits_for_matching_render_ack_before_completing():
     assert events[-1]["type"] == "operation.completed"
 
 
+def test_subflow_stage_is_emitted_for_the_active_workspace_step():
+    events = []
+    released = threading.Event()
+    manager = RuntimeOperationManager(events.append)
+    step = SimpleNamespace(name="Floorplan", tool="ecc", log=SimpleNamespace(file=""))
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_subflow_stage(
+            step,
+            {
+                "name": "init floorplan",
+                "state": "Ongoing",
+                "runtime": "0:0:1",
+                "peak memory (mb)": 12.5,
+            },
+        )
+        assert released.wait(timeout=1)
+        return {"rerun": False}
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=True,
+        step="Floorplan",
+        idempotency_key="subflow-stage",
+        runner=runner,
+    )
+
+    event = _wait_for_event(events, "subflow.stage")
+    assert event["operationId"] == started["operationId"]
+    assert event["payload"] == {
+        "peakMemory": 12.5,
+        "runtime": "0:0:1",
+        "state": "Ongoing",
+        "step": "Floorplan",
+        "subflowStep": "init floorplan",
+        "tool": "ecc",
+    }
+    released.set()
+    assert _wait_for_terminal(manager, started["operationId"])["state"] == "succeeded"
+
+
 def test_render_ack_replays_one_commit_then_pauses_before_a_bounded_timeout(monkeypatch):
     monkeypatch.setattr(operations, "_RENDER_ACK_RETRY_SECONDS", 0.01)
     monkeypatch.setattr(operations, "_RENDER_ACK_PAUSE_SECONDS", 0.02)

--- a/test/test_signoff_package.py
+++ b/test/test_signoff_package.py
@@ -87,6 +87,7 @@ def _make_signoff_workspace(
     _write(workspace_dir / "Harden_ecc" / "output" / f"{design}_Harden.gds")
     _write(workspace_dir / "Harden_ecc" / "output" / f"{design}_Harden.lef")
     _write(workspace_dir / "Harden_ecc" / "output" / f"{design}_Harden.lib")
+    _write(workspace_dir / "Synthesis_yosys" / "output" / f"{design}_Synthesis.v.gz")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.v.gz")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.def.gz")
     _write(workspace_dir / "filler_ecc" / "output" / f"{design}_filler.gds")
@@ -187,6 +188,7 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
 
     package_dir = Path(result.package_dir)
     assert result.ok is True
+    assert (package_dir / "synthesis" / "gcd.v.gz").is_file()
     assert (package_dir / "final" / "design" / "gcd.v.gz").is_file()
     assert (package_dir / "final" / "design" / "gcd.def.gz").is_file()
     assert (package_dir / "final" / "design" / "gcd.gds").is_file()
@@ -198,6 +200,7 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
 
     summary = json.loads((package_dir / "summary.json").read_text())
     assert summary["initial"]["verilog"] == "initial/gcd.v"
+    assert summary["synthesis"]["verilog"] == "synthesis/gcd.v.gz"
     assert summary["final"]["verilog"] == "final/design/gcd.v.gz"
     assert summary["qor_metrics"]["schema_version"] == 3
     assert (
@@ -213,6 +216,9 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
 
     manifest = json.loads((package_dir / "manifest.json").read_text())
     destinations = {item["destination"] for item in manifest["files"]}
+    assert "synthesis/gcd.v.gz" in destinations
+    roles = {item["destination"]: item["role"] for item in manifest["files"]}
+    assert roles["synthesis/gcd.v.gz"] == "synthesis.verilog"
     assert "final/design/gcd.def.gz" in destinations
     assert "final/reports/route/analysis/qor_metrics.json" in destinations
     assert {
@@ -223,6 +229,25 @@ def test_collect_signoff_package_uses_final_design_layout(tmp_path):
         "final/timing/sta/MAX_125/RCworst/feature/timing_paths.json",
     }.issubset(destinations)
     assert all(".tsv" not in destination for destination in destinations)
+
+
+def test_collect_signoff_package_requires_synthesis_verilog(tmp_path):
+    workspace_dir = _make_signoff_workspace(tmp_path)
+    (workspace_dir / "Synthesis_yosys" / "output" / "gcd_Synthesis.v.gz").unlink()
+
+    result = _make_engine_flow(workspace_dir).collect_signoff_package(
+        SignoffPackageOptions(archive=False, materialize=False)
+    )
+
+    assert result.ok is False
+    assert "package.synthesis.gcd.v.gz" in result.missing_required
+    assert any(
+        issue.label == "synthesis.verilog"
+        and issue.location == "Synthesis_yosys/output/gcd_Synthesis.v.gz"
+        and issue.destination == "synthesis/gcd.v.gz"
+        and issue.required
+        for issue in result.issues
+    )
 
 
 def test_collect_signoff_package_tolerates_missing_sta_power_report(tmp_path):


### PR DESCRIPTION
## What Changed

- Update subflow and add synthesis output for signoff package

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
