### PR TITLE
feat(flow): run synthesis LEC before floorplan

### DIFF
--- a/chipcompiler/rtl2gds/builder.py
+++ b/chipcompiler/rtl2gds/builder.py
@@ -8,6 +8,7 @@ def build_rtl2gds_flow() -> list:
     steps = []
 
     steps.append((StepEnum.SYNTHESIS, "yosys", StateEnum.Unstart))
+    steps.append((StepEnum.LEC, "yosys_lec", StateEnum.Unstart))
     steps.append((StepEnum.FLOORPLAN, "ecc", StateEnum.Unstart))
     steps.append((StepEnum.PLACEMENT, "dreamplace", StateEnum.Unstart))
     steps.append((StepEnum.CTS, "ecc", StateEnum.Unstart))

--- a/chipcompiler/tools/yosys_lec/scripts/run_lec.tcl
+++ b/chipcompiler/tools/yosys_lec/scripts/run_lec.tcl
@@ -28,13 +28,13 @@ proc normalize_design {top_design} {
     yosys memory
     yosys async2sync
     yosys flatten
-    yosys splitnets -ports -format __v
+    yosys splitnets -ports -format _
     yosys opt_clean -purge
 }
 
 proc build_design {stash_name top_design netlist_file} {
     read_support_models
-    yosys read_verilog -sv $netlist_file
+    yosys read_verilog -sv -icells $netlist_file
     normalize_design $top_design
     yosys design -stash $stash_name
 }

--- a/test/cli/commands/conftest.py
+++ b/test/cli/commands/conftest.py
@@ -157,10 +157,16 @@ def legacy_hint():
 
 @pytest.fixture
 def create_legacy_workspace():
-    """Factory: a real runs/<run_id> workspace with a two-step flow ledger."""
+    """Factory: a real runs/<run_id> workspace with a Synthesis..Floorplan
+    flow ledger cut from the canonical chain.
+
+    *states* holds (first step state, last step state); steps between them
+    inherit the first state."""
 
     def _create(project_dir, pdk_root, run_id, states):
         from chipcompiler.data import create_workspace
+        from chipcompiler.data.workspace_config import flow_steps_in_range
+        from chipcompiler.rtl2gds.builder import build_harden_flow
 
         rtl_path = os.path.join(project_dir, "rtl", "gcd.v")
         os.makedirs(os.path.dirname(rtl_path), exist_ok=True)
@@ -178,23 +184,23 @@ def create_legacy_workspace():
         )
         assert workspace is not None
 
+        chain = [
+            (step.value if hasattr(step, "value") else str(step), str(tool))
+            for step, tool, _state in build_harden_flow()
+        ]
+        tools = dict(chain)
+        names = flow_steps_in_range("Synthesis", "Floorplan")
+        step_states = [states[0]] * (len(names) - 1) + [states[1]]
         steps = [
             {
-                "name": "Synthesis",
-                "tool": "yosys",
-                "state": states[0],
+                "name": name,
+                "tool": tools[name],
+                "state": state,
                 "runtime": "",
                 "peak memory (mb)": 0,
                 "info": {},
-            },
-            {
-                "name": "Floorplan",
-                "tool": "ecc",
-                "state": states[1],
-                "runtime": "",
-                "peak memory (mb)": 0,
-                "info": {},
-            },
+            }
+            for name, state in zip(names, step_states, strict=True)
         ]
         with open(os.path.join(run_dir, "home", "flow.json"), "w") as f:
             json.dump({"steps": steps}, f)

--- a/test/cli/commands/test_flow_continuation.py
+++ b/test/cli/commands/test_flow_continuation.py
@@ -47,19 +47,20 @@ def _set_flow_preset(project_dir, preset):
         f.write(content)
 
 
-RTL2GDS_NAMES = [
-    "Synthesis",
-    "Floorplan",
-    "place",
-    "CTS",
-    "legalization",
-    "Timing optimization",
-    "route",
-    "drc",
-    "lvs",
-    "filler",
-    "postRouteLec",
-]
+def _preset_names(preset):
+    from chipcompiler.rtl2gds.builder import get_flow_builders
+
+    return [step.value for step, _tool, _state in get_flow_builders()[preset]()]
+
+
+RTL2GDS_NAMES = _preset_names("rtl2gds")
+RCX_NAMES = _preset_names("rcx")
+
+
+def _success_through(names, last):
+    """Success states up to and including *last*; Unstart after."""
+    cut = names.index(last) + 1
+    return ["Success"] * cut + ["Unstart"] * (len(names) - cut)
 
 
 def _flow_states(run_dir):
@@ -116,7 +117,7 @@ class TestFlowContinuation:
         assert rc == 0
         states = _flow_states(run_dir)
         # Exactly RCX + sta appended as Unstart; prefix states untouched.
-        assert list(states) == RTL2GDS_NAMES + ["RCX", "sta"]
+        assert list(states) == RCX_NAMES
         assert all(states[name] == "Success" for name in RTL2GDS_NAMES)
         # The adopted target is the widened preset.
         assert _flow_section(run_dir) == {"preset": "rcx"}
@@ -482,10 +483,9 @@ class TestFlowMismatchZeroMutation:
         run_dir = os.path.join(project_dir, "runs", "default")
         _write_existing_workspace(
             run_dir,
-            RTL2GDS_NAMES + ["RCX", "sta"],
-            states=["Success"] * 4
-            + ["Unstart"] * (len(RTL2GDS_NAMES) - 4)
-            + ["Unstart", "Unstart"],
+            RCX_NAMES,
+            states=_success_through(RTL2GDS_NAMES, "place")
+            + ["Unstart"] * (len(RCX_NAMES) - len(RTL2GDS_NAMES)),
             preset="rtl2gds",
         )
 
@@ -557,8 +557,9 @@ class TestWorkspaceRunLockAndTargetBound:
         run_dir = os.path.join(str(tmp_path), "ws")
         _write_existing_workspace(
             run_dir,
-            RTL2GDS_NAMES + ["RCX", "sta"],
-            states=["Success"] * 4 + ["Unstart"] * (len(RTL2GDS_NAMES) - 4) + ["Success"] * 2,
+            RCX_NAMES,
+            states=_success_through(RTL2GDS_NAMES, "place")
+            + ["Success"] * (len(RCX_NAMES) - len(RTL2GDS_NAMES)),
             preset="rtl2gds",
         )
         captured = {}
@@ -589,14 +590,7 @@ class TestWorkspaceRunLockAndTargetBound:
 
         assert rc == 0
         assert captured["through"] == "postRouteLec"
-        # Synthesis..place are Success; the bounded selection starts at CTS
-        # and never reaches RCX/sta beyond the target end.
-        assert captured["executable"] == {
-            "legalization",
-            "Timing optimization",
-            "route",
-            "drc",
-            "lvs",
-            "filler",
-            "postRouteLec",
-        }
+        # Synthesis..place are Success; the bounded selection covers exactly
+        # the remaining Unstart steps and never reaches RCX/sta beyond the
+        # target end.
+        assert captured["executable"] == set(RTL2GDS_NAMES[RTL2GDS_NAMES.index("place") + 1 :])

--- a/test/cli/commands/test_run.py
+++ b/test/cli/commands/test_run.py
@@ -457,18 +457,20 @@ class TestWorkspaceNoOp:
         workspace = tmp_path / "workspace"
         home = workspace / "home"
         home.mkdir(parents=True)
-        from chipcompiler.rtl2gds.builder import build_harden_flow
+        from chipcompiler.rtl2gds.builder import build_harden_flow, build_rtl2gds_flow
 
         chain = [
             (step.value if hasattr(step, "value") else str(step), str(tool))
             for step, tool, _state in build_harden_flow()
         ]
+        target_len = len(build_rtl2gds_flow())
         steps = [
-            {"name": name, "tool": tool, "state": "Success"}
-            for name, tool in chain[:11]  # the full rtl2gds target
-        ] + [
-            {"name": chain[11][0], "tool": chain[11][1], "state": "Unstart"},
-            {"name": chain[12][0], "tool": chain[12][1], "state": "Unstart"},
+            {
+                "name": name,
+                "tool": tool,
+                "state": "Success" if index < target_len else "Unstart",
+            }
+            for index, (name, tool) in enumerate(chain)
         ]
         (home / "flow.json").write_text(_json.dumps({"steps": steps}))
         assert save_workspace_config(

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -231,6 +231,7 @@ def test_create_workspace_non_contiguous_flow_seeds_both_stores_contiguous(
     flow_data = json_read(workspace_dir / "home" / "flow.json")
     assert [step["name"] for step in flow_data["steps"]] == [
         "Synthesis",
+        "lec",
         "Floorplan",
         "place",
         "CTS",

--- a/test/engine/test_reconcile.py
+++ b/test/engine/test_reconcile.py
@@ -8,20 +8,18 @@ from chipcompiler.engine.reconcile import (
     resolve_target_section,
 )
 
-RTL2GDS_STEPS = [
-    ("Synthesis", "yosys"),
-    ("Floorplan", "ecc"),
-    ("place", "dreamplace"),
-    ("CTS", "ecc"),
-    ("legalization", "dreamplace"),
-    ("Timing optimization", "sizer"),
-    ("route", "ecc"),
-    ("drc", "ecc"),
-    ("lvs", "ecc"),
-    ("filler", "ecc"),
-    ("postRouteLec", "yosys_lec"),
-]
-RCX_SUFFIX = [("RCX", "ecc"), ("sta", "ecc")]
+
+def _preset_entries(preset):
+    from chipcompiler.rtl2gds.builder import get_flow_builders
+
+    return [
+        (step.value if hasattr(step, "value") else str(step), str(tool))
+        for step, tool, _state in get_flow_builders()[preset]()
+    ]
+
+
+RTL2GDS_STEPS = _preset_entries("rtl2gds")
+RCX_SUFFIX = _preset_entries("rcx")[len(RTL2GDS_STEPS) :]
 
 
 def _write_workspace(tmp_path, steps, states=None, flow_section=None, params=None):
@@ -95,11 +93,11 @@ class TestReconcile:
         steps = _flow_steps(workspace_dir)
         assert [(s["name"], s["tool"]) for s in steps] == RTL2GDS_STEPS + RCX_SUFFIX
         assert all(s["state"] == "Success" for s in steps[: len(RTL2GDS_STEPS)])
-        assert [s["state"] for s in steps[-2:]] == ["Unstart", "Unstart"]
+        assert [s["state"] for s in steps[-len(RCX_SUFFIX) :]] == ["Unstart"] * len(RCX_SUFFIX)
         assert _flow_section(workspace_dir) == {"preset": "rcx"}
 
     def test_extension_resumes_from_first_non_success(self, tmp_path):
-        states = ["Success"] * 10 + ["Ongoing"]
+        states = ["Success"] * (len(RTL2GDS_STEPS) - 1) + ["Ongoing"]
         workspace_dir = _write_workspace(
             tmp_path, RTL2GDS_STEPS, states=states, flow_section={"preset": "rtl2gds"}
         )
@@ -119,7 +117,7 @@ class TestReconcile:
         assert result.outcome == "no_op"
 
     def test_equal_with_non_success_is_resume(self, tmp_path):
-        states = ["Success"] * 10 + ["Imcomplete"]
+        states = ["Success"] * (len(RTL2GDS_STEPS) - 1) + ["Imcomplete"]
         workspace_dir = _write_workspace(
             tmp_path, RTL2GDS_STEPS, states=states, flow_section={"preset": "rtl2gds"}
         )
@@ -138,7 +136,7 @@ class TestReconcile:
         result = reconcile_workspace(workspace_dir, {"preset": "rtl2gds"})
 
         assert result.outcome == "no_op"
-        assert len(_flow_steps(workspace_dir)) == len(RTL2GDS_STEPS) + 2
+        assert len(_flow_steps(workspace_dir)) == len(RTL2GDS_STEPS) + len(RCX_SUFFIX)
         # A stale wider target is adopted to the effective one; the extra
         # persisted steps stay in the ledger untouched.
         assert _flow_section(workspace_dir) == {"preset": "rtl2gds"}
@@ -146,7 +144,7 @@ class TestReconcile:
     def test_target_prefix_noop_even_with_unfinished_extras(self, tmp_path):
         # Extra steps beyond the target are never the run's business, and
         # the workspace's [flow] is never widened to cover them.
-        states = ["Success"] * 11 + ["Unstart", "Unstart"]
+        states = ["Success"] * len(RTL2GDS_STEPS) + ["Unstart"] * len(RCX_SUFFIX)
         workspace_dir = _write_workspace(
             tmp_path,
             RTL2GDS_STEPS + RCX_SUFFIX,
@@ -164,7 +162,7 @@ class TestReconcile:
 
     def test_crash_window_repair_then_resume(self, tmp_path):
         # flow.json appended (suffix Unstart) but [flow] never adopted.
-        states = ["Success"] * 11 + ["Unstart", "Unstart"]
+        states = ["Success"] * len(RTL2GDS_STEPS) + ["Unstart"] * len(RCX_SUFFIX)
         workspace_dir = _write_workspace(
             tmp_path,
             RTL2GDS_STEPS + RCX_SUFFIX,

--- a/test/rtl2gds/test_builder.py
+++ b/test/rtl2gds/test_builder.py
@@ -56,6 +56,7 @@ def test_build_rtl2gds_flow_includes_lvs_after_drc():
 
     assert flow == [
         (StepEnum.SYNTHESIS, "yosys", StateEnum.Unstart),
+        (StepEnum.LEC, "yosys_lec", StateEnum.Unstart),
         (StepEnum.FLOORPLAN, "ecc", StateEnum.Unstart),
         (StepEnum.PLACEMENT, "dreamplace", StateEnum.Unstart),
         (StepEnum.CTS, "ecc", StateEnum.Unstart),


### PR DESCRIPTION
## What Changed

Default `rtl2gds` now proves synthesis LEC before physical design, and Yosys LEC reads mapped netlists the same way synthesis writes them.

- Insert `LEC` (`yosys_lec`) immediately after `SYNTHESIS` in `build_rtl2gds_flow()`. `rcx` and `harden` inherit this because they start from that builder. `EngineFlow` already skips `yosys_lec` when chaining physical I/O, so Floorplan still consumes Synthesis outputs; a LEC step after Synthesis already uses the synthesis golden netlist.
- In `run_lec.tcl`, change `splitnets -ports` from `-format __v` to `-format _` so LEC matches the synthesis final netlist (`splitnets -format _ -ports`). `__v` is the internal-net format used earlier in synthesis, and it would make gold/gate port bits disagree (`foo_0` vs `foo__v0`).
- Read gold/gate Verilog with `read_verilog -sv -icells` after liberty models are loaded, so mapped standard-cell instances stay cells instead of unknown modules.

Resulting default `rtl2gds` chain:

`SYNTHESIS → LEC → FLOORPLAN → PLACEMENT → CTS → LEGALIZATION → TIMING_OPT → ROUTING → DRC → LVS → FILLER → POST_ROUTE_LEC`

`synthesis_lec` already had this post-synth LEC step; this PR turns it on for the physical presets as well.

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [x] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [x] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [x] Workspace layout, flow state, or artifact paths changed
- [x] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

- New workspaces on `rtl2gds` / `rcx` / `harden` gain a `lec_yosys_lec` step between Synthesis and Floorplan. Existing workspaces keep their persisted step list until reconcile/rebuild.
- Yosys LEC Tcl behavior changes for every LEC run, including `synthesis_lec` and post-route LEC.
- Docs still describe `rtl2gds` as `SYNTHESIS → FLOORPLAN → ...`. Tests that pin the exact default step list are not updated in this diff (`test/rtl2gds/test_builder.py`, `test/engine/test_reconcile.py` `RTL2GDS_STEPS`, and any CLI continuation fixtures that hard-code the 11-step rtl2gds chain).

## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

- No tests or lint were run for this description-only request.
- Expected unit failures until the pinned rtl2gds step lists are updated: `test_build_rtl2gds_flow_includes_lvs_after_drc` and reconcile fixtures that assume Synthesis is followed by Floorplan.
- No full `rtl2gds` / GCD LEC smoke was run, so mapped-netlist ingest (`-icells` + port `splitnets -format _`) is not proven on a real PDK netlist here.
- PyInstaller / Nix packaging is N/A: no CLI surface, lockfile, or release-input change.

## Checklist

- [x] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [x] I included lockfile or version metadata updates when dependencies changed.
- [x] I documented any submodule updates and why they are needed.
- [x] I did not include local caches, virtual environments, or generated build outputs.
- [x] I explained skipped validation and remaining risk.
