### PR TITLE
test: make stdio redirection scoped and exception-safe

### DIFF
--- a/test/engine/test_state_machine_regression.py
+++ b/test/engine/test_state_machine_regression.py
@@ -10,11 +10,20 @@ import logging
 import os
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 from chipcompiler import tools
-from chipcompiler.data import EccOutput, EccStep, OriginDesign, StateEnum, StepEnum, Workspace
+from chipcompiler.data import (
+    EccOutput,
+    EccStep,
+    LogPaths,
+    OriginDesign,
+    StateEnum,
+    StepEnum,
+    Workspace,
+)
 from chipcompiler.data.workspace import Flow
 from chipcompiler.engine.flow import _VALID_TRANSITIONS, EngineFlow
 from chipcompiler.tools.ecc.runner import EccDesignReadError
@@ -487,6 +496,103 @@ class TestLegacyStateNormalization:
 
         persisted = json.loads((tmp_path / "home" / "flow.json").read_text())
         assert persisted["steps"][1]["state"] == StateEnum.Success.value
+
+
+def test_agent_flow_unusable_log_path_does_not_block_execution(tmp_path, monkeypatch):
+    """AgentEngineFlow: unusable step-log path must not block tool execution."""
+    import agent.engine as agent_engine
+
+    step_dir = tmp_path / "Floorplan_ecc"
+    step_dir.mkdir()
+
+    workspace = Workspace(directory=tmp_path, flow=Flow(path=tmp_path / "flow.json"))
+    workspace.flow.data = {
+        "steps": [
+            {
+                "name": "Floorplan",
+                "tool": "ecc",
+                "state": StateEnum.Unstart.value,
+                "runtime": "",
+                "peak memory (mb)": 0,
+                "info": {},
+            }
+        ]
+    }
+    workspace.logger = Logger()
+
+    agent_flow = agent_engine.AgentEngineFlow.__new__(agent_engine.AgentEngineFlow)
+    agent_flow.workspace = workspace
+    agent_flow.workspace_steps = [
+        EccStep(
+            name="Floorplan",
+            tool="ecc",
+            directory=step_dir,
+            output=EccOutput(verilog=step_dir / "design.v"),
+            log=LogPaths(file=tmp_path),  # directory — open() raises IsADirectoryError
+        )
+    ]
+    agent_flow.engine_db = SimpleNamespace(engine=None)
+
+    mock_run = MagicMock(return_value=True)
+    monkeypatch.setattr(agent_engine, "run_agent_step", mock_run)
+    monkeypatch.setattr(agent_flow, "check_step_result", lambda **_kw: True)
+
+    result = agent_flow.run_step(agent_flow.workspace_steps[0], rerun=False)
+
+    assert mock_run.call_count == 1
+    assert result == StateEnum.Success
+
+    persisted = json.loads((tmp_path / "flow.json").read_text())
+    assert persisted["steps"][0]["state"] != StateEnum.Ongoing.value
+
+
+def test_agent_flow_step_failure_not_silently_swallowed(tmp_path, monkeypatch):
+    """AgentEngineFlow: run_agent_step() failure must not be swallowed."""
+    import agent.engine as agent_engine
+
+    log_file = tmp_path / "agent_step.log"
+    step_dir = tmp_path / "Floorplan_ecc"
+    step_dir.mkdir()
+
+    workspace = Workspace(directory=tmp_path, flow=Flow(path=tmp_path / "flow.json"))
+    workspace.flow.data = {
+        "steps": [
+            {
+                "name": "Floorplan",
+                "tool": "ecc",
+                "state": StateEnum.Unstart.value,
+                "runtime": "",
+                "peak memory (mb)": 0,
+                "info": {},
+            }
+        ]
+    }
+    workspace.logger = Logger()
+
+    agent_flow = agent_engine.AgentEngineFlow.__new__(agent_engine.AgentEngineFlow)
+    agent_flow.workspace = workspace
+    agent_flow.workspace_steps = [
+        EccStep(
+            name="Floorplan",
+            tool="ecc",
+            directory=step_dir,
+            output=EccOutput(verilog=step_dir / "design.v"),
+            log=LogPaths(file=log_file),
+        )
+    ]
+    agent_flow.engine_db = SimpleNamespace(engine=None)
+
+    def _raise(**_kw):
+        raise RuntimeError("tool crashed")
+
+    monkeypatch.setattr(agent_engine, "run_agent_step", _raise)
+
+    result = agent_flow.run_step(agent_flow.workspace_steps[0], rerun=False)
+
+    assert result == StateEnum.Imcomplete
+
+    persisted = json.loads((tmp_path / "flow.json").read_text())
+    assert persisted["steps"][0]["state"] != StateEnum.Ongoing.value
 
 
 class TestRunStepsLedgerCompleteness:


### PR DESCRIPTION
## What Changed

- Replaced process-global stdout/stderr redirection in chipcompiler/utility/log.py with a thread-safe, context-managed _StdioRedirect implementation that safely saves and restores file descriptors even upon exceptions.

Updated chipcompiler/engine/flow.py, chipcompiler/engine/rerun.py, and agent/engine.py to ensure step-level log redirects close cleanly.

Updated chipcompiler/runtime/operations.py to treat event publisher exceptions as non-fatal and wrapped active operation tracking in finally blocks to guarantee cleanup.

Added and updated tests in test/cli/rendering/test_progress.py, test/runtime/test_events.py, and test/runtime/test_operations.py to cover stdio restoration, thread isolation under concurrency, and resilient operation tracking.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

- Fixed critical bugs where process-global stdio redirection corrupts concurrent flow logs, and where event publisher failures leave active operations permanently uncleaned.


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [x] Manual flow smoke:
- [x] Other: - `uv run pytest test/` — 1460 passed, 8 skipped, 4 xfailed, 2 environment-related failures.

Skipped checks and reason:

-

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
