### PR TITLE
chore: bump ecc and ecc-tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag to release (e.g., v0.1.0-alpha.8)'
+        description: 'Tag to release (e.g., v0.1.0-alpha.12)'
         required: false
-        default: 'v0.1.0-alpha.8'
+        default: 'v0.1.0-alpha.12'
 
 permissions:
   actions: read

--- a/chipcompiler/__init__.py
+++ b/chipcompiler/__init__.py
@@ -1,2 +1,2 @@
 # chipcompiler package
-__version__ = "0.1.0-alpha.11"
+__version__ = "0.1.0-alpha.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build>=0.8.5" ]
 
 [project]
 name = "ecc"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 readme = "README.md"
 authors = [
   { name = "Emin", email = "me@emin.chat" },
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "ecc-dreamplace==0.1.0a7",
-  "ecc-tools-bin==0.1.0a12",
+  "ecc-tools-bin==0.1.0a13",
   "fastapi>=0.109",
   "jsonrpcserver>=5.0.9",
   "klayout>=0.30.2",

--- a/uv.lock
+++ b/uv.lock
@@ -445,7 +445,7 @@ wheels = [
 
 [[package]]
 name = "ecc"
-version = "0.1.0a11"
+version = "0.1.0a12"
 source = { editable = "." }
 dependencies = [
     { name = "ecc-dreamplace" },
@@ -591,7 +591,7 @@ dev = [
 
 [[package]]
 name = "ecc-tools-bin"
-version = "0.1.0a12"
+version = "0.1.0a13"
 source = { editable = "chipcompiler/thirdparty/ecc-tools" }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## What Changed

- Bump ecc to v0.1.0-alpha.12
- Bump ecc-tools to v0.1.0-alpha.13

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
