### PR TITLE
fix(yosys): support async latch and ICS55 tri-state buffer mapping

### DIFF
--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -472,7 +472,9 @@ dfflibmap {*}$tech_cells_args {*}$exclude_cells
 
 # dfflibmap intentionally handles only flip-flops.  For ics55 it selects the
 # final matching DFF library in lib_stdcell_list, so use that same H7 variant
-# for the plain D-latch mapping before ABC.
+# for latch mapping before ABC.  The library has separate cells for latch
+# enable polarity and asynchronous set/reset polarity; positive async
+# controls are inverted because the library controls are active low.
 set ics55_latch_suffix ""
 if {[llength $lib_stdcell_list] > 0} {
   set dff_lib [lindex $lib_stdcell_list end]
@@ -495,7 +497,68 @@ module \$_DLATCH_P_ (E, D, Q);
   output Q;
   LATHX1%s _TECHMAP_REPLACE_ (.D(D), .G(E), .Q(Q));
 endmodule
-} $ics55_latch_suffix $ics55_latch_suffix]
+
+module \$_DLATCH_NN0_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  LATLRX1%s _TECHMAP_REPLACE_ (.D(D), .RN(R), .GN(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_NN1_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  LATLSX1%s _TECHMAP_REPLACE_ (.D(D), .SN(R), .GN(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_NP0_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  wire RN;
+  INVX1%s inv_reset (.A(R), .Y(RN));
+  LATLRX1%s _TECHMAP_REPLACE_ (.D(D), .RN(RN), .GN(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_NP1_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  wire SN;
+  INVX1%s inv_set (.A(R), .Y(SN));
+  LATLSX1%s _TECHMAP_REPLACE_ (.D(D), .SN(SN), .GN(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_PN0_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  LATHRX1%s _TECHMAP_REPLACE_ (.D(D), .RN(R), .G(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_PN1_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  LATHSX1%s _TECHMAP_REPLACE_ (.D(D), .SN(R), .G(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_PP0_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  wire RN;
+  INVX1%s inv_reset (.A(R), .Y(RN));
+  LATHRX1%s _TECHMAP_REPLACE_ (.D(D), .RN(RN), .G(E), .Q(Q));
+endmodule
+
+module \$_DLATCH_PP1_ (E, R, D, Q);
+  input E, R, D;
+  output Q;
+  wire SN;
+  INVX1%s inv_set (.A(R), .Y(SN));
+  LATHSX1%s _TECHMAP_REPLACE_ (.D(D), .SN(SN), .G(E), .Q(Q));
+endmodule
+} $ics55_latch_suffix $ics55_latch_suffix \
+  $ics55_latch_suffix $ics55_latch_suffix \
+  $ics55_latch_suffix $ics55_latch_suffix $ics55_latch_suffix \
+  $ics55_latch_suffix $ics55_latch_suffix $ics55_latch_suffix \
+  $ics55_latch_suffix $ics55_latch_suffix $ics55_latch_suffix \
+  $ics55_latch_suffix]
   close $latch_map_file
   techmap -map $ics55_latch_map
   opt -fast -purge

--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -432,6 +432,11 @@ opt -fast -purge
 #===========================================================
 synth -run fine:
 
+# Preserve RTL tri-state semantics before simplemap lowers muxes to gate
+# primitives. The resulting $_TBUF_ cells are mapped to the target library
+# below; do not use -merge because it assumes mutually-exclusive enables.
+tribuf
+
 # simplemap: break complex gates into simple primitives
 # This gives ABC a simpler, more uniform input graph.
 simplemap
@@ -561,6 +566,32 @@ endmodule
   $ics55_latch_suffix]
   close $latch_map_file
   techmap -map $ics55_latch_map
+  opt -fast -purge
+
+  # Map Yosys tri-state buffers to the same ICS55 voltage-threshold variant
+  # selected for the sequential cells.
+  set ics55_tri_map "${tmp_dir}/ics55_tri_map.v"
+  set tri_map_file [open $ics55_tri_map "w"]
+  puts $tri_map_file [format {
+(* techmap_celltype = "\$_TBUF_" *)
+module _tbuf_disabled (A, E, Y);
+  input A, E;
+  output Y;
+  parameter _TECHMAP_CONSTMSK_E_ = 1'b0;
+  parameter _TECHMAP_CONSTVAL_E_ = 1'bx;
+  wire _TECHMAP_FAIL_ = !(_TECHMAP_CONSTMSK_E_ && !_TECHMAP_CONSTVAL_E_);
+  wire [1023:0] _TECHMAP_DO_ = "connect -unset Y";
+endmodule
+
+(* techmap_celltype = "\$_TBUF_" *)
+module _tbuf_enabled (A, E, Y);
+  input A, E;
+  output Y;
+  TBUFX1%s _TECHMAP_REPLACE_ (.A(A), .OE(E), .Y(Y));
+endmodule
+} $ics55_latch_suffix]
+  close $tri_map_file
+  techmap -map $ics55_tri_map
   opt -fast -purge
 }
 


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
