### PR TITLE
feat: save lvs geometry snapshots

### DIFF
--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -28,6 +28,7 @@ _GEOMETRY_SNAPSHOT_STEPS = frozenset(
         StepEnum.LEGALIZATION.value,
         StepEnum.ROUTING.value,
         StepEnum.DRC.value,
+        StepEnum.LVS.value,
         StepEnum.FILLER.value,
     }
 )

--- a/chipcompiler/tools/ecc/runner.py
+++ b/chipcompiler/tools/ecc/runner.py
@@ -38,6 +38,7 @@ _GEOMETRY_SNAPSHOT_STEPS = frozenset(
         StepEnum.LEGALIZATION.value,
         StepEnum.ROUTING.value,
         StepEnum.DRC.value,
+        StepEnum.LVS.value,
         StepEnum.FILLER.value,
         StepEnum.RCX.value,
         StepEnum.STA.value,

--- a/test/tools/ecc/test_runner.py
+++ b/test/tools/ecc/test_runner.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from chipcompiler.data import (
     PDK,
     EccData,
@@ -566,9 +568,10 @@ def test_rcx_checklist_uses_top_module_for_spef_design_token(tmp_path):
     assert checklist.check_spef_file(str(spef)) is True
 
 
-def test_save_data_writes_geometry_snapshot_for_physical_step(tmp_path):
+@pytest.mark.parametrize("step_name", (StepEnum.ROUTING.value, StepEnum.LVS.value))
+def test_save_data_writes_geometry_snapshot_for_physical_step(tmp_path, step_name):
     workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd", top_module="gcd"))
-    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+    step = build_step(workspace, step_name, None, None)
     module = SnapshotSaveEccModule(write_snapshot=True)
 
     assert ecc_runner.save_data(workspace, step, module, feature_step=False) is True
@@ -626,11 +629,18 @@ def test_save_data_fails_when_geometry_snapshot_cannot_be_written(tmp_path):
     )
 
 
-def test_engine_flow_requires_geometry_manifest_for_physical_steps(tmp_path):
+@pytest.mark.parametrize("step_name", (StepEnum.ROUTING.value, StepEnum.LVS.value))
+def test_engine_flow_requires_geometry_manifest_for_physical_steps(tmp_path, step_name):
     workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd", top_module="gcd"))
-    step = build_step(workspace, StepEnum.ROUTING.value, None, None)
+    step = build_step(workspace, step_name, None, None)
     build_step_space(step)
-    for output_path in (step.output.def_, step.output.verilog, step.output.gds):
+    for output_path in (
+        step.output.def_,
+        step.output.verilog,
+        step.output.gds,
+        step.report.step,
+        step.feature.step,
+    ):
         assert output_path is not None
         output_path.write_text("", encoding="utf-8")
     assert step.output.geometry_manifest is not None


### PR DESCRIPTION
## What Changed

- Save the existing LVS geometry snapshot after a successful LVS run.
- Require the LVS geometry manifest when EngineFlow validates the step result.
- Cover both runtime paths with LVS regression cases.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [x] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

- LVS now writes its geometry snapshot to the existing `output/geometry` location for viewer consumers.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [x] Other: `bash .github/scripts/check-version.sh`

Skipped checks and reason:

- PyInstaller and Nix smokes are packaging checks and are not required for this runtime-only PR; the CI-equivalent unit suite covers the change.
- Manual LVS flow smoke requires an external PDK/toolchain workspace and was not run locally.

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
