### PR TITLE
fix(data): preserve workspace paths in home reset

### DIFF
--- a/chipcompiler/data/home.py
+++ b/chipcompiler/data/home.py
@@ -74,7 +74,15 @@ class HomeData:
         self._repair_or_reload()
 
     def reset(self):
-        self._update(lambda data: data.clear() or data.update(_default_home_data()))
+        def mutator(data: dict) -> None:
+            # parameters/flow/checklist locate workspace-lifetime files; only
+            # per-run state (layout/metrics) is cleared.
+            paths = {key: data[key] for key in ("parameters", "flow", "checklist") if data.get(key)}
+            data.clear()
+            data.update(_default_home_data())
+            data.update(paths)
+
+        self._update(mutator)
 
     def save(self):
         source = self.data

--- a/chipcompiler/tools/ecc/signoff_checklist.py
+++ b/chipcompiler/tools/ecc/signoff_checklist.py
@@ -691,7 +691,13 @@ def rebuild_home_checklist(workspace: Workspace, resource_issues=None) -> dict:
     for item in items:
         if isinstance(item, dict):
             deduplicated[item.get("id")] = item
-    checklist_path = workspace.home.data.get("checklist", workspace_dir / "home" / "checklist.json")
+    checklist_path = workspace.home.data.get("checklist")
+    if not checklist_path:
+        # Recover home.json files whose checklist path was cleared by an older
+        # home.reset(); persist so later checklist updates resolve as well.
+        checklist_path = workspace_dir / "home" / "checklist.json"
+        if workspace.home.path is not None:
+            workspace.home.set_checklist(checklist_path)
     checklist = Checklist(checklist_path)
     checklist.replace(list(deduplicated.values()))
     return checklist.data

--- a/test/data/test_home_data.py
+++ b/test/data/test_home_data.py
@@ -151,3 +151,26 @@ def test_path_setters_accept_path_and_persist_strings(tmp_path):
     assert data["flow"] == str(flow_path)
     assert data["parameters"] == str(parameters_path)
     assert data["checklist"] == str(checklist_path)
+
+
+def test_reset_clears_run_state_but_preserves_workspace_paths(tmp_path):
+    path = tmp_path / "home.json"
+    home = HomeData()
+    home.init(path)
+    home.set_flow(tmp_path / "flow.json")
+    home.set_parameters(tmp_path / "parameters.json")
+    home.set_checklist(tmp_path / "checklist.json")
+    home.set_layout(tmp_path / "layout.png")
+    home.set_metrics_pin_dist(tmp_path / "pin.png")
+
+    home.reset()
+
+    expected = {
+        "parameters": str(tmp_path / "parameters.json"),
+        "flow": str(tmp_path / "flow.json"),
+        "layout": "",
+        "checklist": str(tmp_path / "checklist.json"),
+        "metrics": {},
+    }
+    assert _read_json(path) == expected
+    assert home.data == expected

--- a/test/tools/ecc/test_signoff_checklist.py
+++ b/test/tools/ecc/test_signoff_checklist.py
@@ -723,3 +723,28 @@ def test_home_checklist_uses_current_post_route_lec_result_not_stale_snapshot(tm
     home_items = {item["id"]: item for item in rebuild_home_checklist(workspace)["checklist"]}
     assert home_items["artifact.postroutelec.result"]["state"] == "pass"
     assert home_items["artifact.postroutelec.result"]["blocked"] is False
+
+
+def test_rebuild_home_checklist_heals_empty_home_checklist_path(tmp_path):
+    workspace = Workspace(directory=tmp_path, design=OriginDesign(name="gcd"))
+    (tmp_path / "home").mkdir()
+    workspace.home.init(tmp_path / "home" / "home.json")
+    assert workspace.home.data["checklist"] == ""
+
+    data = rebuild_home_checklist(workspace)
+
+    checklist_file = tmp_path / "home" / "checklist.json"
+    assert checklist_file.is_file()
+    persisted = json.loads(checklist_file.read_text(encoding="utf-8"))
+    assert persisted["checklist"] == data["checklist"]
+
+    home_data = json.loads((tmp_path / "home" / "home.json").read_text(encoding="utf-8"))
+    assert home_data["checklist"] == str(checklist_file)
+
+    workspace.home.update_checklist(
+        step="STA", type="Timing", item="check setup timing", state="Passed"
+    )
+    healed = json.loads(checklist_file.read_text(encoding="utf-8"))
+    assert [item["id"] for item in healed["checklist"] if item["step"] == "STA"] == [
+        "sta.check.setup.timing"
+    ]


### PR DESCRIPTION
run_flow_with_progress() calls home.reset() at the start of every progress-mode run, and reset() restored the default template including empty parameters/flow/checklist path fields. STA's rebuild_home_checklist() then picked up the empty checklist path (the .get default only applies to a missing key), built Path("") which resolves to the process cwd, and json_write() failed with IsADirectoryError trying to replace the repository directory. The same empty path also silently dropped every home checklist update during CLI runs.

reset() now clears only per-run state (layout/metrics/monitor) and keeps the workspace-lifetime path fields, matching how both callers use it (prepare_workspace_for_rerun re-sets the same paths immediately after). rebuild_home_checklist() additionally recovers home.json files already corrupted by earlier runs: when the stored checklist path is empty it falls back to the default home/checklist.json location and persists the healed path, so subsequent home checklist updates resolve as well.

## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
