### PR TITLE
fix: detect slang frontend as builtin or plugin for yosys

### DIFF
--- a/chipcompiler/tools/yosys/runner.py
+++ b/chipcompiler/tools/yosys/runner.py
@@ -6,7 +6,7 @@ from chipcompiler.data import StateEnum, Workspace, YosysStep
 from chipcompiler.tools.yosys.checklist import YosysChecklist
 from chipcompiler.tools.yosys.metrics import build_step_metrics
 from chipcompiler.tools.yosys.subflow import YosysSubFlow
-from chipcompiler.tools.yosys.utility import check_slang_plugin, get_yosys_runtime
+from chipcompiler.tools.yosys.utility import check_slang_support, get_yosys_runtime
 
 
 def _run_ecc_synthesis_sta(workspace: Workspace, step: YosysStep, ecc_module=None) -> bool:
@@ -75,7 +75,7 @@ def run_step(workspace: Workspace, step: YosysStep, ecc_module=None) -> bool:
 
         with open(log_path, "w") as log_file:
             step_data = getattr(step, "data", None)
-            if getattr(step_data, "requires_slang", True) and not check_slang_plugin(
+            if getattr(step_data, "requires_slang", True) and not check_slang_support(
                 yosys_cmd=yosys_cmd,
                 cwd_dir=cwd_dir,
                 yosys_env=yosys_env,

--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -366,7 +366,8 @@ log "\[INFO\]: ABC script: $strategy_script"
 
 # Use Slang only for input forms that require its filelist/SystemVerilog support.
 if {$use_slang} {
-  # Newer yosys builds provide slang as a builtin frontend; older builds
+  # yosys v0.67+ enables the slang frontend by default
+  # (https://github.com/YosysHQ/yosys/releases/tag/v0.67); older builds
   # ship it as a plugin that must be loaded explicitly.
   if {[llength [info commands read_slang]] == 0} {
     yosys plugin -i slang

--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -366,7 +366,11 @@ log "\[INFO\]: ABC script: $strategy_script"
 
 # Use Slang only for input forms that require its filelist/SystemVerilog support.
 if {$use_slang} {
-  yosys plugin -i slang
+  # Newer yosys builds provide slang as a builtin frontend; older builds
+  # ship it as a plugin that must be loaded explicitly.
+  if {[llength [info commands read_slang]] == 0} {
+    yosys plugin -i slang
+  }
 
   # Check if FILELIST is set and non-empty, prioritize it over individual Verilog files
   if {[info exists filelist] && $filelist ne ""} {

--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -375,10 +375,10 @@ if {$use_slang} {
   # Check if FILELIST is set and non-empty, prioritize it over individual Verilog files
   if {[info exists filelist] && $filelist ne ""} {
     puts "Reading SystemVerilog sources from filelist: $filelist"
-    set arg "-F $filelist"
+    set arg [list -F $filelist]
   } else {
     puts "Reading SystemVerilog sources from rtl files: $rtl_file"
-    set arg "{*}$rtl_file"
+    set arg $rtl_file
   }
   yosys read_slang {*}$arg --top $top_design \
     --compat-mode --keep-hierarchy \

--- a/chipcompiler/tools/yosys/utility.py
+++ b/chipcompiler/tools/yosys/utility.py
@@ -114,8 +114,9 @@ def check_slang_support(
     """
     Run a lightweight slang frontend availability check.
 
-    Newer yosys builds provide slang as a builtin frontend, older builds ship
-    it as a plugin loaded via `plugin -i slang`. Accept either form.
+    Since v0.67 yosys enables the slang frontend by default
+    (https://github.com/YosysHQ/yosys/releases/tag/v0.67); older builds
+    ship it as a plugin loaded via `plugin -i slang`. Accept either form.
     """
     # `help` exits 0 even for unknown commands, so inspect the output text.
     builtin_check = subprocess.run(

--- a/chipcompiler/tools/yosys/utility.py
+++ b/chipcompiler/tools/yosys/utility.py
@@ -108,27 +108,42 @@ def get_yosys_runtime() -> tuple[list[str], dict[str, str]]:
     return command, env
 
 
-def check_slang_plugin(
+def check_slang_support(
     yosys_cmd: list[str], cwd_dir: str, yosys_env: dict[str, str], log_file, timeout: int = 60
 ) -> bool:
     """
-    Run a lightweight slang plugin availability check.
+    Run a lightweight slang frontend availability check.
+
+    Newer yosys builds provide slang as a builtin frontend, older builds ship
+    it as a plugin loaded via `plugin -i slang`. Accept either form.
     """
-    slang_check_cmd = yosys_cmd + ["-p", "plugin -i slang"]
-    slang_check_result = subprocess.run(
-        slang_check_cmd,
+    # `help` exits 0 even for unknown commands, so inspect the output text.
+    builtin_check = subprocess.run(
+        yosys_cmd + ["-Q", "-T", "-p", "help read_slang"],
+        cwd=cwd_dir,
+        env=yosys_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout,
+    )
+    if builtin_check.returncode == 0 and b"No such command" not in builtin_check.stdout:
+        return True
+
+    plugin_check = subprocess.run(
+        yosys_cmd + ["-Q", "-T", "-p", "plugin -i slang"],
         cwd=cwd_dir,
         env=yosys_env,
         stdout=log_file,
         stderr=subprocess.STDOUT,
         timeout=timeout,
     )
-    if slang_check_result.returncode == 0:
+    if plugin_check.returncode == 0:
         return True
 
     error_msg = (
-        "Error: yosys slang plugin check failed. "
-        "Please use a yosys build with slang plugin support."
+        "Error: yosys slang frontend check failed. "
+        "Neither builtin read_slang nor a loadable slang plugin was found. "
+        "Please use a yosys build with slang support."
     )
     log_file.write(error_msg + "\n")
     print(error_msg)

--- a/test/tools/yosys/test_runner.py
+++ b/test/tools/yosys/test_runner.py
@@ -48,7 +48,7 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
         def check(self):
             return None
 
-    def fake_check_slang_plugin(yosys_cmd, cwd_dir, yosys_env, log_file):
+    def fake_check_slang_support(yosys_cmd, cwd_dir, yosys_env, log_file):
         check_calls.append(
             {
                 "yosys_cmd": list(yosys_cmd),
@@ -75,7 +75,7 @@ def test_run_step_uses_local_env_and_runs_synthesis(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "YosysChecklist", FakeChecklist)
     monkeypatch.setattr(runner, "build_step_metrics", lambda workspace, step: None)
     monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], runtime_env))
-    monkeypatch.setattr(runner, "check_slang_plugin", fake_check_slang_plugin)
+    monkeypatch.setattr(runner, "check_slang_support", fake_check_slang_support)
     monkeypatch.setattr(runner.subprocess, "run", fake_run)
     sta_calls = []
     monkeypatch.setattr(
@@ -126,7 +126,7 @@ def test_run_step_keeps_synthesis_success_when_sta_report_fails(tmp_path, monkey
     monkeypatch.setattr(runner, "YosysChecklist", FakeChecklist)
     monkeypatch.setattr(runner, "build_step_metrics", lambda workspace, step: None)
     monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], {"PATH": "/tmp"}))
-    monkeypatch.setattr(runner, "check_slang_plugin", lambda *args, **kwargs: True)
+    monkeypatch.setattr(runner, "check_slang_support", lambda *args, **kwargs: True)
     monkeypatch.setattr(runner.subprocess, "run", fake_run)
     monkeypatch.setattr(runner, "_run_ecc_synthesis_sta", lambda **kwargs: False)
 
@@ -147,8 +147,8 @@ def test_run_step_marks_invalid_when_slang_check_fails(tmp_path, monkeypatch):
         def update_step(self, step_name, state, runtime="", memory=0, info=None):
             updates.append((step_name, state))
 
-    def fake_check_slang_plugin(yosys_cmd, cwd_dir, yosys_env, log_file):
-        log_file.write("Error: yosys slang plugin check failed.\n")
+    def fake_check_slang_support(yosys_cmd, cwd_dir, yosys_env, log_file):
+        log_file.write("Error: yosys slang frontend check failed.\n")
         return False
 
     def fake_run(cmd, cwd, env, stdout, stderr):
@@ -158,7 +158,7 @@ def test_run_step_marks_invalid_when_slang_check_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "YosysSubFlow", FakeSubFlow)
     monkeypatch.setattr(runner, "build_step_metrics", lambda workspace, step: None)
     monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], {"PATH": "/tmp"}))
-    monkeypatch.setattr(runner, "check_slang_plugin", fake_check_slang_plugin)
+    monkeypatch.setattr(runner, "check_slang_support", fake_check_slang_support)
     monkeypatch.setattr(runner.subprocess, "run", fake_run)
 
     result = runner.run_step(workspace=workspace, step=step)
@@ -166,7 +166,7 @@ def test_run_step_marks_invalid_when_slang_check_fails(tmp_path, monkeypatch):
     assert result is False
     assert run_calls == []
     assert ("run yosys", StateEnum.Invalid) in updates
-    assert "slang plugin check failed" in log_file.read_text()
+    assert "slang frontend check failed" in log_file.read_text()
 
 
 def test_run_step_skips_slang_check_for_native_verilog(tmp_path, monkeypatch):
@@ -189,7 +189,7 @@ def test_run_step_skips_slang_check_for_native_verilog(tmp_path, monkeypatch):
             return None
 
     def fail_slang_check(*args, **kwargs):
-        raise AssertionError("native Verilog must not probe the Slang plugin")
+        raise AssertionError("native Verilog must not probe the Slang frontend")
 
     def fake_run(cmd, cwd, env, stdout, stderr):
         output_file.write_text("module top(); endmodule\n")
@@ -199,7 +199,7 @@ def test_run_step_skips_slang_check_for_native_verilog(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "YosysChecklist", FakeChecklist)
     monkeypatch.setattr(runner, "build_step_metrics", lambda workspace, step: None)
     monkeypatch.setattr(runner, "get_yosys_runtime", lambda: (["yosys"], {"PATH": "/tmp"}))
-    monkeypatch.setattr(runner, "check_slang_plugin", fail_slang_check)
+    monkeypatch.setattr(runner, "check_slang_support", fail_slang_check)
     monkeypatch.setattr(runner, "_run_ecc_synthesis_sta", lambda **kwargs: True)
     monkeypatch.setattr(runner.subprocess, "run", fake_run)
 

--- a/test/tools/yosys/test_utility.py
+++ b/test/tools/yosys/test_utility.py
@@ -66,7 +66,7 @@ def test_get_yosys_runtime_builds_local_env_without_mutating_global_env(tmp_path
     assert before == after
 
 
-def test_check_slang_plugin_executes_expected_command(tmp_path, monkeypatch):
+def test_check_slang_support_accepts_builtin_frontend(tmp_path, monkeypatch):
     log_path = tmp_path / "check.log"
     calls = []
 
@@ -79,11 +79,11 @@ def test_check_slang_plugin_executes_expected_command(tmp_path, monkeypatch):
                 "timeout": timeout,
             }
         )
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0, stdout=b"read_slang [options] [filename]")
 
     monkeypatch.setattr(utility.subprocess, "run", fake_run)
     with open(log_path, "w") as log_file:
-        ok = utility.check_slang_plugin(
+        ok = utility.check_slang_support(
             yosys_cmd=["yosys"],
             cwd_dir="/tmp/test",
             yosys_env={"PATH": "/tmp/bin"},
@@ -92,21 +92,49 @@ def test_check_slang_plugin_executes_expected_command(tmp_path, monkeypatch):
 
     assert ok is True
     assert len(calls) == 1
-    assert calls[0]["cmd"] == ["yosys", "-p", "plugin -i slang"]
+    assert calls[0]["cmd"] == ["yosys", "-Q", "-T", "-p", "help read_slang"]
     assert calls[0]["cwd"] == "/tmp/test"
     assert calls[0]["env"] == {"PATH": "/tmp/bin"}
     assert calls[0]["timeout"] == 60
 
 
-def test_check_slang_plugin_writes_error_on_failure(tmp_path, monkeypatch):
-    log_path = tmp_path / "check_fail.log"
+def test_check_slang_support_falls_back_to_plugin(tmp_path, monkeypatch):
+    log_path = tmp_path / "check.log"
+    calls = []
 
     def fake_run(cmd, cwd, env, stdout, stderr, timeout):
-        return SimpleNamespace(returncode=1)
+        calls.append(list(cmd))
+        if "help read_slang" in cmd:
+            return SimpleNamespace(returncode=0, stdout=b"No such command or cell type: read_slang")
+        return SimpleNamespace(returncode=0, stdout=b"")
 
     monkeypatch.setattr(utility.subprocess, "run", fake_run)
     with open(log_path, "w") as log_file:
-        ok = utility.check_slang_plugin(
+        ok = utility.check_slang_support(
+            yosys_cmd=["yosys"],
+            cwd_dir="/tmp/test",
+            yosys_env={"PATH": "/tmp/bin"},
+            log_file=log_file,
+        )
+
+    assert ok is True
+    assert calls == [
+        ["yosys", "-Q", "-T", "-p", "help read_slang"],
+        ["yosys", "-Q", "-T", "-p", "plugin -i slang"],
+    ]
+
+
+def test_check_slang_support_writes_error_on_failure(tmp_path, monkeypatch):
+    log_path = tmp_path / "check_fail.log"
+
+    def fake_run(cmd, cwd, env, stdout, stderr, timeout):
+        if "help read_slang" in cmd:
+            return SimpleNamespace(returncode=0, stdout=b"No such command or cell type: read_slang")
+        return SimpleNamespace(returncode=1, stdout=b"")
+
+    monkeypatch.setattr(utility.subprocess, "run", fake_run)
+    with open(log_path, "w") as log_file:
+        ok = utility.check_slang_support(
             yosys_cmd=["yosys"],
             cwd_dir="/tmp/test",
             yosys_env={"PATH": "/tmp/bin"},
@@ -114,4 +142,4 @@ def test_check_slang_plugin_writes_error_on_failure(tmp_path, monkeypatch):
         )
 
     assert ok is False
-    assert "slang plugin check failed" in log_path.read_text()
+    assert "slang frontend check failed" in log_path.read_text()


### PR DESCRIPTION
## What Changed

Newer yosys builds (e.g. 0.67) ship slang as a builtin frontend and no
longer provide the slang plugin, so both the run_step gate and the
synthesis script failed on them:

- check_slang_plugin only probed "plugin -i slang". Rename it to
  check_slang_support and probe the builtin frontend first via
  "help read_slang" (help exits 0 even for unknown commands, so the
  output text is what distinguishes them), falling back to the plugin
  load probe for older builds.
- yosys_synthesis.tcl loaded the plugin unconditionally. Skip the load
  when read_slang is already registered (info commands after
  yosys -import); older yosys builds still load the plugin, and a
  failed load aborts the script as before.

Verified against yosys 0.67 (builtin), the dev-shell 0.62 build with
slang compiled in, and a 0.62 build without slang (clean error).

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
