### PR TITLE
revert: disable lec due to yosys lec unstable

### DIFF
--- a/chipcompiler/rtl2gds/builder.py
+++ b/chipcompiler/rtl2gds/builder.py
@@ -8,7 +8,8 @@ def build_rtl2gds_flow() -> list:
     steps = []
 
     steps.append((StepEnum.SYNTHESIS, "yosys", StateEnum.Unstart))
-    steps.append((StepEnum.LEC, "yosys_lec", StateEnum.Unstart))
+    # LEC is still unstable; keep it disabled until it is reliable enough to enable.
+    # steps.append((StepEnum.LEC, "yosys_lec", StateEnum.Unstart))
     steps.append((StepEnum.PRE_FLOORPLAN, "ecc", StateEnum.Unstart))
     steps.append((StepEnum.MACRO_PLACEMENT, "dreamplace", StateEnum.Unstart))
     steps.append((StepEnum.POST_FLOORPLAN, "ecc", StateEnum.Unstart))

--- a/test/cli/commands/test_report_step.py
+++ b/test/cli/commands/test_report_step.py
@@ -272,7 +272,6 @@ class TestStepOverview:
         assert rc == 0
         assert [record["step"] for record in records[1:]] == [
             "synthesis",
-            "lec",
             "pre_floorplan",
             "macro_placement",
             "post_floorplan",

--- a/test/cli/commands/test_status.py
+++ b/test/cli/commands/test_status.py
@@ -27,7 +27,6 @@ class TestStatus:
         records = plain_records(capsys.readouterr().out)
         assert [record["step"] for record in records if "step" in record] == [
             "synthesis",
-            "lec",
             "pre_floorplan",
             "macro_placement",
             "post_floorplan",

--- a/test/data/test_workspace.py
+++ b/test/data/test_workspace.py
@@ -238,7 +238,7 @@ def test_create_workspace_copies_external_lec_and_sta_inputs(
         pdk="ics55",
         parameters=default_ics55_parameters,
         pdk_root=pdk_root,
-        flow_config={"start_step": "lec", "end_step": "lec"},
+        flow_config={"start_step": "postlec", "end_step": "postlec"},
     )
 
     assert workspace is not None
@@ -327,7 +327,6 @@ def test_create_workspace_non_contiguous_flow_seeds_both_stores_contiguous(
     flow_data = json_read(workspace_dir / "home" / "flow.json")
     assert [step["name"] for step in flow_data["steps"]] == [
         "Synthesis",
-        "lec",
         "preFloorplan",
         "macroPlacement",
         "postFloorplan",

--- a/test/engine/test_reconcile.py
+++ b/test/engine/test_reconcile.py
@@ -14,7 +14,6 @@ from chipcompiler.engine.reconcile import (
 RTL2GDS_STEPS = [(name, tool) for name, tool, _state in _canonical_rtl2gds_flow_entries()]
 LEGACY_RTL2GDS_STEPS = RTL2GDS_STEPS[:-3]
 FULL_FLOW_SUFFIX = RTL2GDS_STEPS[-3:]
-LEGACY_SYNTH_LEC_STEPS = [entry for entry in RTL2GDS_STEPS if entry[0] != "lec"]
 
 
 def _write_workspace(tmp_path, steps, states=None, flow_section=None, params=None):
@@ -76,21 +75,6 @@ class TestCompareFlows:
 
 
 class TestReconcile:
-    def test_upgrade_inserts_new_synthesis_lec_step(self, tmp_path):
-        workspace_dir = _write_workspace(
-            tmp_path, LEGACY_SYNTH_LEC_STEPS, flow_section={"preset": "rtl2gds"}
-        )
-
-        result = reconcile_workspace(workspace_dir, {"preset": "rtl2gds"})
-
-        assert result.outcome == "extended"
-        assert result.appended == ("lec",)
-        steps = _flow_steps(workspace_dir)
-        assert [(s["name"], s["tool"]) for s in steps] == RTL2GDS_STEPS
-        assert steps[0]["state"] == "Success"
-        assert steps[1]["state"] == "Unstart"
-        assert all(s["state"] == "Success" for s in steps[2:])
-
     def test_extension_appends_suffix_and_adopts_target(self, tmp_path):
         workspace_dir = _write_workspace(
             tmp_path, LEGACY_RTL2GDS_STEPS, flow_section={"preset": "rtl2gds"}
@@ -128,22 +112,6 @@ class TestReconcile:
 
     def test_equal_with_non_success_is_resume(self, tmp_path):
         states = ["Success"] * (len(RTL2GDS_STEPS) - 1) + ["Imcomplete"]
-        workspace_dir = _write_workspace(
-            tmp_path, RTL2GDS_STEPS, states=states, flow_section={"preset": "rtl2gds"}
-        )
-
-        result = reconcile_workspace(workspace_dir, {"preset": "rtl2gds"})
-
-        assert result.outcome == "resume"
-
-    def test_equal_with_legacy_warned_lec_resumes(self, tmp_path):
-        # The removed terminal Warning state is not finished: a persisted
-        # warned LEC reconciles to a resume that re-runs it and its suffix.
-        lec_index = next(
-            index for index, (name, _tool) in enumerate(RTL2GDS_STEPS) if name == "lec"
-        )
-        states = ["Success"] * len(RTL2GDS_STEPS)
-        states[lec_index] = "Warning"
         workspace_dir = _write_workspace(
             tmp_path, RTL2GDS_STEPS, states=states, flow_section={"preset": "rtl2gds"}
         )

--- a/test/rtl2gds/test_builder.py
+++ b/test/rtl2gds/test_builder.py
@@ -56,7 +56,6 @@ def test_build_rtl2gds_flow_is_the_complete_flow():
 
     assert flow == [
         (StepEnum.SYNTHESIS, "yosys", StateEnum.Unstart),
-        (StepEnum.LEC, "yosys_lec", StateEnum.Unstart),
         (StepEnum.PRE_FLOORPLAN, "ecc", StateEnum.Unstart),
         (StepEnum.MACRO_PLACEMENT, "dreamplace", StateEnum.Unstart),
         (StepEnum.POST_FLOORPLAN, "ecc", StateEnum.Unstart),

--- a/test/yosys_lec/test_tools_yosys_lec.py
+++ b/test/yosys_lec/test_tools_yosys_lec.py
@@ -439,16 +439,12 @@ def test_rtl2gds_flow_runs_post_route_lec_after_lvs_before_drc():
     assert steps[lec_index] == (StepEnum.POST_ROUTE_LEC, "yosys_lec", StateEnum.Unstart)
 
 
-def test_rtl2gds_flow_runs_synthesis_lec_before_pre_floorplan():
+def test_rtl2gds_flow_keeps_unstable_synthesis_lec_disabled():
     from chipcompiler.rtl2gds import build_rtl2gds_flow
 
     steps = build_rtl2gds_flow()
     step_names = [step[0] for step in steps]
-    lec_index = step_names.index(StepEnum.LEC)
-    assert (
-        step_names.index(StepEnum.SYNTHESIS) < lec_index < step_names.index(StepEnum.PRE_FLOORPLAN)
-    )
-    assert steps[lec_index] == (StepEnum.LEC, "yosys_lec", StateEnum.Unstart)
+    assert StepEnum.LEC not in step_names
 
 
 def test_engine_flow_wires_synthesis_lec_without_changing_physical_chain(tmp_path, monkeypatch):


### PR DESCRIPTION
## What Changed

- 

## Scope

Select the areas touched by this PR:

- [ ] CLI - command behavior, Typer command surface, output formats, or workspace commands.
- [ ] Flow/runtime - workspace lifecycle, EngineFlow, step execution, logs, metrics, or artifacts.
- [ ] EDA integration - Yosys, ECC-Tools, DreamPlace, KLayout, PDKs, or native/runtime wrappers.
- [ ] Build/package - Nix, PyInstaller, wheels, `uv.lock`, or release artifacts.
- [ ] CI/release - GitHub Actions, version checks, changelog, or release automation.
- [ ] Tests/docs only

## Runtime And Packaging Impact

- [ ] No runtime or packaging impact
- [ ] CLI output or machine-readable contract changed
- [ ] Workspace layout, flow state, or artifact paths changed
- [ ] Native toolchain or wrapper behavior changed
- [ ] `ecc-tools` or `ecc-dreamplace` dependency changed
- [ ] PyInstaller, Nix, or release artifact changed

Notes:

-


## Validation

List the commands you ran. Mark checks that are not applicable as N/A.

- [ ] `uv run pytest test/`
- [ ] `uv run ruff check chipcompiler test`
- [ ] `uv run ruff format --check chipcompiler test`
- [ ] PyInstaller smoke: `ecc --help`, `ecc --version`, `ecc version --json`
- [ ] Nix smoke: `nix run .#cli -- --help`
- [ ] Manual flow smoke:
- [ ] Other:

Skipped checks and reason:

-

## Checklist

- [ ] I kept the change scoped to ECC.
- [ ] I updated docs or user-facing CLI text where behavior changed.
- [ ] I included lockfile or version metadata updates when dependencies changed.
- [ ] I documented any submodule updates and why they are needed.
- [ ] I did not include local caches, virtual environments, or generated build outputs.
- [ ] I explained skipped validation and remaining risk.
