### PR TITLE
ci: gate commit messages in CI and reject subject full stops

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,51 @@
+name: Commit Message
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: commit-message-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  commit-message:
+    name: Check commit messages and PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: latest
+          enable-cache: "true"
+
+      - name: Run commit-msg hooks on every commit and the PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          msg_file="$RUNNER_TEMP/commit-msg.txt"
+
+          while read -r sha; do
+            git log -1 --format=%B "$sha" > "$msg_file"
+            echo "Checking commit $(git log -1 --format='%h %s' "$sha")"
+            uvx prek@0.2.30 run --hook-stage commit-msg --commit-msg-filename "$msg_file"
+          done < <(git log --format=%H "origin/$BASE_REF..HEAD")
+
+          printf '%s\n' "$TITLE" > "$msg_file"
+          echo "Checking PR title: $TITLE"
+          uvx prek@0.2.30 run --hook-stage commit-msg --commit-msg-filename "$msg_file"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,15 @@ repos:
           - ci
           - chore
           - revert
+
+  - repo: local
+    hooks:
+      - id: no-subject-full-stop
+        name: Commit subject must not end with a full stop
+        language: system
+        stages:
+          - commit-msg
+        entry: >-
+          bash -c 'subject=$(head -n1 "$1");
+          case "$subject" in "fixup! "*|"squash! "*|"amend! "*|"Merge "*) exit 0;; esac;
+          case "$subject" in *.) echo "error: commit subject must not end with a full stop" >&2; exit 1;; esac' --


### PR DESCRIPTION
Add a local commit-msg hook that rejects subjects ending with a period; conventional-pre-commit has no such rule and upstream declined it (compilerla/conventional-pre-commit#92). Add a Commit Message workflow that runs the repo's commit-msg hooks via prek on every PR commit and the PR title, so local and CI checks share the single .pre-commit-config.yaml source of truth.

## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
