### PR TITLE
feat(runtime): support injecting additional files into signoff export archive

### DIFF
--- a/chipcompiler/runtime/requests.py
+++ b/chipcompiler/runtime/requests.py
@@ -48,6 +48,7 @@ class WorkspaceSyncConfigRequest:
 class WorkspaceExportSignoffRequest:
     workspace_id: str
     output_path: str
+    additional_files: list[dict[str, str]] | None = None
 
 
 @dataclass(frozen=True)
@@ -192,6 +193,7 @@ FIELD_ALIASES = {
     "expectedRevision": "expected_revision",
     "expectedSourceFingerprint": "expected_source_fingerprint",
     "id": "info_id",
+    "additionalFiles": "additional_files",
 }
 
 

--- a/chipcompiler/runtime/signoff_export.py
+++ b/chipcompiler/runtime/signoff_export.py
@@ -220,17 +220,18 @@ def export_signoff_package_archive(
                 "command_failed",
                 "signoff package directory was not created",
             )
-            
+
         package_dir = Path(result.package_dir)
-        
+
         if additional_files:
             for file_info in additional_files:
                 p = package_dir / file_info["archivePath"]
                 p.parent.mkdir(parents=True, exist_ok=True)
                 p.write_text(file_info["content"], encoding="utf-8")
-                
+
         archive = package_dir.with_suffix(".tar.gz")
         import tarfile
+
         with tarfile.open(archive, "w:gz") as tar:
             tar.add(package_dir, arcname=package_dir.name)
 

--- a/chipcompiler/runtime/signoff_export.py
+++ b/chipcompiler/runtime/signoff_export.py
@@ -193,7 +193,11 @@ def _review_group_for_item(item: dict) -> str:
     return "reports"
 
 
-def export_signoff_package_archive(workspace, output_path: str) -> str:
+def export_signoff_package_archive(
+    workspace,
+    output_path: str,
+    additional_files: list[dict[str, str]] | None = None,
+) -> str:
     raw_destination = Path(output_path).expanduser()
     destination = raw_destination.parent.resolve() / raw_destination.name
 
@@ -201,7 +205,7 @@ def export_signoff_package_archive(workspace, output_path: str) -> str:
         result = EngineFlow(workspace).collect_signoff_package(
             SignoffPackageOptions(
                 output_dir=temporary_root,
-                archive=True,
+                archive=False,
                 refresh_analysis=True,
             )
         )
@@ -211,18 +215,24 @@ def export_signoff_package_archive(workspace, output_path: str) -> str:
                 "command_failed",
                 f"signoff package is incomplete: {missing}",
             )
-        if not result.archive_path:
+        if not result.package_dir:
             raise RuntimeApiError(
                 "command_failed",
-                "signoff package archive was not created",
+                "signoff package directory was not created",
             )
-
-        archive = Path(result.archive_path)
-        if not archive.is_file():
-            raise RuntimeApiError(
-                "command_failed",
-                "signoff package archive does not exist",
-            )
+            
+        package_dir = Path(result.package_dir)
+        
+        if additional_files:
+            for file_info in additional_files:
+                p = package_dir / file_info["archivePath"]
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(file_info["content"], encoding="utf-8")
+                
+        archive = package_dir.with_suffix(".tar.gz")
+        import tarfile
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(package_dir, arcname=package_dir.name)
 
         destination.parent.mkdir(parents=True, exist_ok=True)
         descriptor, staged_name = tempfile.mkstemp(

--- a/chipcompiler/runtime/workspace_api.py
+++ b/chipcompiler/runtime/workspace_api.py
@@ -224,6 +224,7 @@ class WorkspaceRuntimeApi:
             output_path = export_signoff_package_archive(
                 session.workspace,
                 request.output_path,
+                request.additional_files,
             )
             return {"outputPath": output_path}
 

--- a/test/runtime/test_signoff_export.py
+++ b/test/runtime/test_signoff_export.py
@@ -22,7 +22,7 @@ def test_workspace_export_signoff_returns_exact_output_path(monkeypatch, tmp_pat
     output_path = tmp_path / "exports" / "custom name.tar.gz"
     calls = []
 
-    def fake_export(active_workspace, requested_output):
+    def fake_export(active_workspace, requested_output, additional_files=None):
         calls.append((active_workspace, requested_output))
         return str(output_path)
 
@@ -51,7 +51,7 @@ def test_workspace_export_signoff_waits_for_session_mutation_lock(monkeypatch, t
     entered = threading.Event()
     results = queue.Queue()
 
-    def fake_export(_workspace, requested_output):
+    def fake_export(_workspace, requested_output, additional_files=None):
         entered.set()
         return requested_output
 
@@ -292,7 +292,10 @@ def test_export_signoff_package_archive_collects_temporarily_and_replaces_atomic
     result = export_signoff_package_archive("workspace", str(output_path))
 
     assert result == str(output_path.resolve())
-    assert output_path.read_bytes() == b"archive"
+    import tarfile
+
+    with tarfile.open(output_path, "r:gz") as tar:
+        assert tar.extractfile("design_signoff_package/dummy.txt").read() == b"archive"
     assert captured_output_dirs
     assert not Path(captured_output_dirs[0]).exists()
     assert not list(output_path.parent.glob(f".{output_path.name}.*"))
@@ -353,7 +356,7 @@ def test_export_signoff_package_archive_replaces_symlink_entry_not_target(
         def collect_signoff_package(self, options):
             package_dir = Path(options.output_dir) / "design_signoff_package"
             package_dir.mkdir(parents=True, exist_ok=True)
-            (package_dir / "dummy.txt").write_text("archive")
+            (package_dir / "dummy.txt").write_text("new")
             return SimpleNamespace(ok=True, package_dir=str(package_dir), missing_required=[])
 
     monkeypatch.setattr(
@@ -364,5 +367,8 @@ def test_export_signoff_package_archive_replaces_symlink_entry_not_target(
     export_signoff_package_archive("workspace", str(output_path))
 
     assert not output_path.is_symlink()
-    assert output_path.read_bytes() == b"new"
+    import tarfile
+
+    with tarfile.open(output_path, "r:gz") as tar:
+        assert tar.extractfile("design_signoff_package/dummy.txt").read() == b"new"
     assert target.read_bytes() == b"target"

--- a/test/runtime/test_signoff_export.py
+++ b/test/runtime/test_signoff_export.py
@@ -275,11 +275,12 @@ def test_export_signoff_package_archive_collects_temporarily_and_replaces_atomic
 
         def collect_signoff_package(self, options):
             captured_output_dirs.append(options.output_dir)
-            archive = Path(options.output_dir) / "design_signoff_package.tar.gz"
-            archive.write_bytes(b"archive")
+            package_dir = Path(options.output_dir) / "design_signoff_package"
+            package_dir.mkdir(parents=True, exist_ok=True)
+            (package_dir / "dummy.txt").write_text("archive")
             return SimpleNamespace(
                 ok=True,
-                archive_path=str(archive),
+                package_dir=str(package_dir),
                 missing_required=[],
             )
 
@@ -313,7 +314,7 @@ def test_export_signoff_package_archive_preserves_existing_target_on_incomplete_
         def collect_signoff_package(self, options):
             return SimpleNamespace(
                 ok=False,
-                archive_path=None,
+                package_dir=None,
                 missing_required=["harden/design.gds", "harden/design.lef"],
             )
 
@@ -350,9 +351,10 @@ def test_export_signoff_package_archive_replaces_symlink_entry_not_target(
             pass
 
         def collect_signoff_package(self, options):
-            archive = Path(options.output_dir) / "archive.tar.gz"
-            archive.write_bytes(b"new")
-            return SimpleNamespace(ok=True, archive_path=str(archive), missing_required=[])
+            package_dir = Path(options.output_dir) / "design_signoff_package"
+            package_dir.mkdir(parents=True, exist_ok=True)
+            (package_dir / "dummy.txt").write_text("archive")
+            return SimpleNamespace(ok=True, package_dir=str(package_dir), missing_required=[])
 
     monkeypatch.setattr(
         "chipcompiler.runtime.signoff_export.EngineFlow",


### PR DESCRIPTION
## What Changed

- Extended `WorkspaceExportSignoffRequest` RPC schema to accept an `additional_files` array.
- Modified `export_signoff_package_archive` in the runtime to intercept the uncompressed package directory, write any provided external files (like GUI-generated design summaries), and manually compress the `.tar.gz`.
- Updated test mocks to reflect that `collect_signoff_package` now yields a `package_dir` rather than a pre-compressed `archive_path` when `archive=False` is passed.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [x] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

- The `workspace.export_signoff` JSON-RPC method now accepts an optional `additional_files` array. This is required to support openecos-projects/ecos-studio/pull/196 so the frontend can bundle in-memory generated files into the signoff archive.

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [x] `uv run pytest test/`
- [x] `uv run ruff check chipcompiler test`
- [x] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

- Skipped Nix and PyInstaller smoke tests as this change is strictly confined to the JSON-RPC payload schema and Python-side standard library (`tarfile`) packaging. It does not modify CLI entrypoints, native integrations, or system dependencies.

## Checklist

- [x] I kept the change scoped to ECC.
- [x] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.