### PR TITLE
feat: add sta.max_paths param to control STA timing report path count

### DIFF
--- a/chipcompiler/cli/project/params.py
+++ b/chipcompiler/cli/project/params.py
@@ -165,6 +165,18 @@ PARAM_REGISTRY: tuple[ParamSchema, ...] = (
         choices=("MET2", "MET3", "MET4", "MET5", "MET6"),
         example="MET5",
     ),
+    ParamSchema(
+        param="sta.max_paths",
+        group="sta",
+        name="max_paths",
+        type="int",
+        default=1000,
+        applies="sta",
+        maps_to="STA max paths",
+        description="Maximum number of paths in each STA timing report",
+        range=(1, 100000),
+        example="1000",
+    ),
 )
 
 _REGISTRY_INDEX: dict[str, ParamSchema] = {s.param: s for s in PARAM_REGISTRY}

--- a/chipcompiler/data/parameter.py
+++ b/chipcompiler/data/parameter.py
@@ -27,6 +27,7 @@ ICS55_PARAMETERS_TEMPLATE = {
     "Frequency max [MHz]": 100,
     "Bottom layer": "MET2",
     "Top layer": "MET5",
+    "STA max paths": 1000,
 }
 SG13G2_PARAMETERS_TEMPLATE = {
     "PDK": "sg13g2",
@@ -51,6 +52,7 @@ SG13G2_PARAMETERS_TEMPLATE = {
     "Frequency max [MHz]": 100,
     "Bottom layer": "Metal2",
     "Top layer": "Metal5",
+    "STA max paths": 1000,
     "Floorplan": {
         "Tap distance": 0,
         "Auto place pin": {"layer": "Metal3", "width": 300, "height": 600, "sides": []},

--- a/chipcompiler/tools/ecc/module.py
+++ b/chipcompiler/tools/ecc/module.py
@@ -644,6 +644,7 @@ class ECCToolsModule:
         spef_path: str = "",
         output_modes: tuple[str, ...] = ("report", "structured"),
         max_paths_per_analysis: int = 20,
+        max_paths: int = 1000,
         corner: str = "",
     ):
         if lib_paths is None:
@@ -657,6 +658,8 @@ class ECCToolsModule:
             or max_paths_per_analysis <= 0
         ):
             raise ValueError("STA max_paths_per_analysis must be a positive integer")
+        if isinstance(max_paths, bool) or not isinstance(max_paths, int) or max_paths <= 0:
+            raise ValueError("STA max_paths must be a positive integer")
         if "report" in modes and not report_dir:
             raise ValueError("STA report_dir is required when report output is requested")
         if "structured" in modes and not feature_dir:
@@ -675,6 +678,7 @@ class ECCToolsModule:
                 "-output_timing_reports": "1" if "report" in modes else "0",
                 "-output_timing_features": "1" if "structured" in modes else "0",
                 "-timing_path_limit": str(max_paths_per_analysis),
+                "-max_paths": str(max_paths),
             }
         )
         if corner:

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -355,6 +355,7 @@ def run_sta_without_spef(
             feature_dir=feature_dir,
             lib_paths=liberty_paths,
             sdc_path=sdc_path,
+            max_paths=workspace.parameters.data.get("STA max paths", 1000),
             corner=corner,
         )
     except Exception as exc:
@@ -963,6 +964,7 @@ def run_sta(workspace: Workspace, step: EccStep, ecc_module: ECCToolsModule | No
             sdc_path=workspace.pdk.sdc,
             spef_path=spef_file,
             output_modes=("report", "structured"),
+            max_paths=workspace.parameters.data.get("STA max paths", 1000),
             corner=corner,
         )
 

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -473,6 +473,9 @@ run = "default"
 
 [params.place]
 target_density = 0.65
+
+[params.sta]
+max_paths = 1000
 ```
 
 Current validation supports the `ics55` PDK. `flow.run` selects the run

--- a/test/cli/params/test_commands.py
+++ b/test/cli/params/test_commands.py
@@ -27,7 +27,7 @@ class TestParamList:
         assert rc == 0
         lines = capsys.readouterr().out.strip().split("\n")
         objects = [json.loads(ln) for ln in lines]
-        assert len(objects) == 12
+        assert len(objects) == 13
 
     def test_param_list_plain(self, tmp_path, capsys, create_cli_project):
         project_dir = create_cli_project()
@@ -334,7 +334,7 @@ class TestOutputContracts:
         assert rc == 0
         out = capsys.readouterr().out
         lines = [line for line in out.strip().split("\n") if line.strip()]
-        assert len(lines) == 12
+        assert len(lines) == 13
 
 
 class TestConfigResolved:
@@ -357,7 +357,7 @@ class TestConfigResolved:
         data = json.loads(capsys.readouterr().out)
         records = data["records"]
         param_records = [r for r in records if r.get("kind") == "param"]
-        assert len(param_records) == 12
+        assert len(param_records) == 13
         first_param = param_records[0]
         assert "source" in first_param
         assert "maps_to" in first_param
@@ -424,7 +424,7 @@ class TestPrettyOutput:
         assert rc == 0
         out = capsys.readouterr().out
         lines = [line for line in out.strip().split("\n") if line.strip()]
-        assert len(lines) == 12
+        assert len(lines) == 13
         assert "\033[" not in out
 
     def test_param_show_default_is_pretty(self, tmp_path, capsys, create_cli_project):

--- a/test/tools/ecc/test_module_timing.py
+++ b/test/tools/ecc/test_module_timing.py
@@ -91,6 +91,7 @@ def test_run_timing_splits_text_reports_and_structured_artifacts(tmp_path):
         feature_dir=feature_dir,
         output_modes=("structured", "report"),
         max_paths_per_analysis=7,
+        max_paths=100,
         corner="MAX_125/RCworst",
     )
 
@@ -115,6 +116,7 @@ def test_run_timing_splits_text_reports_and_structured_artifacts(tmp_path):
         "-output_timing_reports": "1",
         "-output_timing_features": "1",
         "-timing_path_limit": "7",
+        "-max_paths": "100",
         "-timing_corner": "MAX_125/RCworst",
     }
 
@@ -176,6 +178,19 @@ def test_run_timing_rejects_invalid_output_modes(tmp_path):
             work_dir=tmp_path / "data" / "sta",
             feature_dir=tmp_path / "feature",
             output_modes=("structured", "raw"),
+        )
+
+    assert module.ecc.calls == []
+
+
+def test_run_timing_rejects_non_positive_max_paths(tmp_path):
+    module = make_module()
+
+    with pytest.raises(ValueError, match="STA max_paths must be a positive integer"):
+        module.run_timing(
+            work_dir=tmp_path / "data" / "sta",
+            feature_dir=tmp_path / "feature",
+            max_paths=0,
         )
 
     assert module.ecc.calls == []
@@ -301,6 +316,7 @@ def test_run_timing_stringifies_path_arguments(tmp_path):
                     "-output_timing_reports": "1",
                     "-output_timing_features": "1",
                     "-timing_path_limit": "20",
+                    "-max_paths": "1000",
                     "-timing_corner": "MAX_125/RCworst",
                 },
             },

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -296,6 +296,7 @@ def test_run_sta_without_spef_reads_netlist_and_writes_to_step_report_and_featur
                 "feature_dir": step.feature.dir / "post_synthesis",
                 "lib_paths": [liberty],
                 "sdc_path": sdc,
+                "max_paths": 1000,
                 "corner": "post_synthesis",
             },
         ),
@@ -447,6 +448,7 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
         directory=tmp_path,
         design=OriginDesign(name="gcd", top_module="gcd"),
         pdk=PDK(libs=[max_lib, min_lib], sdc=sdc),
+        parameters=Parameters(data={"STA max paths": 500}),
         config={StepEnum.STA.value: incorrect_sta_config, StepEnum.RCX.value: rcx_config},
         logger=logger,
     )
@@ -477,6 +479,7 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
             "sdc_path": sdc,
             "spef_path": str(spef_root / "gcd_RCworst_125C.spef"),
             "output_modes": ("report", "structured"),
+            "max_paths": 500,
             "corner": "MAX_125/RCworst",
         },
         {
@@ -488,6 +491,7 @@ def test_run_sta_uses_matched_report_and_feature_corner_directories(tmp_path, mo
             "sdc_path": sdc,
             "spef_path": str(spef_root / "gcd_Cbest_m40C.spef"),
             "output_modes": ("report", "structured"),
+            "max_paths": 500,
             "corner": "MIN_m40/Cbest",
         },
     ]


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
