### PR TITLE
fix(runtime): persist tool failures and recover interrupted steps

### DIFF
--- a/agent/engine.py
+++ b/agent/engine.py
@@ -4,7 +4,8 @@ import traceback
 from threading import Event, Thread
 
 from chipcompiler.data import StateEnum, WorkspaceStep
-from chipcompiler.engine.flow import EngineFlow, get_process_rss_mb, track_current_process_memory
+from chipcompiler.engine.flow import EngineFlow
+from chipcompiler.engine.step_execution import get_process_rss_mb, track_current_process_memory
 from chipcompiler.utility.log import redirect_stdio_to_file
 
 from .tools import run_step as run_agent_step

--- a/chipcompiler/engine/flow.py
+++ b/chipcompiler/engine/flow.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import os
 import time
-from threading import Event, Thread
+from copy import deepcopy
 
 from chipcompiler.data import EccOutput, StateEnum, StepEnum, Workspace, WorkspaceStep, log_flow
 from chipcompiler.engine import EngineDB
@@ -13,7 +13,7 @@ from chipcompiler.engine.signoff import (
     SignoffPackageOptions,
     SignoffPackageResult,
 )
-from chipcompiler.utility.log import redirect_stdio_to_file
+from chipcompiler.engine.step_execution import execute_tool_step, record_tool_failure
 
 logger = logging.getLogger(__name__)
 
@@ -32,27 +32,6 @@ _GEOMETRY_SNAPSHOT_STEPS = frozenset(
         StepEnum.FILLER.value,
     }
 )
-
-
-def get_process_rss_mb(pid: int) -> float:
-    peak_memory = 0
-    try:
-        with open(f"/proc/{pid}/status") as f:
-            for line in f:
-                if line.startswith("VmRSS:"):
-                    rss_kb = int(line.split()[1])
-                    peak_memory = rss_kb / 1024
-                    break
-    except (OSError, ValueError):
-        pass
-    return peak_memory
-
-
-def track_current_process_memory(pid: int, stop_event: Event, peak_memory: list[float]):
-    while not stop_event.is_set():
-        peak_memory[0] = max(peak_memory[0], get_process_rss_mb(pid))
-        stop_event.wait(0.1)
-    peak_memory[0] = max(peak_memory[0], get_process_rss_mb(pid))
 
 
 class EngineFlow:
@@ -155,24 +134,33 @@ class EngineFlow:
         state: str | StateEnum,
         runtime: str = None,
         peak_memory: float = None,
+        *,
+        clear_runtime_operation: bool = False,
     ) -> bool:
         state_value = state.value if isinstance(state, StateEnum) else state
         for step in self.workspace.flow.data.get("steps", []):
             if step.get("name") == name and step.get("tool") == tool:
+                previous_step = deepcopy(step)
                 step["state"] = state_value
                 if runtime is not None:
                     step["runtime"] = runtime
                 if peak_memory is not None:
                     step["peak memory (mb)"] = peak_memory
+                if clear_runtime_operation:
+                    step.get("info", {}).pop("runtime_operation", None)
 
+                if self.workspace.flow.path is None:
+                    return True
                 if not self.save():
+                    step.clear()
+                    step.update(previous_step)
                     logger.error(
-                        "Failed to persist flow state for %s/%s (state=%s); "
-                        "state change exists only in memory",
+                        "Failed to persist flow state for %s/%s (state=%s)",
                         name,
                         tool,
                         state_value,
                     )
+                    return False
                 return True
 
         return False
@@ -477,123 +465,150 @@ class EngineFlow:
         # set state ongoing
         start_time = time.time()
         timing_constraints = self.timing_constraint_facts()
-        self.set_state(name=workspace_step.name, tool=workspace_step.tool, state=StateEnum.Ongoing)
+        flow_step = self.get_step(workspace_step.name, workspace_step.tool)
+        operation_marker = getattr(observer, "runtime_operation", None)
+        if operation_marker:
+            if flow_step is None:
+                raise RuntimeError(f"cannot persist runtime operation marker for {step_tag}")
+            previous_state = flow_step.get("state")
+            previous_info = dict(flow_step.get("info", {}))
+            flow_step.setdefault("info", {})["runtime_operation"] = {
+                **operation_marker,
+                "started_at": start_time,
+            }
+            flow_step["state"] = StateEnum.Ongoing.value
+            if not self.save():
+                flow_step["state"] = previous_state
+                flow_step["info"] = previous_info
+                raise RuntimeError(f"failed to persist runtime operation marker for {step_tag}")
+        else:
+            if flow_step is not None and not self.set_state(
+                name=workspace_step.name,
+                tool=workspace_step.tool,
+                state=StateEnum.Ongoing,
+            ):
+                raise RuntimeError(f"failed to persist ongoing state for {step_tag}")
         _notify_flow_observer(observer, "on_step_started", workspace_step)
 
-        # run step
-        log_file = workspace_step.log.file or ""
-        if log_file:
-            log_file = os.path.abspath(log_file)
-            try:
-                os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
-                redirect_stdio_to_file(log_file)
-            except Exception:
-                logger.exception("Failed to redirect stdio to log file: %s", log_file)
-
-        step_tag = f"{workspace_step.name}({workspace_step.tool})"
-        self.workspace.logger.info(f"[STEP] {step_tag} pid={os.getpid()} started")
-
-        pid = os.getpid()
-        start_memory_mb = get_process_rss_mb(pid)
-        peak_memory = [start_memory_mb]
-        stop_memory_monitor = Event()
-        memory_monitor = Thread(
-            target=track_current_process_memory,
-            args=(pid, stop_memory_monitor, peak_memory),
-            daemon=True,
+        execution = execute_tool_step(
+            self.workspace,
+            workspace_step,
+            self.engine_db,
+            observer=observer,
+            started_at=start_time,
         )
-        memory_monitor.start()
-        previous_observer = getattr(self.workspace, "_runtime_flow_observer", None)
-        if observer is not None:
-            self.workspace._runtime_flow_observer = observer
-        step_raised_exception = False
+        step_error = execution.error
+        elapsed = execution.elapsed_seconds
+        peak_memory_mb = execution.peak_memory_mb
+        runtime = execution.runtime
+
+        state = StateEnum.Imcomplete
+        terminal_persisted = False
         try:
-            from chipcompiler.tools import run_step as run_tool_step
+            if step_error is None:
+                state = (
+                    StateEnum.Success
+                    if self.check_step_result(workspace_step=workspace_step)
+                    else StateEnum.Imcomplete
+                )
+                if state == StateEnum.Imcomplete:
+                    step_error = f"{step_tag} did not produce the required outputs."
 
-            result = run_tool_step(
-                workspace=self.workspace, step=workspace_step, ecc_module=self.engine_db.engine
-            )
-            self.workspace.logger.info(f"[STEP] {step_tag} finished result={result}")
-        except Exception:
-            step_raised_exception = True
-            self.workspace.logger.error(f"[STEP] {step_tag} failed with exception")
-            self.workspace.logger.exception(f"[STEP] {step_tag} exception details")
-        finally:
-            stop_memory_monitor.set()
-            memory_monitor.join()
-            if observer is not None:
-                if previous_observer is None:
-                    delattr(self.workspace, "_runtime_flow_observer")
+            if state == StateEnum.Imcomplete:
+                _finalize_interrupted_subflow(
+                    observer,
+                    workspace_step,
+                    runtime,
+                    peak_memory_mb,
+                )
+
+            if flow_step is not None and not self.set_state(
+                name=workspace_step.name,
+                tool=workspace_step.tool,
+                state=state,
+                runtime=runtime,
+                peak_memory=peak_memory_mb,
+                clear_runtime_operation=True,
+            ):
+                raise RuntimeError(f"failed to persist terminal state for {step_tag}")
+            terminal_persisted = True
+
+            # save layout snapshot on success
+            if state == StateEnum.Success:
+                if self.save_step_flow_facts(
+                    workspace_step=workspace_step,
+                    state=state,
+                    runtime_seconds=elapsed,
+                    peak_memory_mb=peak_memory_mb,
+                    timing_constraints=timing_constraints,
+                ):
+                    try:
+                        from chipcompiler.tools import build_step_metrics
+
+                        if (
+                            build_step_metrics(workspace=self.workspace, step=workspace_step)
+                            is None
+                        ):
+                            self.workspace.logger.warning(
+                                "[QOR] %s run facts were saved but analysis refresh is unavailable",
+                                step_tag,
+                            )
+                    except Exception:
+                        self.workspace.logger.exception(
+                            "[QOR] %s failed to refresh analysis after saving run facts",
+                            step_tag,
+                        )
                 else:
-                    self.workspace._runtime_flow_observer = previous_observer
+                    self.workspace.logger.warning(
+                        "[QOR] %s has no step feature path; run facts were not saved",
+                        step_tag,
+                    )
+                from chipcompiler.tools import save_layout_image
 
-        # compute metrics
-        peak_memory_mb = peak_memory[0] - start_memory_mb
-        peak_memory_mb = 0 if peak_memory_mb < 0 else round(peak_memory_mb, 3)
-        elapsed = time.time() - start_time
-        runtime = f"{int(elapsed // 3600)}:{int((elapsed % 3600) // 60)}:{int(elapsed % 60)}"
-
-        # determine and save state
-        if step_raised_exception:
+                save_layout_image(workspace=self.workspace, step=workspace_step)
+        except (Exception, SystemExit) as exc:
+            failure_message = record_tool_failure(self.workspace.logger, step_tag, exc)
+            step_error = step_error or failure_message
             state = StateEnum.Imcomplete
-        else:
-            state = (
-                StateEnum.Success
-                if self.check_step_result(workspace_step=workspace_step)
-                else StateEnum.Imcomplete
+            _finalize_interrupted_subflow(
+                observer,
+                workspace_step,
+                runtime,
+                peak_memory_mb,
             )
+            if flow_step is not None and not self.set_state(
+                name=workspace_step.name,
+                tool=workspace_step.tool,
+                state=state,
+                runtime=runtime,
+                peak_memory=peak_memory_mb,
+                clear_runtime_operation=True,
+            ):
+                raise RuntimeError(f"failed to persist terminal state for {step_tag}") from exc
+            terminal_persisted = True
+        finally:
+            if terminal_persisted:
+                _refresh_signoff_checklist(self.workspace, workspace_step)
+            try:
+                self.clear_db_engine_after_step(workspace_step, state)
+            except (Exception, SystemExit):
+                logger.exception("Failed to release DB engine after %s", step_tag)
+            if terminal_persisted:
+                _notify_flow_observer(
+                    observer,
+                    "on_step_completed",
+                    workspace_step,
+                    state,
+                    step_error,
+                )
 
-        self.set_state(
-            name=workspace_step.name,
-            tool=workspace_step.tool,
-            state=state,
-            runtime=runtime,
-            peak_memory=peak_memory_mb,
-        )
         self.workspace.logger.info(
-            "[RESULT] %s state=%s runtime=%s mem=%sMB exitcode=%s",
+            "[RESULT] %s state=%s runtime=%s mem=%sMB",
             step_tag,
             state.value,
             runtime,
             peak_memory_mb,
-            0,
         )
-
-        # save layout snapshot on success
-        if state == StateEnum.Success:
-            if self.save_step_flow_facts(
-                workspace_step=workspace_step,
-                state=state,
-                runtime_seconds=elapsed,
-                peak_memory_mb=peak_memory_mb,
-                timing_constraints=timing_constraints,
-            ):
-                try:
-                    from chipcompiler.tools import build_step_metrics
-
-                    if build_step_metrics(workspace=self.workspace, step=workspace_step) is None:
-                        self.workspace.logger.warning(
-                            "[QOR] %s run facts were saved but analysis refresh is unavailable",
-                            step_tag,
-                        )
-                except Exception:
-                    self.workspace.logger.exception(
-                        "[QOR] %s failed to refresh analysis after saving run facts",
-                        step_tag,
-                    )
-            else:
-                self.workspace.logger.warning(
-                    "[QOR] %s has no step feature path; run facts were not saved",
-                    step_tag,
-                )
-            from chipcompiler.tools import save_layout_image
-
-            save_layout_image(workspace=self.workspace, step=workspace_step)
-
-        _refresh_signoff_checklist(self.workspace, workspace_step)
-
-        self.clear_db_engine_after_step(workspace_step, state)
-        _notify_flow_observer(observer, "on_step_completed", workspace_step, state)
         if state == StateEnum.Success and not _wait_for_step_rendered(
             observer,
             workspace_step,
@@ -613,13 +628,37 @@ class EngineFlow:
         return self.engine_db.create_db_engine(step=workspace_step)
 
 
+def _finalize_interrupted_subflow(
+    observer,
+    workspace_step: WorkspaceStep,
+    runtime: str,
+    peak_memory_mb: float,
+) -> None:
+    try:
+        from chipcompiler.runtime.subflow_events import finalize_interrupted_subflow
+
+        for subflow_step in finalize_interrupted_subflow(
+            workspace_step,
+            runtime,
+            peak_memory_mb,
+        ):
+            _notify_flow_observer(
+                observer,
+                "on_subflow_stage",
+                workspace_step,
+                subflow_step,
+            )
+    except (Exception, SystemExit):
+        logger.exception("Failed to finalize subflow after %s", workspace_step.name)
+
+
 def _refresh_signoff_checklist(workspace: Workspace, workspace_step: WorkspaceStep) -> None:
     """Replace step/home checklists after the step's terminal flow state is saved."""
     try:
         from chipcompiler.tools.ecc.signoff_checklist import refresh_step_checklist
 
         refresh_step_checklist(workspace, workspace_step)
-    except Exception:
+    except (Exception, SystemExit):
         logger.exception(
             "Failed to refresh signoff checklist after %s/%s",
             workspace_step.name,
@@ -636,7 +675,7 @@ def _notify_flow_observer(observer, method_name: str, *args) -> None:
         return
     try:
         callback(*args)
-    except Exception:
+    except (Exception, SystemExit):
         # Runtime observers must never turn a completed tool execution into a
         # failed flow. The coordinator records transport failures separately.
         logging.getLogger(__name__).exception("flow observer callback failed: %s", method_name)

--- a/chipcompiler/engine/step_execution.py
+++ b/chipcompiler/engine/step_execution.py
@@ -1,0 +1,153 @@
+import logging
+import os
+import time
+from dataclasses import dataclass
+from threading import Event, Thread
+
+from chipcompiler.data import Workspace, WorkspaceStep
+from chipcompiler.engine.db import EngineDB
+from chipcompiler.utility.log import capture_stdio_to_file, flush_cstdio
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StepExecutionResult:
+    error: str | None
+    elapsed_seconds: float
+    peak_memory_mb: float
+    runtime: str
+
+
+def get_process_rss_mb(pid: int) -> float:
+    rss_mb = 0.0
+    try:
+        with open(f"/proc/{pid}/status") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    rss_mb = int(line.split()[1]) / 1024
+                    break
+    except (OSError, ValueError):
+        pass
+    return rss_mb
+
+
+def track_current_process_memory(pid: int, stop_event: Event, peak_memory: list[float]) -> None:
+    while not stop_event.is_set():
+        peak_memory[0] = max(peak_memory[0], get_process_rss_mb(pid))
+        stop_event.wait(0.1)
+    peak_memory[0] = max(peak_memory[0], get_process_rss_mb(pid))
+
+
+def execute_tool_step(
+    workspace: Workspace,
+    workspace_step: WorkspaceStep,
+    engine_db: EngineDB | None,
+    *,
+    observer=None,
+    started_at: float | None = None,
+) -> StepExecutionResult:
+    """Run one tool while containing its stdio, memory monitor, and failures."""
+    start_time = time.time() if started_at is None else started_at
+    step_tag = f"{workspace_step.name}({workspace_step.tool})"
+    log_file = _prepare_log_file(workspace_step)
+    pid = os.getpid()
+    start_memory_mb = 0.0
+    peak_memory = [0.0]
+    stop_memory_monitor = Event()
+    memory_monitor = None
+    previous_observer = getattr(workspace, "_runtime_flow_observer", None)
+    observer_installed = False
+    step_error = None
+    try:
+        workspace.logger.info(f"[STEP] {step_tag} pid={pid} started")
+        start_memory_mb = get_process_rss_mb(pid)
+        peak_memory[0] = start_memory_mb
+        memory_monitor = Thread(
+            target=track_current_process_memory,
+            args=(pid, stop_memory_monitor, peak_memory),
+            daemon=True,
+        )
+        memory_monitor.start()
+        if observer is not None:
+            workspace._runtime_flow_observer = observer
+            observer_installed = True
+        with capture_stdio_to_file(log_file):
+            try:
+                from chipcompiler.tools import run_step
+
+                if engine_db is None:
+                    raise AttributeError("'NoneType' object has no attribute 'engine'")
+                result = run_step(
+                    workspace=workspace,
+                    step=workspace_step,
+                    ecc_module=engine_db.engine,
+                )
+                workspace.logger.info(f"[STEP] {step_tag} finished result={result}")
+            except (Exception, SystemExit) as exc:
+                step_error = record_tool_failure(workspace.logger, step_tag, exc)
+    except (Exception, SystemExit) as exc:
+        failure_message = record_tool_failure(workspace.logger, step_tag, exc)
+        step_error = step_error or failure_message
+    finally:
+        stop_memory_monitor.set()
+        if memory_monitor is not None:
+            try:
+                memory_monitor.join()
+            except (Exception, SystemExit) as exc:
+                failure_message = record_tool_failure(
+                    workspace.logger,
+                    step_tag,
+                    exc,
+                )
+                step_error = step_error or failure_message
+        try:
+            if observer_installed:
+                if previous_observer is None:
+                    delattr(workspace, "_runtime_flow_observer")
+                else:
+                    workspace._runtime_flow_observer = previous_observer
+        except (Exception, SystemExit) as exc:
+            failure_message = record_tool_failure(workspace.logger, step_tag, exc)
+            step_error = step_error or failure_message
+
+    peak_memory_mb = peak_memory[0] - start_memory_mb
+    peak_memory_mb = 0 if peak_memory_mb < 0 else round(peak_memory_mb, 3)
+    elapsed = time.time() - start_time
+    return StepExecutionResult(
+        error=step_error,
+        elapsed_seconds=elapsed,
+        peak_memory_mb=peak_memory_mb,
+        runtime=f"{int(elapsed // 3600)}:{int((elapsed % 3600) // 60)}:{int(elapsed % 60)}",
+    )
+
+
+def record_tool_failure(
+    tool_logger: logging.Logger,
+    step_tag: str,
+    error: BaseException,
+) -> str:
+    flush_cstdio()
+    message = _tool_error_message(step_tag, error)
+    tool_logger.error(f"[STEP] {step_tag} failed: {message}")
+    tool_logger.exception(f"[STEP] {step_tag} exception details")
+    return message
+
+
+def _prepare_log_file(workspace_step: WorkspaceStep) -> str:
+    log_file = workspace_step.log.file or ""
+    if not log_file:
+        return ""
+    log_file = os.path.abspath(log_file)
+    try:
+        os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
+    except Exception:
+        logger.exception("Failed to prepare stdio log file: %s", log_file)
+        return ""
+    return log_file
+
+
+def _tool_error_message(step_tag: str, error: BaseException) -> str:
+    if isinstance(error, SystemExit):
+        return f"{step_tag} exited unexpectedly (code {error.code!r})."
+    return str(error) or type(error).__name__

--- a/chipcompiler/runtime/events.py
+++ b/chipcompiler/runtime/events.py
@@ -2,9 +2,26 @@ import os
 import sys
 from contextlib import contextmanager, suppress
 
+from chipcompiler.utility.log import stdio_redirect_lock
+
 
 @contextmanager
 def redirect_stdout_to_stderr():
+    acquired = stdio_redirect_lock.acquire(blocking=False)
+    if not acquired:
+        # A tool already owns fd 1/2. Its protocol writer uses a duplicated fd,
+        # so the RPC can proceed without installing a competing redirect.
+        yield
+        return
+    try:
+        with _redirect_stdout_to_stderr():
+            yield
+    finally:
+        stdio_redirect_lock.release()
+
+
+@contextmanager
+def _redirect_stdout_to_stderr():
     saved_stdout = sys.stdout
     saved_stderr = sys.stderr
     saved_stdout_fd = None

--- a/chipcompiler/runtime/methods.py
+++ b/chipcompiler/runtime/methods.py
@@ -24,6 +24,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceInfoRequest,
     WorkspaceInspectSignoffRequest,
     WorkspaceOpenRequest,
+    WorkspaceRecoverInterruptedRequest,
     WorkspaceSyncConfigRequest,
 )
 
@@ -127,6 +128,11 @@ RUNTIME_METHODS: Final[tuple[RuntimeMethodSpec[Any], ...]] = (
         method_name="workspace.snapshot",
         request_model=WorkspaceIdRequest,
         handler_name="workspace_snapshot",
+    ),
+    RuntimeMethodSpec(
+        method_name="workspace.recover_interrupted",
+        request_model=WorkspaceRecoverInterruptedRequest,
+        handler_name="recover_interrupted",
     ),
 )
 

--- a/chipcompiler/runtime/operations.py
+++ b/chipcompiler/runtime/operations.py
@@ -14,6 +14,7 @@ _MAX_FINAL_LOG_BYTES = 64 * 1024
 _RENDER_ACK_RETRY_SECONDS = 5.0
 _RENDER_ACK_PAUSE_SECONDS = 30.0
 _RENDER_ACK_ABORT_SECONDS = 300.0
+_TERMINAL_OPERATION_STATES = frozenset({"succeeded", "failed", "cancelled"})
 
 
 @dataclass
@@ -149,6 +150,11 @@ class RuntimeOperationManager:
                 raise KeyError(operation_id)
             return self._operation_payload(operation)
 
+    def is_active(self, operation_id: str) -> bool:
+        with self._lock:
+            operation = self._operations.get(operation_id)
+            return operation is not None and operation.state not in _TERMINAL_OPERATION_STATES
+
     def workspace_snapshot(self, workspace_id: str) -> dict[str, Any]:
         with self._lock:
             operations = [
@@ -229,7 +235,7 @@ class RuntimeOperationManager:
             operation = self._operations.get(operation_id)
             if operation is None:
                 raise KeyError(operation_id)
-            if operation.state in {"succeeded", "failed", "cancelled"}:
+            if operation.state in _TERMINAL_OPERATION_STATES:
                 return {"accepted": False, "operationId": operation_id, "state": operation.state}
             operation.cancel_requested = True
             operation.updated_at = time.time()
@@ -263,50 +269,77 @@ class RuntimeOperationManager:
             operation.state = "running"
             operation.updated_at = time.time()
             started_event = self._new_event_locked(operation, "operation.started", {})
-        self._publish(started_event)
-
         observer = RuntimeFlowObserver(self, operation_id)
         try:
-            result = runner(observer)
-            with self._lock:
-                operation = self._operations[operation_id]
-                if operation.cancel_requested:
-                    raise RuntimeOperationCancelled("operation cancelled at a step boundary")
-                operation.state = "succeeded"
-                operation.result = result
-                operation.updated_at = time.time()
-                event = self._new_event_locked(operation, "operation.completed", {"result": result})
-        except RuntimeOperationCancelled as exc:
-            with self._lock:
-                operation = self._operations[operation_id]
-                operation.state = "cancelled"
-                operation.error = {
-                    "message": str(exc),
-                    "code": "cancelled",
-                }
-                operation.updated_at = time.time()
-                event = self._new_event_locked(
-                    operation,
-                    "operation.cancelled",
-                    {"error": operation.error},
-                )
-        except Exception as exc:
-            with self._lock:
-                operation = self._operations[operation_id]
-                if operation.cancel_requested:
-                    operation.state = "cancelled"
-                    operation.error = {"message": str(exc), "code": "cancelled"}
-                    event_type = "operation.cancelled"
-                else:
-                    operation.state = "failed"
-                    operation.error = {"message": str(exc), "code": "command_failed"}
-                    event_type = "operation.failed"
-                operation.updated_at = time.time()
-                event = self._new_event_locked(operation, event_type, {"error": operation.error})
-        self._publish(event)
-        self._stop_step_log_tail(operation_id)
-        with self._lock:
-            self._active_by_workspace.pop(self._operations[operation_id].workspace_id, None)
+            self._publish(started_event)
+            try:
+                result = runner(observer)
+                with self._lock:
+                    operation = self._operations[operation_id]
+                    if operation.cancel_requested:
+                        raise RuntimeOperationCancelled("operation cancelled at a step boundary")
+                    operation.state = "succeeded"
+                    operation.result = result
+                    operation.updated_at = time.time()
+                    event = self._new_event_locked(
+                        operation,
+                        "operation.completed",
+                        {"result": result},
+                    )
+            except RuntimeOperationCancelled as exc:
+                with self._lock:
+                    operation = self._operations[operation_id]
+                    if operation.error is not None:
+                        operation.state = "failed"
+                        event_type = "operation.failed"
+                    else:
+                        operation.state = "cancelled"
+                        operation.error = {
+                            "message": str(exc),
+                            "code": "cancelled",
+                        }
+                        event_type = "operation.cancelled"
+                    operation.updated_at = time.time()
+                    event = self._new_event_locked(
+                        operation,
+                        event_type,
+                        {"error": operation.error},
+                    )
+            except Exception as exc:
+                with self._lock:
+                    operation = self._operations[operation_id]
+                    if operation.cancel_requested and operation.error is None:
+                        operation.state = "cancelled"
+                        operation.error = {"message": str(exc), "code": "cancelled"}
+                        event_type = "operation.cancelled"
+                    else:
+                        operation.state = "failed"
+                        operation.error = operation.error or {
+                            "message": str(exc),
+                            "code": "command_failed",
+                        }
+                        event_type = "operation.failed"
+                    operation.updated_at = time.time()
+                    payload = {"error": operation.error}
+                    if operation.error:
+                        payload.update(
+                            {
+                                key: operation.error[key]
+                                for key in ("step", "tool", "logFile")
+                                if key in operation.error
+                            }
+                        )
+                    event = self._new_event_locked(operation, event_type, payload)
+            self._publish(event)
+        finally:
+            try:
+                self._stop_step_log_tail(operation_id)
+            finally:
+                with self._lock:
+                    self._active_by_workspace.pop(
+                        self._operations[operation_id].workspace_id,
+                        None,
+                    )
 
     def step_started(self, operation_id: str, workspace_step: Any) -> None:
         self._stop_step_log_tail(operation_id)
@@ -366,7 +399,13 @@ class RuntimeOperationManager:
             )
         self._publish(event)
 
-    def step_completed(self, operation_id: str, workspace_step: Any, state: Any) -> None:
+    def step_completed(
+        self,
+        operation_id: str,
+        workspace_step: Any,
+        state: Any,
+        error: str | None = None,
+    ) -> None:
         self._stop_step_log_tail(operation_id)
         state_value = str(getattr(state, "value", state))
         final_log = _read_final_log(getattr(workspace_step, "log", None))
@@ -381,6 +420,17 @@ class RuntimeOperationManager:
                 "tool": operation.current_tool,
                 "state": state_value,
             }
+            if error:
+                log_file = str(getattr(getattr(workspace_step, "log", None), "file", "") or "")
+                operation.error = {
+                    "code": "tool_failed",
+                    "message": error,
+                    "step": operation.current_step,
+                    "tool": operation.current_tool,
+                    "logFile": log_file,
+                }
+                payload["error"] = operation.error
+                payload["logFile"] = log_file
             event = self._new_event_locked(operation, "step.completed", payload)
             if state_value == "Success":
                 operation.workspace_revision += 1
@@ -617,7 +667,7 @@ class RuntimeOperationManager:
             "cancelRequested": operation.cancel_requested,
             "interruptibility": operation.interruptibility,
             "safeToStop": bool(operation.awaiting_event_id),
-            "shutdownBarrier": operation.state not in {"succeeded", "failed", "cancelled"},
+            "shutdownBarrier": operation.state not in _TERMINAL_OPERATION_STATES,
             "createdAt": operation.created_at,
             "updatedAt": operation.updated_at,
         }
@@ -632,6 +682,14 @@ class RuntimeFlowObserver:
     def __init__(self, manager: RuntimeOperationManager, operation_id: str):
         self._manager = manager
         self._operation_id = operation_id
+
+    @property
+    def runtime_operation(self) -> dict[str, Any]:
+        return {
+            "schema": 1,
+            "operation_id": self._operation_id,
+            "runtime_instance_id": self._manager._runtime_instance_id,
+        }
 
     def on_step_started(self, workspace_step: Any) -> None:
         self._manager.step_started(self._operation_id, workspace_step)
@@ -650,8 +708,13 @@ class RuntimeFlowObserver:
             target_step=target_step,
         )
 
-    def on_step_completed(self, workspace_step: Any, state: Any) -> None:
-        self._manager.step_completed(self._operation_id, workspace_step, state)
+    def on_step_completed(
+        self,
+        workspace_step: Any,
+        state: Any,
+        error: str | None = None,
+    ) -> None:
+        self._manager.step_completed(self._operation_id, workspace_step, state, error)
 
     def on_subflow_stage(self, workspace_step: Any, subflow_step: dict[str, Any]) -> None:
         self._manager.subflow_stage(self._operation_id, workspace_step, subflow_step)

--- a/chipcompiler/runtime/recovery.py
+++ b/chipcompiler/runtime/recovery.py
@@ -1,0 +1,53 @@
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from chipcompiler.data import StateEnum, Workspace
+from chipcompiler.runtime.operations import RuntimeOperationManager
+from chipcompiler.utility import json_write
+
+
+def recover_interrupted_operation(
+    workspace: Workspace,
+    operations: RuntimeOperationManager,
+    operation_id: str = "",
+) -> dict[str, list[dict[str, str]]]:
+    flow_data = deepcopy(workspace.flow.data)
+    recovered = []
+    for step in flow_data.get("steps", []):
+        marker = step.get("info", {}).get("runtime_operation")
+        if (
+            step.get("state") != "Ongoing"
+            or not isinstance(marker, dict)
+            or marker.get("schema") != 1
+            or not isinstance(marker.get("operation_id"), str)
+            or not marker["operation_id"]
+            or not isinstance(marker.get("runtime_instance_id"), str)
+            or not marker["runtime_instance_id"]
+            or not isinstance(marker.get("started_at"), (int, float))
+            or (operation_id and marker.get("operation_id") != operation_id)
+            or operations.is_active(str(marker["operation_id"]))
+        ):
+            continue
+        log_file = _step_log_file(workspace.directory, step)
+        step["state"] = StateEnum.Imcomplete.value
+        step["info"].pop("runtime_operation", None)
+        recovered.append(
+            {
+                "step": str(step.get("name", "")),
+                "tool": str(step.get("tool", "")),
+                "operationId": str(marker["operation_id"]),
+                "logFile": log_file,
+            }
+        )
+    if recovered:
+        if not json_write(workspace.flow.path, flow_data):
+            raise OSError(f"failed to save recovered flow state: {workspace.flow.path}")
+        workspace.flow.data = flow_data
+    return {"recovered": recovered}
+
+
+def _step_log_file(directory: str | Path, step: dict[str, Any]) -> str:
+    name = str(step.get("name", ""))
+    tool = str(step.get("tool", ""))
+    return str(Path(directory) / f"{name}_{tool}" / "log" / f"{name}.log")

--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -28,6 +28,12 @@ class WorkspaceIdRequest:
 
 
 @dataclass(frozen=True)
+class WorkspaceRecoverInterruptedRequest:
+    workspace_id: str
+    operation_id: str = ""
+
+
+@dataclass(frozen=True)
 class WorkspaceCloseRequest:
     workspace_id: str
 

--- a/chipcompiler/runtime/subflow_events.py
+++ b/chipcompiler/runtime/subflow_events.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
+
+from chipcompiler.data import StateEnum
+from chipcompiler.utility import json_write
 
 
 def publish_subflow_stage(
@@ -21,6 +25,31 @@ def publish_subflow_stage(
         return
     try:
         callback(workspace_step, dict(subflow_step))
-    except Exception:
+    except (Exception, SystemExit):
         # GUI event delivery must not affect an EDA tool's result.
         return
+
+
+def finalize_interrupted_subflow(
+    workspace_step: Any,
+    runtime: str,
+    peak_memory_mb: float,
+) -> list[dict[str, Any]]:
+    subflow = getattr(workspace_step, "subflow", None)
+    steps = getattr(subflow, "steps", None) or []
+    previous_steps = deepcopy(steps)
+    interrupted = []
+    for step in steps:
+        if step.get("state") != "Ongoing":
+            continue
+        step["state"] = StateEnum.Imcomplete.value
+        step["runtime"] = runtime
+        step["peak memory (mb)"] = peak_memory_mb
+        interrupted.append(dict(step))
+    path = getattr(subflow, "path", None)
+    if interrupted and path and not json_write(path, {"path": str(path), "steps": steps}):
+        for step, previous_step in zip(steps, previous_steps, strict=True):
+            step.clear()
+            step.update(previous_step)
+        raise OSError(f"failed to save interrupted subflow: {path}")
+    return interrupted

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -37,6 +37,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceInfoRequest,
     WorkspaceInspectSignoffRequest,
     WorkspaceOpenRequest,
+    WorkspaceRecoverInterruptedRequest,
     WorkspaceSyncConfigRequest,
 )
 from chipcompiler.runtime.sessions import (
@@ -128,6 +129,18 @@ class WorkspaceRuntimeApi:
         build_flow_for_workspace(workspace, create_step_workspaces=False)
         session = self.sessions.open_session(workspace.directory, workspace=workspace)
         return _workspace_session_result(session)
+
+    def recover_interrupted(self, request: WorkspaceRecoverInterruptedRequest) -> dict:
+        from chipcompiler.runtime.recovery import recover_interrupted_operation
+
+        return self._with_session_mutation_lock(
+            request.workspace_id,
+            lambda session: recover_interrupted_operation(
+                session.workspace,
+                self.operations,
+                request.operation_id,
+            ),
+        )
 
     def workspace_home(self, request: WorkspaceIdRequest) -> dict:
         session = self._get_session(request.workspace_id)

--- a/chipcompiler/utility/log.py
+++ b/chipcompiler/utility/log.py
@@ -4,11 +4,15 @@ import ctypes
 import logging
 import os
 import sys
+import threading
 import time
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from typing import TextIO
+
+# ponytail: process-wide fds require one lock; move tools to subprocesses for parallel capture.
+stdio_redirect_lock = threading.RLock()
 
 
 # TODO: Move some functions to Logger Module
@@ -83,6 +87,34 @@ def redirect_stdio_to_file(log_file: str) -> TextIO:
     sys.stdout = os.fdopen(1, "w", encoding="utf-8", buffering=1, closefd=False)
     sys.stderr = os.fdopen(2, "w", encoding="utf-8", buffering=1, closefd=False)
     return log_stream
+
+
+@contextmanager
+def capture_stdio_to_file(log_file: str | None):
+    """Redirect fd 1/2 for one scope, then restore the original streams."""
+    if not log_file:
+        yield
+        return
+
+    with stdio_redirect_lock:
+        saved_fds = (os.dup(1), os.dup(2))
+        saved_streams = (sys.stdout, sys.stderr)
+        log_stream = None
+        try:
+            log_stream = redirect_stdio_to_file(log_file)
+            yield
+        finally:
+            for stream in (sys.stdout, sys.stderr):
+                with suppress(Exception):
+                    stream.flush()
+            flush_cstdio()
+            os.dup2(saved_fds[0], 1)
+            os.dup2(saved_fds[1], 2)
+            os.close(saved_fds[0])
+            os.close(saved_fds[1])
+            sys.stdout, sys.stderr = saved_streams
+            if log_stream is not None:
+                log_stream.close()
 
 
 def init_api_runtime_log(

--- a/test/runtime/test_events.py
+++ b/test/runtime/test_events.py
@@ -1,7 +1,12 @@
 import os
 import sys
+import threading
+from contextlib import nullcontext
+
+import pytest
 
 from chipcompiler.runtime.events import redirect_stdout_to_stderr
+from chipcompiler.utility.log import capture_stdio_to_file
 
 
 def test_redirect_stdout_to_stderr_restores_fd_1_and_fd_2(tmp_path):
@@ -33,3 +38,119 @@ def test_redirect_stdout_to_stderr_restores_fd_1_and_fd_2(tmp_path):
     assert stdout_target.read_text() == "restored stdout\n"
     assert stderr_target.read_text() == "captured stdout\nrestored stderr\n"
     assert redirected_target.read_text() == "captured stderr\n"
+
+
+@pytest.mark.parametrize("error", [None, RuntimeError("failed"), SystemExit(0)])
+def test_capture_stdio_to_file_restores_fd_1_and_fd_2(tmp_path, error):
+    original_fds = (os.dup(1), os.dup(2))
+    stdout_target = tmp_path / "stdout.txt"
+    stderr_target = tmp_path / "stderr.txt"
+    step_log = tmp_path / "step.log"
+    with open(stdout_target, "wb") as stdout_file, open(stderr_target, "wb") as stderr_file:
+        os.dup2(stdout_file.fileno(), 1)
+        os.dup2(stderr_file.fileno(), 2)
+        try:
+            with (
+                pytest.raises(type(error)) if error else nullcontext(),
+                capture_stdio_to_file(str(step_log)),
+            ):
+                os.write(1, b"step stdout\n")
+                os.write(2, b"step stderr\n")
+                if error:
+                    raise error
+            os.write(1, b"restored stdout\n")
+            os.write(2, b"restored stderr\n")
+        finally:
+            os.dup2(original_fds[0], 1)
+            os.dup2(original_fds[1], 2)
+            os.close(original_fds[0])
+            os.close(original_fds[1])
+
+    assert step_log.read_text() == "step stdout\nstep stderr\n"
+    assert stdout_target.read_text() == "restored stdout\n"
+    assert stderr_target.read_text() == "restored stderr\n"
+
+
+def test_capture_stdio_to_file_serializes_process_fds(tmp_path):
+    first_entered = threading.Event()
+    second_attempted = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+
+    def capture_first():
+        with capture_stdio_to_file(str(tmp_path / "first.log")):
+            os.write(1, b"first\n")
+            first_entered.set()
+            release_first.wait(timeout=2)
+
+    def capture_second():
+        first_entered.wait(timeout=2)
+        second_attempted.set()
+        with capture_stdio_to_file(str(tmp_path / "second.log")):
+            second_entered.set()
+            os.write(1, b"second\n")
+
+    first = threading.Thread(target=capture_first)
+    second = threading.Thread(target=capture_second)
+    first.start()
+    second.start()
+    try:
+        assert first_entered.wait(timeout=2)
+        assert second_attempted.wait(timeout=2)
+        assert not second_entered.wait(timeout=0.05)
+    finally:
+        release_first.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert second_entered.is_set()
+    assert (tmp_path / "first.log").read_text() == "first\n"
+    assert (tmp_path / "second.log").read_text() == "second\n"
+
+
+def test_rpc_redirect_does_not_restore_step_capture_after_capture_exits(tmp_path):
+    original_fds = (os.dup(1), os.dup(2))
+    stdout_target = tmp_path / "stdout.txt"
+    stderr_target = tmp_path / "stderr.txt"
+    step_log = tmp_path / "step.log"
+    capture_entered = threading.Event()
+    release_capture = threading.Event()
+    capture_exited = threading.Event()
+
+    def capture_step():
+        with capture_stdio_to_file(str(step_log)):
+            capture_entered.set()
+            release_capture.wait(timeout=2)
+        capture_exited.set()
+
+    def dispatch_rpc():
+        capture_entered.wait(timeout=2)
+        with redirect_stdout_to_stderr():
+            release_capture.set()
+            capture_exited.wait(timeout=2)
+
+    with open(stdout_target, "wb") as stdout_file, open(stderr_target, "wb") as stderr_file:
+        os.dup2(stdout_file.fileno(), 1)
+        os.dup2(stderr_file.fileno(), 2)
+        first = threading.Thread(target=capture_step)
+        second = threading.Thread(target=dispatch_rpc)
+        try:
+            first.start()
+            second.start()
+            first.join(timeout=2)
+            second.join(timeout=2)
+            assert not first.is_alive()
+            assert not second.is_alive()
+            os.write(1, b"after capture\n")
+        finally:
+            os.dup2(original_fds[0], 1)
+            os.dup2(original_fds[1], 2)
+            os.close(original_fds[0])
+            os.close(original_fds[1])
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+
+    assert stdout_target.read_text() == "after capture\n"
+    assert "after capture" not in step_log.read_text()

--- a/test/runtime/test_methods.py
+++ b/test/runtime/test_methods.py
@@ -34,6 +34,7 @@ def test_runtime_method_registry_contains_current_methods_once():
         "operation.cancel",
         "operation.ack_step_rendered",
         "workspace.snapshot",
+        "workspace.recover_interrupted",
     )
 
     assert runtime_method_names() == expected_methods

--- a/test/runtime/test_operations.py
+++ b/test/runtime/test_operations.py
@@ -411,6 +411,95 @@ def test_step_log_events_stream_only_new_log_bytes_and_keep_final_tail(tmp_path)
     assert _wait_for_terminal(manager, started["operationId"])["state"] == "succeeded"
 
 
+def test_step_error_survives_generic_runner_error_and_releases_workspace(tmp_path):
+    events = []
+    manager = RuntimeOperationManager(events.append)
+    log_file = tmp_path / "place.log"
+    log_file.write_text("traceback\n", encoding="utf-8")
+    step = SimpleNamespace(
+        name="place",
+        tool="dreamplace",
+        log=SimpleNamespace(file=log_file),
+    )
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Imcomplete, "movable utilization is 100.0%")
+        raise RuntimeError("run step place failed with state Imcomplete")
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=False,
+        step="place",
+        idempotency_key="failed-place",
+        runner=runner,
+    )
+
+    status = _wait_for_terminal(manager, started["operationId"])
+    assert status["error"] == {
+        "code": "tool_failed",
+        "message": "movable utilization is 100.0%",
+        "step": "place",
+        "tool": "dreamplace",
+        "logFile": str(log_file),
+    }
+    assert _wait_for_event(events, "operation.failed")["payload"]["error"] == status["error"]
+    second = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=True,
+        step="place",
+        idempotency_key="retry-place",
+        runner=lambda _observer: {"state": "Success"},
+    )
+    assert _wait_for_terminal(manager, second["operationId"])["state"] == "succeeded"
+
+
+def test_cancel_does_not_replace_a_specific_tool_error(tmp_path):
+    manager = RuntimeOperationManager()
+    log_file = tmp_path / "place.log"
+    step = SimpleNamespace(
+        name="place",
+        tool="dreamplace",
+        log=SimpleNamespace(file=log_file),
+    )
+    step_failed = threading.Event()
+    release_runner = threading.Event()
+
+    def runner(observer):
+        observer.on_step_started(step)
+        observer.on_step_completed(step, StateEnum.Imcomplete, "utilization is larger than 0.99")
+        step_failed.set()
+        assert release_runner.wait(timeout=2)
+        raise RuntimeError("run step place failed with state Incomplete")
+
+    started = manager.start(
+        workspace_id="workspace-1",
+        kind="step",
+        origin="gui",
+        rerun=False,
+        step="place",
+        idempotency_key="cancelled-failed-place",
+        runner=runner,
+    )
+    assert step_failed.wait(timeout=1)
+    assert manager.request_cancel(started["operationId"])["accepted"] is True
+    release_runner.set()
+
+    status = _wait_for_terminal(manager, started["operationId"])
+    assert status["state"] == "failed"
+    assert status["error"] == {
+        "code": "tool_failed",
+        "message": "utilization is larger than 0.99",
+        "step": "place",
+        "tool": "dreamplace",
+        "logFile": str(log_file),
+    }
+
+
 def _wait_for_event(events: list[dict], event_type: str) -> dict:
     for _ in range(200):
         for event in events:

--- a/test/runtime/test_server.py
+++ b/test/runtime/test_server.py
@@ -73,6 +73,9 @@ class CompleteFakeApi:
     def workspace_snapshot(self, _request):
         raise AssertionError("unexpected workspace_snapshot call")
 
+    def recover_interrupted(self, _request):
+        raise AssertionError("unexpected recover_interrupted call")
+
     def db_ensure(self, _request):
         raise AssertionError("unexpected db_ensure call")
 

--- a/test/runtime/test_subflow_events.py
+++ b/test/runtime/test_subflow_events.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+import pytest
+
+from chipcompiler.runtime import subflow_events
+
+
+def test_interrupted_subflow_write_failure_restores_ongoing_state(monkeypatch, tmp_path):
+    step = {"name": "run placement", "state": "Ongoing"}
+    workspace_step = SimpleNamespace(
+        subflow=SimpleNamespace(path=tmp_path / "subflow.json", steps=[step])
+    )
+    monkeypatch.setattr(subflow_events, "json_write", lambda *_args, **_kwargs: False)
+
+    with pytest.raises(OSError, match="failed to save interrupted subflow"):
+        subflow_events.finalize_interrupted_subflow(workspace_step, "0:0:1", 10.0)
+
+    assert step == {"name": "run placement", "state": "Ongoing"}

--- a/test/runtime/test_workspace_api.py
+++ b/test/runtime/test_workspace_api.py
@@ -17,6 +17,7 @@ from chipcompiler.runtime.requests import (
     WorkspaceIdRequest,
     WorkspaceInfoRequest,
     WorkspaceOpenRequest,
+    WorkspaceRecoverInterruptedRequest,
     WorkspaceSyncConfigRequest,
 )
 from chipcompiler.runtime.sessions import WorkspaceSessionRegistry
@@ -400,6 +401,123 @@ def test_open_workspace_loads_without_creating_step_workspaces(monkeypatch, tmp_
     }
     assert capture["loaded"] == [str(ws)]
     assert not DummyFlow.instances[0].created
+
+
+def test_recover_interrupted_is_marker_scoped_and_idempotent(monkeypatch, tmp_path):
+    _capture, ws = _install_runtime_mocks(monkeypatch, tmp_path)
+    api = WorkspaceRuntimeApi()
+    workspace_id = api.open_workspace(WorkspaceOpenRequest(directory=str(ws)))["workspaceId"]
+    session = api.sessions.get_session(workspace_id)
+    session.workspace.flow.data = {
+        "steps": [
+            {
+                "name": "place",
+                "tool": "dreamplace",
+                "state": "Ongoing",
+                "info": {
+                    "runtime_operation": {
+                        "schema": 1,
+                        "operation_id": "operation-1",
+                        "runtime_instance_id": "runtime-old",
+                        "started_at": 1.0,
+                    }
+                },
+            },
+            {"name": "route", "tool": "ecc", "state": "Ongoing", "info": {}},
+            {
+                "name": "Floorplan",
+                "tool": "ecc",
+                "state": "Success",
+                "info": {
+                    "runtime_operation": {
+                        "schema": 1,
+                        "operation_id": "operation-2",
+                    }
+                },
+            },
+            {
+                "name": "CTS",
+                "tool": "ecc",
+                "state": "Ongoing",
+                "info": {
+                    "runtime_operation": {
+                        "schema": 1,
+                        "operation_id": "operation-partial",
+                    }
+                },
+            },
+            {
+                "name": "STA",
+                "tool": "ecc",
+                "state": "Ongoing",
+                "info": {
+                    "runtime_operation": {
+                        "schema": 1,
+                        "operation_id": "operation-active",
+                        "runtime_instance_id": "runtime-current",
+                        "started_at": 2.0,
+                    }
+                },
+            },
+            {
+                "name": "DRC",
+                "tool": "ecc",
+                "state": "Ongoing",
+                "info": {
+                    "runtime_operation": {
+                        "schema": 1,
+                        "operation_id": "operation-previous",
+                        "runtime_instance_id": "runtime-old",
+                        "started_at": 3.0,
+                    }
+                },
+            },
+        ]
+    }
+    mismatch = api.recover_interrupted(
+        WorkspaceRecoverInterruptedRequest(workspace_id, "operation-other")
+    )
+    assert mismatch == {"recovered": []}
+
+    result = api.recover_interrupted(
+        WorkspaceRecoverInterruptedRequest(workspace_id, "operation-1")
+    )
+    assert result == {
+        "recovered": [
+            {
+                "step": "place",
+                "tool": "dreamplace",
+                "operationId": "operation-1",
+                "logFile": str(ws / "place_dreamplace" / "log" / "place.log"),
+            }
+        ]
+    }
+    assert session.workspace.flow.data["steps"][0]["state"] == StateEnum.Imcomplete.value
+    assert session.workspace.flow.data["steps"][0]["info"] == {}
+    assert session.workspace.flow.data["steps"][1]["state"] == "Ongoing"
+    assert session.workspace.flow.data["steps"][2]["state"] == "Success"
+    monkeypatch.setattr(
+        api.operations,
+        "is_active",
+        lambda operation_id: operation_id == "operation-active",
+    )
+    previous = api.recover_interrupted(WorkspaceRecoverInterruptedRequest(workspace_id))
+    assert previous == {
+        "recovered": [
+            {
+                "step": "DRC",
+                "tool": "ecc",
+                "operationId": "operation-previous",
+                "logFile": str(ws / "DRC_ecc" / "log" / "DRC.log"),
+            }
+        ]
+    }
+    assert session.workspace.flow.data["steps"][3]["state"] == "Ongoing"
+    assert session.workspace.flow.data["steps"][4]["state"] == "Ongoing"
+    assert session.workspace.flow.data["steps"][5]["state"] == StateEnum.Imcomplete.value
+    assert api.recover_interrupted(
+        WorkspaceRecoverInterruptedRequest(workspace_id, "operation-1")
+    ) == {"recovered": []}
 
 
 def test_create_workspace_replaces_existing_same_directory_session(monkeypatch, tmp_path):

--- a/test/test_engine_flow.py
+++ b/test/test_engine_flow.py
@@ -1,3 +1,4 @@
+import ctypes
 import json
 from hashlib import sha256
 from types import SimpleNamespace
@@ -11,9 +12,11 @@ from chipcompiler.data import (
     EccFeature,
     EccOutput,
     EccStep,
+    LogPaths,
     StateEnum,
     StepEnum,
     StepMetrics,
+    SubflowState,
     Workspace,
     YosysOutput,
     YosysStep,
@@ -301,6 +304,40 @@ class TestStepExceptionForcesIncomplete:
         state = engine_flow.run_step(workspace_step)
         assert state == StateEnum.Imcomplete
 
+    def test_native_output_precedes_failure_summary(self, monkeypatch, tmp_path):
+        workspace = Workspace()
+        workspace.flow.data = {
+            "steps": [{"name": "place", "tool": "dreamplace", "state": "Unstart"}],
+        }
+        log_file = tmp_path / "place.log"
+        workspace_step = EccStep(
+            name="place",
+            directory=tmp_path,
+            tool="dreamplace",
+            log=LogPaths(file=log_file),
+        )
+        engine_flow = EngineFlow(workspace)
+        engine_flow.workspace_steps = [workspace_step]
+        engine_flow.engine_db = SimpleNamespace(engine=None)
+        monkeypatch.setattr(workspace.logger, "error", print)
+        monkeypatch.setattr(workspace.logger, "exception", print)
+
+        def fail_after_native_output(**_kwargs):
+            libc = ctypes.CDLL(None)
+            libc.fputs(
+                b"[native] setup completed\n",
+                ctypes.c_void_p.in_dll(libc, "stdout"),
+            )
+            raise RuntimeError("placement failed")
+
+        monkeypatch.setattr(tools, "run_step", fail_after_native_output)
+
+        assert engine_flow.run_step(workspace_step) == StateEnum.Imcomplete
+        contents = log_file.read_text(encoding="utf-8")
+        assert contents.index("[native] setup completed") < contents.index(
+            "[STEP] place(dreamplace) failed"
+        )
+
     def test_no_exception_uses_file_check(self, monkeypatch, tmp_path):
         workspace = Workspace()
         workspace.flow.data = {
@@ -318,6 +355,169 @@ class TestStepExceptionForcesIncomplete:
 
         state = engine_flow.run_step(workspace_step)
         assert state == StateEnum.Success
+
+    def test_marker_persist_failure_does_not_start_tool(self, monkeypatch, tmp_path):
+        workspace = Workspace()
+        engine_flow = EngineFlow(workspace)
+        workspace.flow.data = {
+            "steps": [{"name": "place", "tool": "dreamplace", "state": "Unstart", "info": {}}],
+        }
+        workspace_step = EccStep(name="place", directory=tmp_path, tool="dreamplace")
+        engine_flow.workspace_steps = [workspace_step]
+
+        class Observer:
+            runtime_operation = {
+                "schema": 1,
+                "operation_id": "operation-1",
+                "runtime_instance_id": "runtime-1",
+            }
+
+        monkeypatch.setattr(engine_flow, "save", lambda: False)
+        monkeypatch.setattr(
+            tools,
+            "run_step",
+            lambda **_kwargs: pytest.fail("tool must not start without a durable marker"),
+        )
+
+        with pytest.raises(RuntimeError, match="failed to persist runtime operation marker"):
+            engine_flow.run_step(workspace_step, observer=Observer())
+
+        assert workspace.flow.data["steps"][0] == {
+            "name": "place",
+            "tool": "dreamplace",
+            "state": "Unstart",
+            "info": {},
+        }
+
+    def test_terminal_persist_failure_keeps_recoverable_marker(self, monkeypatch, tmp_path):
+        workspace = Workspace()
+        workspace.flow.path = tmp_path / "flow.json"
+        flow_data = {
+            "steps": [{"name": "place", "tool": "dreamplace", "state": "Unstart", "info": {}}],
+        }
+        workspace.flow.path.write_text(json.dumps(flow_data), encoding="utf-8")
+        workspace.flow.data = flow_data
+        engine_flow = EngineFlow(workspace)
+        workspace_step = EccStep(name="place", directory=tmp_path, tool="dreamplace")
+        engine_flow.workspace_steps = [workspace_step]
+        engine_flow.engine_db = SimpleNamespace(engine=None)
+
+        class Observer:
+            runtime_operation = {
+                "schema": 1,
+                "operation_id": "operation-1",
+                "runtime_instance_id": "runtime-1",
+            }
+
+        saves = iter([True, False, False])
+        monkeypatch.setattr(engine_flow, "save", lambda: next(saves))
+        monkeypatch.setattr(tools, "run_step", lambda **_kwargs: True)
+        monkeypatch.setattr(engine_flow, "check_step_result", lambda **_kwargs: True)
+
+        with pytest.raises(RuntimeError, match="failed to persist terminal state"):
+            engine_flow.run_step(workspace_step, observer=Observer())
+
+        step = workspace.flow.data["steps"][0]
+        assert step["state"] == StateEnum.Ongoing.value
+        assert step["info"]["runtime_operation"]["operation_id"] == "operation-1"
+
+    def test_result_check_system_exit_still_finalizes_step(self, monkeypatch, tmp_path):
+        workspace = Workspace()
+        workspace.flow.path = tmp_path / "flow.json"
+        workspace.flow.data = {
+            "steps": [{"name": "place", "tool": "dreamplace", "state": "Unstart", "info": {}}],
+        }
+        workspace.flow.path.write_text(json.dumps(workspace.flow.data), encoding="utf-8")
+        engine_flow = EngineFlow(workspace)
+        workspace_step = EccStep(name="place", directory=tmp_path, tool="dreamplace")
+        engine_flow.workspace_steps = [workspace_step]
+        engine_flow.engine_db = SimpleNamespace(engine=None)
+        completed = []
+
+        class Observer:
+            runtime_operation = {
+                "schema": 1,
+                "operation_id": "operation-1",
+                "runtime_instance_id": "runtime-1",
+            }
+
+            def on_step_completed(self, _step, state, error=None):
+                completed.append((state, error))
+
+        monkeypatch.setattr(tools, "run_step", lambda **_kwargs: True)
+        monkeypatch.setattr(
+            engine_flow,
+            "check_step_result",
+            lambda **_kwargs: (_ for _ in ()).throw(SystemExit(0)),
+        )
+
+        assert engine_flow.run_step(workspace_step, observer=Observer()) == StateEnum.Imcomplete
+        assert completed == [
+            (
+                StateEnum.Imcomplete,
+                "place(dreamplace) exited unexpectedly (code 0).",
+            )
+        ]
+        persisted_step = json.loads(workspace.flow.path.read_text(encoding="utf-8"))["steps"][0]
+        assert persisted_step["state"] == StateEnum.Imcomplete.value
+        assert persisted_step["info"] == {}
+
+    @pytest.mark.parametrize("exit_code", [0, 1])
+    def test_system_exit_is_incomplete_and_preserves_error(self, monkeypatch, tmp_path, exit_code):
+        workspace = Workspace()
+        workspace.flow.path = tmp_path / "flow.json"
+        flow_data = {
+            "steps": [{"name": "place", "tool": "dreamplace", "state": "Unstart", "info": {}}],
+        }
+        workspace.flow.path.write_text(json.dumps(flow_data), encoding="utf-8")
+        workspace.flow.data = flow_data
+        engine_flow = EngineFlow(workspace)
+        subflow_path = tmp_path / "subflow.json"
+        workspace_step = EccStep(
+            name="place",
+            directory=tmp_path,
+            tool="dreamplace",
+            subflow=SubflowState(
+                path=subflow_path,
+                steps=[{"name": "run placement", "state": "Ongoing"}],
+            ),
+        )
+        engine_flow.workspace_steps = [workspace_step]
+        engine_flow.engine_db = SimpleNamespace(engine=None)
+        completed = []
+
+        class Observer:
+            runtime_operation = {
+                "schema": 1,
+                "operation_id": "operation-1",
+                "runtime_instance_id": "runtime-1",
+            }
+
+            def on_step_started(self, _step):
+                marker = workspace.flow.data["steps"][0]["info"]["runtime_operation"]
+                assert marker["operation_id"] == "operation-1"
+                assert marker["started_at"] > 0
+
+            def on_step_completed(self, _step, state, error=None):
+                completed.append((state, error))
+
+        monkeypatch.setattr(
+            tools, "run_step", lambda **_kwargs: (_ for _ in ()).throw(SystemExit(exit_code))
+        )
+
+        assert engine_flow.run_step(workspace_step, observer=Observer()) == StateEnum.Imcomplete
+        assert completed == [
+            (
+                StateEnum.Imcomplete,
+                f"place(dreamplace) exited unexpectedly (code {exit_code}).",
+            )
+        ]
+        assert workspace.flow.data["steps"][0]["info"] == {}
+        interrupted_step = json.loads(subflow_path.read_text(encoding="utf-8"))["steps"][0]
+        assert interrupted_step["name"] == "run placement"
+        assert interrupted_step["state"] == StateEnum.Imcomplete.value
+        assert interrupted_step["runtime"] == "0:0:0"
+        assert interrupted_step["peak memory (mb)"] >= 0
 
 
 class TestCreateStepFailureBreaksChain:

--- a/test/utility/test_json.py
+++ b/test/utility/test_json.py
@@ -155,7 +155,7 @@ class TestJsonWriteFailureLogging:
 class TestFlowSetStatePersistence:
     """Tests for EngineFlow.set_state json_write failure handling."""
 
-    def test_set_state_updates_in_memory_when_save_fails(self, tmp_path, monkeypatch):
+    def test_set_state_rolls_back_when_save_fails(self, tmp_path, monkeypatch):
         from chipcompiler.data import StateEnum
         from chipcompiler.engine.flow import EngineFlow
 
@@ -191,9 +191,8 @@ class TestFlowSetStatePersistence:
         monkeypatch.setattr("chipcompiler.utility.json_write", lambda *a, **kw: False)
 
         result = flow.set_state("SYNTHESIS", "yosys", StateEnum.Success)
-        assert result is True
-        # In-memory state is updated
-        assert workspace.flow.data["steps"][0]["state"] == StateEnum.Success.value
+        assert result is False
+        assert workspace.flow.data["steps"][0]["state"] == StateEnum.Unstart.value
 
     def test_stale_file_causes_rerun_on_resume(self, tmp_path, monkeypatch):
         """When save() fails, file stays stale; a fresh resume load sees stale state."""


### PR DESCRIPTION
## What Changed

- Contain tool exceptions and `SystemExit` inside the step execution boundary, persist `Imcomplete`, and preserve the original failure message in runtime events.
- Persist schema-1 runtime operation markers and add an idempotent `workspace.recover_interrupted` RPC for interrupted steps.
- Finalize subflow/checklist/observer state on terminal failures and update the `ecc-dreamplace` gitlink for catchable utilization failures.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [x] Native toolchain or wrapper behavior changed
- [x] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

- Ongoing steps now store `info.runtime_operation` in `workspace.flow.json`; the marker is cleared on normal terminal completion.
- `workspace.recover_interrupted` only transitions matching schema-1 interrupted steps to `Imcomplete` and does not rerun them.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/ --ignore=test/examples/test_soc.py -q`
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [x] Manual flow smoke: verified DreamPlace failure persistence and rerun state through the GUI.
- [x] Other: `bash .github/scripts/check-version.sh`; `git diff --check origin/main...HEAD`

Skipped checks and reason:

- PyInstaller bundle build was skipped because packaging files are unchanged; CI will run the bundle job.
- Nix smoke was skipped because Nix files are unchanged.

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed. (N/A: no public CLI text or documentation contract changed.)
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
