### PR TITLE
feat: resolve PDK-content override paths against pdk.root

### DIFF
--- a/chipcompiler/cli/project/config.py
+++ b/chipcompiler/cli/project/config.py
@@ -302,20 +302,23 @@ def _resolve_pdk_root(cfg: ProjectConfig) -> str:
 
 
 def resolve_pdk_overrides(cfg: ProjectConfig) -> dict[str, object]:
-    """Return pdk_overrides with path-field values resolved against the project dir.
+    """Return pdk_overrides with path-field values resolved to absolute paths.
 
-    Only fields the PDK dataclass declares as paths are rewritten; non-path
+    PDK-content paths (PDK_CONTENT_PATH_FIELDS) resolve against the PDK root;
+    design-data paths (sdc/spef) resolve against the project dir. Non-path
     values such as dont_use glob patterns pass through untouched.
     """
-    from chipcompiler.data.pdk import PATH_LIST_FIELDS, PATH_SCALAR_FIELDS
+    from chipcompiler.data.pdk import PATH_LIST_FIELDS, PATH_SCALAR_FIELDS, PDK_CONTENT_PATH_FIELDS
 
     resolved = dict(cfg.pdk_overrides)
+    pdk_root = _resolve_pdk_root(cfg)
     for key, value in resolved.items():
+        base = pdk_root if key in PDK_CONTENT_PATH_FIELDS else cfg.project_dir
         if key in PATH_SCALAR_FIELDS and isinstance(value, str):
-            resolved[key] = _resolve_path(cfg.project_dir, value)
+            resolved[key] = _resolve_path(base, value)
         elif key in PATH_LIST_FIELDS and isinstance(value, list):
             resolved[key] = [
-                _resolve_path(cfg.project_dir, element) if isinstance(element, str) else element
+                _resolve_path(base, element) if isinstance(element, str) else element
                 for element in value
             ]
     return resolved
@@ -340,7 +343,9 @@ def _pdk_root_from_env() -> str:
         val = os.environ.get(key, "").strip()
         if not val:
             continue
-        val = os.path.normpath(val)
+        # Absolute: the value becomes the join base for serialized override
+        # paths consumed from step working directories.
+        val = os.path.abspath(val)
         if os.path.isdir(val):
             return val
     return ""

--- a/chipcompiler/data/pdk.py
+++ b/chipcompiler/data/pdk.py
@@ -92,6 +92,11 @@ PATH_SCALAR_FIELDS = {f.name for f in fields(PDK) if f.type == Path | None}
 PATH_LIST_FIELDS = {f.name for f in fields(PDK) if f.type == list[Path]}
 STRING_LIST_FIELDS = {f.name for f in fields(PDK) if f.type == list[str]}
 
+# Path fields holding PDK content: relative override values resolve against
+# the PDK root. sdc/spef are design data and stay project-relative; root is
+# the resolution anchor itself.
+PDK_CONTENT_PATH_FIELDS = {"tech", "lefs", "libs", "mapping_file"}
+
 # Optional path fields not covered by PDK.validate() (which only checks the
 # always-required root/tech/lefs/libs). When one of these is set through an
 # override, get_pdk checks its existence so a bad configured path fails before
@@ -122,7 +127,9 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
         return pdk
 
     all_fields = {f.name for f in fields(PDK)}
-    overridable = sorted(all_fields - _PROTECTED_FIELDS)
+    # root is rejected below with its own guidance; keep it out of the
+    # advertised set so the error matches the actual contract.
+    overridable = sorted(all_fields - _PROTECTED_FIELDS - {"root"})
     unknown = sorted(set(overrides) - all_fields)
 
     if unknown:
@@ -136,6 +143,12 @@ def apply_pdk_overrides(pdk: PDK, overrides: dict) -> PDK:
             f"PDK override fields {protected} cannot be overridden; "
             "use the appropriate built-in PDK name instead"
         )
+
+    # root names the tree every other path field is resolved against; letting
+    # an override retarget it after PDK construction would mix default content
+    # paths from one tree with a root pointing at another.
+    if "root" in overrides:
+        raise ValueError("PDK override 'root' cannot be overridden; set pdk.root in [pdk] instead")
 
     for key, value in overrides.items():
         default = getattr(_DEFAULT_PDK, key)

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -527,7 +527,7 @@ The override delta reaches the Yosys builder and other tool steps within a singl
   the in-memory PDK — exactly like the base PDK's own `corners`.
 
 - **`root`**: Written to `parameters.json` as `PDK Root` and re-read by `load_workspace`.
-  Overriding `root` is redundant with `pdk.root` in `[pdk]`; use `pdk.root` instead.
+  `root` cannot be overridden; set `pdk.root` in `[pdk]` instead.
 
 - **Path fields** (`tech`, `lefs`, `libs`): Written to `db.json` at build time and
   restored by `load_workspace`. Path overrides survive through `db.json`, not through
@@ -544,14 +544,17 @@ The primary use case is tuning cell lists (`dont_use`) and synthesis parameters
 (`abc_load`), which are scalar/list fields consumed within a run.
 
 Overrides are validated at `ecc check` time — unknown keys, type mismatches, and
-path-existence failures are caught before any run begins. Path values in overrides
-resolve against the project directory (like `pdk.root` and `design.rtl`), and the
-resolved paths are what `ecc run` forwards to workspace creation. Path-existence is
-checked for every path field an override sets: the required `tech`, `lefs`, and `libs`
-(checked for every PDK by `PDK.validate()`) and the optional `mapping_file`, `sdc`,
-and `spef` (checked only when an override supplies them). A non-empty value pointing
-at a missing file fails `ecc check` regardless of whether that field is later
-persisted or regenerated.
+path-existence failures are caught before any run begins. Relative path values in
+overrides resolve by field semantics: PDK-content paths (`tech`, `lefs`, `libs`,
+`mapping_file`) resolve against the PDK root, while design-data paths (`sdc`,
+`spef`) resolve against the project directory (like `pdk.root` and `design.rtl`).
+The resolved paths are what `ecc run` forwards to
+workspace creation. Path-existence is checked for every path field an override
+sets: the required `tech`, `lefs`, and `libs` (checked for every PDK by
+`PDK.validate()`) and the optional `mapping_file`, `sdc`, and `spef` (checked only
+when an override supplies them). A non-empty value pointing at a missing file
+fails `ecc check` regardless of whether that field is later persisted or
+regenerated.
 `ecc config --resolved` surfaces the raw `[pdk.overrides]` input as a project
 configuration entry.
 

--- a/test/cli/commands/test_check.py
+++ b/test/cli/commands/test_check.py
@@ -376,6 +376,55 @@ class TestMissingConfigErrorRecord:
         assert "PDK SDC file not found" in out
         assert os.path.join(project_dir, "constraints", "missing.sdc") in out
 
+    def test_check_pdk_overrides_relative_paths_resolve_against_pdk_root(
+        self, tmp_path, create_cli_project, minimal_ics55_pdk_factory
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write(
+                "\n[pdk.overrides]\n"
+                'tech = "prtech/techLEF/N551P6M_ecos.lef"\n'
+                'lefs = ["IP/STD_cell/ics55_LLSC_H7C_V1p10C100/ics55_LLSC_H7CR'
+                '/lef/ics55_LLSC_H7CR_ecos.lef"]\n'
+                'libs = ["IP/STD_cell/ics55_LLSC_H7C_V1p10C100/ics55_LLSC_H7CR'
+                '/liberty/ics55_LLSC_H7CR_ss_rcworst_1p08_125_nldm.lib"]\n'
+            )
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        assert rc == 0
+
+    def test_check_pdk_overrides_missing_relative_lef_reports_pdk_root_resolved_path(
+        self, tmp_path, create_cli_project, minimal_ics55_pdk_factory, capsys
+    ):
+        pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+        project_dir = create_cli_project(pdk_root=str(pdk_root))
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nlefs = ["IP/STD_cell/missing.lef"]\n')
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "PDK LEF not found" in out
+        assert os.path.join(str(pdk_root), "IP", "STD_cell", "missing.lef") in out
+
+    def test_check_pdk_overrides_root_rejected(self, tmp_path, create_cli_project, capsys):
+        project_dir = create_cli_project()
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nroot = "/some/other/pdk"\n')
+
+        rc = cli_main.run(["check", "--project", project_dir])
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "'root'" in out
+        assert "cannot be overridden" in out
+
     @pytest.mark.parametrize("field", ["lefs", "dont_use"])
     def test_check_pdk_overrides_non_string_list_element(
         self, tmp_path, create_cli_project, capsys, field

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -200,6 +200,7 @@ class TestRunFlowPreset:
             f.write(
                 "\n[pdk.overrides]\n"
                 'sdc = "constraints/design.sdc"\n'
+                'lefs = ["IP/STD_cell/x.lef"]\n'
                 f'spef = "{tmp_path}/absolute.spef"\n'
                 'dont_use = ["ICG*"]\n'
             )
@@ -211,8 +212,29 @@ class TestRunFlowPreset:
         assert create_kwargs is not None
         assert create_kwargs["pdk_overrides"] == {
             "sdc": os.path.join(project_dir, "constraints", "design.sdc"),
+            "lefs": [os.path.join(str(tmp_path / "ics55"), "IP", "STD_cell", "x.lef")],
             "spef": str(tmp_path / "absolute.spef"),
             "dont_use": ["ICG*"],
+        }
+
+    def test_run_forwards_absolute_paths_with_relative_env_pdk_root(
+        self, tmp_path, monkeypatch, create_cli_project, flow_mocks
+    ):
+        project_dir = create_cli_project(pdk_root="")
+        (tmp_path / "ics55").mkdir(exist_ok=True)
+        toml_path = os.path.join(project_dir, "ecc.toml")
+        with open(toml_path, "a") as f:
+            f.write('\n[pdk.overrides]\nlefs = ["IP/STD_cell/x.lef"]\n')
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("CHIPCOMPILER_ICS55_PDK_ROOT", "ics55")
+
+        rc = cli_main.run(["run", "--project", project_dir])
+
+        assert rc == 0
+        create_kwargs = flow_mocks.capture["create_kwargs"]
+        assert create_kwargs is not None
+        assert create_kwargs["pdk_overrides"] == {
+            "lefs": [os.path.join(str(tmp_path / "ics55"), "IP", "STD_cell", "x.lef")],
         }
 
 

--- a/test/data/test_pdk.py
+++ b/test/data/test_pdk.py
@@ -177,6 +177,7 @@ def test_apply_pdk_overrides_unknown_key_raises(tmp_path, minimal_ics55_pdk_fact
         "version" not in error_msg
         or "version" not in error_msg.split("valid overridable fields:")[-1]
     )
+    assert "root" not in error_msg.split("valid overridable fields:")[-1]
 
 
 def test_apply_pdk_overrides_type_mismatch_list_field(tmp_path, minimal_ics55_pdk_factory):
@@ -223,6 +224,14 @@ def test_apply_pdk_overrides_version_rejected(tmp_path, minimal_ics55_pdk_factor
 
     with pytest.raises(ValueError, match="'version'.*cannot be overridden"):
         apply_pdk_overrides(base_pdk, {"version": "custom"})
+
+
+def test_apply_pdk_overrides_root_rejected(tmp_path, minimal_ics55_pdk_factory):
+    pdk_root = minimal_ics55_pdk_factory(tmp_path / "ics55")
+    base_pdk = get_pdk("ics55", pdk_root=pdk_root)
+
+    with pytest.raises(ValueError, match="'root'.*cannot be overridden"):
+        apply_pdk_overrides(base_pdk, {"root": "/other/pdk"})
 
 
 def test_get_pdk_with_overrides(tmp_path, minimal_ics55_pdk_factory):


### PR DESCRIPTION
## What Changed

- Fix #215 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
