### PR TITLE
feat: tune default delay synthesis strategy

### DIFF
--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -42,7 +42,7 @@ yosys -import
 #   DELAY N   — maximize frequency
 #   AREA N    — minimize area
 #   BALANCE N — balanced PPA
-set synth_strategy "BALANCE 3"
+set synth_strategy "DELAY 4"
 if {[info exists env(YOSYS_SYNTH_STRATEGY)]} {
   # TODO: Move this to global_var.tcl
   set synth_strategy $::env(YOSYS_SYNTH_STRATEGY)
@@ -70,11 +70,11 @@ set valid_types {DELAY AREA BALANCE}
 
 # --- DELAY family ---
 # Slack margin: tighten target to push frequency (<1 = tighter)
-set delay_slack_margin 0.92
+set delay_slack_margin 0.95
 # Redelay depth
 set delay_retime_M 8
 # Max fanout for buffer insertion
-set delay_max_FO 24
+set delay_max_FO 20
 # Multi-pass: 0=off, 1=on (second ABC pass to reinforce critical paths)
 set delay_multipass 1
 # Pass-2 relaxation factor
@@ -195,7 +195,7 @@ close $abc_constr_file
 
 #=======================================================================
 # DELAY scripts — maximize frequency
-# 12 scripts (index 0..11)
+# 14 scripts (index 0..13)
 # Common prefix: fx;mfs;strash;refactor;resyn2;retime_dly;scleanup
 # Mapper: abc_map_tight (map,-p,-B,0.2,-A,0.9,-M,0)
 # Fine-tune: abc_finetune_delay / delay2 / delay3 (upsize+buffer)


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
