### PR TITLE
fix(yosys): select ICS55 mapping variant from loaded cells

### DIFF
--- a/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
+++ b/chipcompiler/tools/yosys/scripts/yosys_synthesis.tcl
@@ -480,18 +480,16 @@ clockgate {*}$tech_cells_args {*}$exclude_cells
 # technology mapping for flip-flops
 dfflibmap {*}$tech_cells_args {*}$exclude_cells
 
-# dfflibmap intentionally handles only flip-flops.  For ics55 it selects the
-# final matching DFF library in lib_stdcell_list, so use that same H7 variant
-# for latch mapping before ABC.  The library has separate cells for latch
-# enable polarity and asynchronous set/reset polarity; positive async
-# controls are inverted because the library controls are active low.
-set ics55_latch_suffix ""
-if {[llength $lib_stdcell_list] > 0} {
-  set dff_lib [lindex $lib_stdcell_list end]
-  if {[regexp {ics55_LLSC_H7C([HLR])_} [file tail $dff_lib] -> vt]} {
-    set ics55_latch_suffix "H7$vt"
-  }
+# Follow mapped DFF cell names, not library filenames. For designs without
+# mapped ICS55 DFFs, select from the loaded latch library cells.
+set ics55_cells [tee -q -s result.string select -list-mod =*/t:DFF*H7? %M]
+if {[string trim $ics55_cells] eq ""} {
+  set ics55_cells [tee -q -s result.string select -list-mod =LATLX1H7?]
 }
+set ics55_latch_suffix ""
+regexp {H7[HLR]\M} $ics55_cells ics55_latch_suffix
+
+# Positive asynchronous controls are inverted for the active-low library pins.
 if {$ics55_latch_suffix ne ""} {
   set ics55_latch_map "${tmp_dir}/ics55_latch_map.v"
   set latch_map_file [open $ics55_latch_map "w"]


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
