### PR TITLE
feat(cli): ecc run -to

### DIFF
--- a/chipcompiler/cli/command_handlers/project.py
+++ b/chipcompiler/cli/command_handlers/project.py
@@ -195,6 +195,7 @@ def run(command_input: RunInput, ctx: CommandContext) -> CommandResult:
         (
             command_input.resume,
             command_input.from_step is not None,
+            command_input.to_step is not None,
             command_input.only is not None,
             command_input.force,
         )
@@ -488,6 +489,8 @@ def _run_workspace(command_input: RunInput, ctx: CommandContext) -> CommandResul
         return error("selector_conflict")
     if command_input.force and command_input.only is None:
         return error("force_requires_only")
+    if command_input.to_step is not None and command_input.from_step is None:
+        return error("to_requires_from")
 
     from chipcompiler.data import load_workspace
     from chipcompiler.engine import EngineFlow, rerun
@@ -511,6 +514,7 @@ def _run_workspace(command_input: RunInput, ctx: CommandContext) -> CommandResul
         selected = rerun.selected_step_names(
             engine_flow,
             from_step=command_input.from_step,
+            to_step=command_input.to_step,
             only=command_input.only,
             force=command_input.force,
         )
@@ -526,7 +530,9 @@ def _run_workspace(command_input: RunInput, ctx: CommandContext) -> CommandResul
             if command_input.only is not None:
                 result = rerun.run_only(engine_flow, command_input.only, force=command_input.force)
             elif command_input.from_step is not None:
-                result = rerun.run_from(engine_flow, command_input.from_step)
+                result = rerun.run_from(
+                    engine_flow, command_input.from_step, to_step=command_input.to_step
+                )
             else:
                 result = rerun.run_resume(engine_flow)
     except ValueError as exc:

--- a/chipcompiler/cli/commands/project.py
+++ b/chipcompiler/cli/commands/project.py
@@ -74,6 +74,10 @@ def run_cmd(
         str | None,
         typer.Option("--from", help="Re-execute a step and its persisted suffix"),
     ] = None,
+    to_step: Annotated[
+        str | None,
+        typer.Option("--to", help="Stop an --from run after this step"),
+    ] = None,
     only: Annotated[
         str | None,
         typer.Option("--only", help="Run exactly one persisted step"),
@@ -101,6 +105,7 @@ def run_cmd(
         workspace=workspace,
         resume=resume,
         from_step=from_step,
+        to_step=to_step,
         only=only,
         force=force,
     )

--- a/chipcompiler/cli/core/inputs.py
+++ b/chipcompiler/cli/core/inputs.py
@@ -38,6 +38,7 @@ class RunInput:
     from_step: str | None = None
     only: str | None = None
     force: bool = False
+    to_step: str | None = None
 
 
 @dataclass(frozen=True)

--- a/chipcompiler/engine/rerun.py
+++ b/chipcompiler/engine/rerun.py
@@ -30,7 +30,12 @@ class StepRunResult(NamedTuple):
 
 
 def selected_step_names(
-    flow: "EngineFlow", *, from_step: str = None, only: str = None, force: bool = False
+    flow: "EngineFlow",
+    *,
+    from_step: str = None,
+    to_step: str = None,
+    only: str = None,
+    force: bool = False,
 ) -> list[str]:
     """Resolve a run selector to the persisted step names it would execute."""
     steps = flow.workspace.flow.data.get("steps", [])
@@ -40,7 +45,11 @@ def selected_step_names(
             return []
         return [steps[index]["name"]]
     if from_step is not None:
-        return [step["name"] for step in steps[_require_step_index(flow, from_step) :]]
+        first_index = _require_step_index(flow, from_step)
+        last_index = len(steps) - 1 if to_step is None else _require_step_index(flow, to_step)
+        if last_index < first_index:
+            raise ValueError(f"step '{to_step}' precedes step '{from_step}'")
+        return [step["name"] for step in steps[first_index : last_index + 1]]
     for index, step in enumerate(steps):
         if step.get("state") != StateEnum.Success.value:
             return [step["name"] for step in steps[index:]]
@@ -55,15 +64,18 @@ def run_resume(flow: "EngineFlow") -> StepRunResult:
     return StepRunResult(ok=True, executed=())
 
 
-def run_from(flow: "EngineFlow", name: str) -> StepRunResult:
-    """Re-execute the named step and every following step in persisted order."""
+def run_from(flow: "EngineFlow", name: str, to_step: str = None) -> StepRunResult:
+    """Re-execute the named step through an optional end step."""
     steps = flow.workspace.flow.data.get("steps", [])
     index = _require_step_index(flow, name)
-    _require_steps_available(flow, len(steps) - 1)
-    suffix = flow.workspace_steps[index:]
-    output_dirs = _validated_output_dirs(flow.workspace, suffix)
+    last_index = len(steps) - 1 if to_step is None else _require_step_index(flow, to_step)
+    if last_index < index:
+        raise ValueError(f"step '{to_step}' precedes step '{name}'")
+    _require_steps_available(flow, last_index)
+    selected = flow.workspace_steps[index : last_index + 1]
+    output_dirs = _validated_output_dirs(flow.workspace, selected)
     _invalidate_suffix(flow, index)
-    return _run_selected(flow, list(zip(suffix, output_dirs, strict=True)))
+    return _run_selected(flow, list(zip(selected, output_dirs, strict=True)))
 
 
 def run_only(flow: "EngineFlow", name: str, *, force: bool = False) -> StepRunResult:

--- a/docs/development.md
+++ b/docs/development.md
@@ -396,15 +396,18 @@ workspace=/path/to/reported/workspace
 # Re-execute CTS and every following step in the persisted flow.
 .venv/bin/ecc run --workspace "$workspace" --from CTS
 
+# Re-execute a continuous range and stop after CTS.
+.venv/bin/ecc run --workspace "$workspace" --from Floorplan --to CTS
+
 # Run exactly one step; add --force if it already succeeded.
 .venv/bin/ecc run --workspace "$workspace" --only place
 .venv/bin/ecc run --workspace "$workspace" --only place --force
 ```
 
-`--resume`, `--from`, and `--only` are mutually exclusive, and `--force` is
-only valid with `--only`. Workspace mode cannot be combined with `--project`,
-`--run-id`, `--overwrite`, or `--set`. Step names must match `home/flow.json`
-exactly.
+`--resume`, `--from`, and `--only` are mutually exclusive, `--to` is only valid
+with `--from`, and `--force` is only valid with `--only`. Workspace mode cannot
+be combined with `--project`, `--run-id`, `--overwrite`, or `--set`. Step names
+must match `home/flow.json` exactly.
 
 Workspace mode mutates the workspace in place: each executed step's `output/`
 is replaced, and steps downstream of a re-executed step are marked `Unstart`

--- a/docs/specification/cli-design.md
+++ b/docs/specification/cli-design.md
@@ -257,6 +257,7 @@ re-executed in place through `ecc run --workspace`:
 ecc run --workspace /path/to/workspace
 ecc run --workspace /path/to/workspace --resume
 ecc run --workspace /path/to/workspace --from CTS
+ecc run --workspace /path/to/workspace --from Floorplan --to CTS
 ecc run --workspace /path/to/workspace --only place
 ecc run --workspace /path/to/workspace --only place --force
 ```
@@ -264,16 +265,17 @@ ecc run --workspace /path/to/workspace --only place --force
 Step names and order come from the workspace's persisted `home/flow.json`.
 Omitting a selector has resume semantics: execution starts at the first step
 whose state is not `Success` and reuses the successful prefix. `--from <step>`
-re-executes the named step and its persisted suffix. `--only <step>` runs
-exactly that step; an already successful step is a no-op unless `--force` is
-given. Re-executing a step marks downstream steps `Unstart`, replaces the
-executed step's `output/`, and regenerates `workspace/config/*.json` from the
-persisted parameters.
+re-executes the named step and its persisted suffix. Adding `--to <step>` stops
+after that step; omitting `--to` retains the full-suffix behavior.
+`--only <step>` runs exactly that step; an already successful step is a no-op
+unless `--force` is given. Re-executing a step marks downstream steps
+`Unstart`, replaces the executed step's `output/`, and regenerates
+`workspace/config/*.json` from the persisted parameters.
 
-`--resume`, `--from`, and `--only` are mutually exclusive, `--force` requires
-`--only`, and workspace mode cannot be combined with `--project`, `--run-id`,
-`--overwrite`, or `--set`. Arbitrary step sequences, step ranges (`--to`,
-`--after`), and run-time parameter overlays remain planned work.
+`--resume`, `--from`, and `--only` are mutually exclusive, `--to` requires
+`--from`, `--force` requires `--only`, and workspace mode cannot be combined
+with `--project`, `--run-id`, `--overwrite`, or `--set`. Arbitrary step
+sequences, `--after`, and run-time parameter overlays remain planned work.
 
 Project mode creates a fresh `runs/<run_id>` workspace and supports:
 

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -250,6 +250,7 @@ class TestWorkspaceRun:
             executable=None,
             only=None,
             from_step=None,
+            to_step=None,
             resume=False,
             result=StepRunResult(ok=True, executed=("place",)),
         )
@@ -265,10 +266,17 @@ class TestWorkspaceRun:
                 seen.create_calls += 1
                 seen.executable = executable_steps
 
-        def selected_step_names(flow, *, from_step=None, only=None, force=False):
+        def selected_step_names(
+            flow, *, from_step=None, to_step=None, only=None, force=False
+        ):
             if seen.selected_error is not None:
                 raise seen.selected_error
-            seen.selected = {"from_step": from_step, "only": only, "force": force}
+            seen.selected = {
+                "from_step": from_step,
+                "to_step": to_step,
+                "only": only,
+                "force": force,
+            }
             if only is not None:
                 return [] if not force else [only]
             if from_step is not None:
@@ -279,8 +287,9 @@ class TestWorkspaceRun:
             seen.only = (name, force)
             return seen.result
 
-        def run_from(flow, name):
+        def run_from(flow, name, to_step=None):
             seen.from_step = name
+            seen.to_step = to_step
             return seen.result
 
         def run_resume(flow):
@@ -311,7 +320,12 @@ class TestWorkspaceRun:
         record = json.loads(capsys.readouterr().out)["records"][0]
         assert rc == 0
         assert workspace_mocks.load_path == workspace
-        assert workspace_mocks.selected == {"from_step": None, "only": "place", "force": True}
+        assert workspace_mocks.selected == {
+            "from_step": None,
+            "to_step": None,
+            "only": "place",
+            "force": True,
+        }
         assert workspace_mocks.executable == {"place"}
         assert workspace_mocks.only == ("place", True)
         assert record["run"] == "workspace"
@@ -324,7 +338,12 @@ class TestWorkspaceRun:
         rc = cli_main.run(["run", "--workspace", str(tmp_path / "workspace"), "--plain"])
 
         assert rc == 0
-        assert workspace_mocks.selected == {"from_step": None, "only": None, "force": False}
+        assert workspace_mocks.selected == {
+            "from_step": None,
+            "to_step": None,
+            "only": None,
+            "force": False,
+        }
         assert workspace_mocks.executable == {"place", "CTS"}
         assert workspace_mocks.resume is True
 
@@ -333,7 +352,35 @@ class TestWorkspaceRun:
 
         assert rc == 0
         assert workspace_mocks.from_step == "CTS"
+        assert workspace_mocks.to_step is None
         assert workspace_mocks.executable == {"CTS"}
+
+    def test_from_to_step_wiring(self, workspace_mocks, tmp_path):
+        rc = cli_main.run(
+            [
+                "run",
+                "--workspace",
+                str(tmp_path / "workspace"),
+                "--from",
+                "place",
+                "--to",
+                "CTS",
+            ]
+        )
+
+        assert rc == 0
+        assert workspace_mocks.from_step == "place"
+        assert workspace_mocks.to_step == "CTS"
+        assert workspace_mocks.executable == {"place", "CTS"}
+
+    def test_to_requires_from(self, workspace_mocks, tmp_path, capsys):
+        rc = cli_main.run(
+            ["run", "--workspace", str(tmp_path / "workspace"), "--to", "CTS", "--json"]
+        )
+
+        record = json.loads(capsys.readouterr().out)["records"][0]
+        assert rc == 1
+        assert record["error"] == "to_requires_from"
 
     def test_noop_selection_skips_workspace_rebuild(self, workspace_mocks, tmp_path, capsys):
         workspace_mocks.result = StepRunResult(ok=True, executed=())

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -266,9 +266,7 @@ class TestWorkspaceRun:
                 seen.create_calls += 1
                 seen.executable = executable_steps
 
-        def selected_step_names(
-            flow, *, from_step=None, to_step=None, only=None, force=False
-        ):
+        def selected_step_names(flow, *, from_step=None, to_step=None, only=None, force=False):
             if seen.selected_error is not None:
                 raise seen.selected_error
             seen.selected = {

--- a/test/test_engine_rerun.py
+++ b/test/test_engine_rerun.py
@@ -96,6 +96,17 @@ class TestSelectedStepNames:
 
         assert rerun.selected_step_names(flow, from_step="place") == ["place", "CTS"]
 
+    def test_from_to_selects_range(self, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Success"), ("CTS", "Success")],
+        )
+
+        assert rerun.selected_step_names(flow, from_step="Synthesis", to_step="place") == [
+            "Synthesis",
+            "place",
+        ]
+
     def test_only_success_step_requires_force(self, tmp_path):
         flow = _make_run_flow(tmp_path, [("place", "Success")])
 
@@ -129,6 +140,26 @@ class TestRunFrom:
         assert keep.read_text(encoding="utf-8") == "old"
         assert not stale_place.exists()
         assert not stale_cts.exists()
+
+    def test_reexecutes_through_end_step_and_invalidates_suffix(self, monkeypatch, tmp_path):
+        flow = _make_run_flow(
+            tmp_path,
+            [("Synthesis", "Success"), ("place", "Success"), ("CTS", "Success")],
+        )
+        stale_synthesis = _write_output(flow, "Synthesis")
+        stale_place = _write_output(flow, "place")
+        keep_cts = _write_output(flow, "CTS")
+        calls = _fake_execution(flow, monkeypatch)
+
+        result = rerun.run_from(flow, "Synthesis", to_step="place")
+
+        assert result.ok
+        assert result.executed == ("Synthesis", "place")
+        assert calls == [("Synthesis", True), ("place", True)]
+        assert _flow_states(flow) == ["Success", "Success", "Unstart"]
+        assert not stale_synthesis.exists()
+        assert not stale_place.exists()
+        assert keep_cts.read_text(encoding="utf-8") == "old"
 
     def test_failure_stops_suffix_and_keeps_downstream_output(self, monkeypatch, tmp_path):
         flow = _make_run_flow(


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
